### PR TITLE
feat: add LearnerProfile and ProgressState schemas

### DIFF
--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from datetime import date, datetime
 from typing import Literal
+from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
@@ -29,3 +31,36 @@ class MentorResponse(BaseModel):
     next_action: str
     source_policy: list[str]
     direct_solution_allowed: bool
+
+
+# --- Learner profile & progression schemas (Issue #22) ---
+
+Track = Literal["shell", "c", "python_ai"]
+Phase = Literal["foundation", "practice", "core", "advanced"]
+
+
+class LearnerProfile(BaseModel):
+    """Core identity of a learner on the platform."""
+
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    username: str = Field(min_length=1, max_length=64)
+    active_track: Track = "shell"
+    enrolled_on: date = Field(default_factory=date.today)
+
+
+class Checkpoint(BaseModel):
+    """A validated checkpoint within a module."""
+
+    module_id: str
+    validated_at: datetime
+
+
+class ProgressState(BaseModel):
+    """Tracks a learner's progression through the curriculum."""
+
+    learner_id: str
+    completed_modules: list[str] = Field(default_factory=list)
+    current_module: str | None = None
+    acquired_skills: list[str] = Field(default_factory=list)
+    validated_checkpoints: list[Checkpoint] = Field(default_factory=list)
+    phase: Phase = "foundation"

--- a/services/api/tests/test_schemas.py
+++ b/services/api/tests/test_schemas.py
@@ -1,0 +1,91 @@
+"""Tests for LearnerProfile and ProgressState schemas (Issue #22)."""
+
+from datetime import date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas import Checkpoint, LearnerProfile, ProgressState
+
+
+# -- LearnerProfile ----------------------------------------------------------
+
+
+class TestLearnerProfile:
+    def test_minimal_creation(self) -> None:
+        profile = LearnerProfile(username="edecarva")
+        assert profile.username == "edecarva"
+        assert profile.active_track == "shell"
+        assert profile.enrolled_on == date.today()
+        assert len(profile.id) == 32  # uuid4 hex
+
+    def test_full_creation(self) -> None:
+        profile = LearnerProfile(
+            id="abc123",
+            username="jdoe",
+            active_track="c",
+            enrolled_on=date(2026, 3, 1),
+        )
+        assert profile.id == "abc123"
+        assert profile.active_track == "c"
+        assert profile.enrolled_on == date(2026, 3, 1)
+
+    def test_invalid_track_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LearnerProfile(username="x", active_track="rust")  # type: ignore[arg-type]
+
+    def test_empty_username_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LearnerProfile(username="")
+
+    def test_long_username_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LearnerProfile(username="a" * 65)
+
+
+# -- ProgressState ------------------------------------------------------------
+
+
+class TestProgressState:
+    def test_minimal_creation(self) -> None:
+        state = ProgressState(learner_id="abc123")
+        assert state.learner_id == "abc123"
+        assert state.completed_modules == []
+        assert state.current_module is None
+        assert state.acquired_skills == []
+        assert state.validated_checkpoints == []
+        assert state.phase == "foundation"
+
+    def test_full_creation(self) -> None:
+        cp = Checkpoint(module_id="shell-basics", validated_at=datetime(2026, 3, 15))
+        state = ProgressState(
+            learner_id="abc123",
+            completed_modules=["shell-basics"],
+            current_module="shell-permissions",
+            acquired_skills=["ls", "cd", "pwd"],
+            validated_checkpoints=[cp],
+            phase="practice",
+        )
+        assert state.completed_modules == ["shell-basics"]
+        assert state.current_module == "shell-permissions"
+        assert len(state.acquired_skills) == 3
+        assert state.validated_checkpoints[0].module_id == "shell-basics"
+        assert state.phase == "practice"
+
+    def test_invalid_phase_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ProgressState(learner_id="x", phase="expert")  # type: ignore[arg-type]
+
+    def test_learner_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ProgressState()  # type: ignore[call-arg]
+
+
+# -- Checkpoint ---------------------------------------------------------------
+
+
+class TestCheckpoint:
+    def test_creation(self) -> None:
+        cp = Checkpoint(module_id="shell-basics", validated_at=datetime(2026, 3, 10, 14, 30))
+        assert cp.module_id == "shell-basics"
+        assert cp.validated_at.hour == 14


### PR DESCRIPTION
## Summary

- Add `LearnerProfile` schema: learner identity with id, username, active_track, enrolled_on
- Add `ProgressState` schema: progression tracking with completed_modules, current_module, acquired_skills, validated_checkpoints, phase
- Add `Checkpoint` helper schema for validated module checkpoints
- 10 unit tests covering creation defaults, full instantiation, and validation constraints

Closes #22

## Test plan

- [x] `pytest` — 12/12 passing (2 existing + 10 new)
- [ ] Verify schemas integrate correctly when wired to future endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)