### PR TITLE
feat: define Skill, Checkpoint, Resource, Evidence curriculum entities (#10)

### DIFF
--- a/packages/curriculum/data/42_lausanne_curriculum.json
+++ b/packages/curriculum/data/42_lausanne_curriculum.json
@@ -3,7 +3,9 @@
     "campus": "42 Lausanne",
     "updated_on": "2026-03-27",
     "status": "mvp",
-    "positioning": "triple-track learning app for shell, C, Python and AI literacy"
+    "positioning": "triple-track learning app for shell, C, Python and AI literacy",
+    "schema_version": "0.2.0",
+    "entity_note": "skills, checkpoints, resources and evidence_types are seeded for shell-basics as exemplar. Other modules will be populated incrementally."
   },
   "source_policy": {
     "tiers": [
@@ -113,6 +115,10 @@
           "phase": "foundation",
           "prerequisites": [],
           "skills": ["pwd", "ls", "cd", "mkdir", "touch", "cp", "mv", "rm"],
+          "skill_ids": [
+            "shell-pwd", "shell-ls", "shell-cd", "shell-mkdir",
+            "shell-touch", "shell-cp", "shell-mv", "shell-rm"
+          ],
           "deliverable": "Navigate, create, copy and clean files without hesitation.",
           "objectives": [
             "Move confidently in a filesystem hierarchy",
@@ -147,6 +153,10 @@
           "phase": "foundation",
           "prerequisites": ["shell-basics"],
           "skills": ["stdin", "stdout", "stderr", "redirect", "append", "pipe", "grep"],
+          "skill_ids": [
+            "shell-stdin", "shell-stdout", "shell-stderr", "shell-redirect",
+            "shell-append", "shell-pipe", "shell-grep"
+          ],
           "deliverable": "Compose useful shell chains and inspect text quickly.",
           "objectives": [
             "Distinguish stdin, stdout and stderr",
@@ -181,6 +191,9 @@
           "phase": "foundation",
           "prerequisites": ["shell-basics"],
           "skills": ["chmod", "ownership", "executable bit", "PATH"],
+          "skill_ids": [
+            "shell-chmod", "shell-ownership", "shell-executable-bit", "shell-path"
+          ],
           "deliverable": "Understand why a script runs or fails.",
           "objectives": [
             "Read and interpret rwx permission triads",
@@ -215,6 +228,9 @@
           "phase": "practice",
           "prerequisites": ["shell-streams", "shell-permissions"],
           "skills": ["find", "history", "man", "vim basics", "git basics"],
+          "skill_ids": [
+            "shell-find", "shell-history", "shell-man", "shell-vim-basics", "shell-git-basics"
+          ],
           "deliverable": "Operate daily in Linux without depending on GUI reflexes.",
           "objectives": [
             "Use find to locate files by name, type and modification time",
@@ -263,6 +279,9 @@
           "phase": "foundation",
           "prerequisites": ["shell-basics"],
           "skills": ["variables", "conditions", "loops", "functions", "headers"],
+          "skill_ids": [
+            "c-variables", "c-conditions", "c-loops", "c-functions", "c-headers"
+          ],
           "deliverable": "Write small programs cleanly and compile with warnings enabled.",
           "objectives": [
             "Declare and use variables with appropriate types",
@@ -304,6 +323,9 @@
           "phase": "foundation",
           "prerequisites": ["c-basics"],
           "skills": ["addresses", "pointers", "arrays", "strings", "malloc", "free"],
+          "skill_ids": [
+            "c-addresses", "c-pointers", "c-arrays", "c-strings", "c-malloc", "c-free"
+          ],
           "deliverable": "Explain memory decisions and avoid basic leaks.",
           "objectives": [
             "Understand the difference between stack and heap allocation",
@@ -345,6 +367,9 @@
           "phase": "practice",
           "prerequisites": ["c-basics", "shell-streams"],
           "skills": ["cc", "Wall", "Wextra", "Werror", "gdb", "valgrind"],
+          "skill_ids": [
+            "c-cc", "c-wall", "c-wextra", "c-werror", "c-gdb", "c-valgrind"
+          ],
           "deliverable": "Investigate failures instead of guessing.",
           "objectives": [
             "Compile with strict warning flags and interpret compiler messages",
@@ -392,6 +417,9 @@
           "phase": "core",
           "prerequisites": ["c-memory", "c-build-debug"],
           "skills": ["libft mindset", "API naming", "sorting logic", "complexity intuition"],
+          "skill_ids": [
+            "c-libft-mindset", "c-api-naming", "c-sorting-logic", "c-complexity-intuition"
+          ],
           "deliverable": "Prepare for libft, printf, gnl and push_swap logic.",
           "objectives": [
             "Understand the purpose of building a personal C library",
@@ -446,6 +474,9 @@
           "phase": "foundation",
           "prerequisites": ["shell-basics"],
           "skills": ["variables", "conditions", "loops", "functions", "collections"],
+          "skill_ids": [
+            "py-variables", "py-conditions", "py-loops", "py-functions", "py-collections"
+          ],
           "deliverable": "Write and explain small scripts confidently.",
           "objectives": [
             "Use Python types, variables and basic data structures",
@@ -481,6 +512,9 @@
           "phase": "practice",
           "prerequisites": ["python-basics"],
           "skills": ["classes", "methods", "files", "json", "argparse"],
+          "skill_ids": [
+            "py-classes", "py-methods", "py-files", "py-json", "py-argparse"
+          ],
           "deliverable": "Build useful utilities and simple models.",
           "objectives": [
             "Define classes with attributes, methods and constructors",
@@ -516,6 +550,9 @@
           "phase": "advanced",
           "prerequisites": ["python-oop-scripting"],
           "skills": ["prompt design", "retrieval", "evaluation", "agent workflow", "source policy"],
+          "skill_ids": [
+            "ai-prompt-design", "ai-retrieval", "ai-evaluation", "ai-agent-workflow", "ai-source-policy"
+          ],
           "deliverable": "Use AI as a disciplined tool without outsourcing understanding.",
           "objectives": [
             "Understand the retrieval-augmented generation pattern",
@@ -552,6 +589,167 @@
           "estimated_hours": 15
         }
       ]
+    }
+  ],
+  "skills": [
+    {
+      "id": "shell-pwd",
+      "label": "pwd",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "Print the current working directory to know where you are.",
+      "phase": "foundation",
+      "prerequisites": []
+    },
+    {
+      "id": "shell-ls",
+      "label": "ls",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "List directory contents to see what files exist.",
+      "phase": "foundation",
+      "prerequisites": ["shell-pwd"]
+    },
+    {
+      "id": "shell-cd",
+      "label": "cd",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "Change directory to move through the filesystem.",
+      "phase": "foundation",
+      "prerequisites": ["shell-pwd"]
+    },
+    {
+      "id": "shell-mkdir",
+      "label": "mkdir",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "Create directories to organize files.",
+      "phase": "foundation",
+      "prerequisites": ["shell-cd"]
+    },
+    {
+      "id": "shell-touch",
+      "label": "touch",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "Create empty files or update timestamps.",
+      "phase": "foundation",
+      "prerequisites": ["shell-cd"]
+    },
+    {
+      "id": "shell-cp",
+      "label": "cp",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "Copy files and directories.",
+      "phase": "foundation",
+      "prerequisites": ["shell-ls"]
+    },
+    {
+      "id": "shell-mv",
+      "label": "mv",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "Move or rename files and directories.",
+      "phase": "foundation",
+      "prerequisites": ["shell-ls"]
+    },
+    {
+      "id": "shell-rm",
+      "label": "rm",
+      "track": "shell",
+      "module_id": "shell-basics",
+      "description": "Remove files and directories. Understand irreversibility.",
+      "phase": "foundation",
+      "prerequisites": ["shell-ls", "shell-cp"]
+    }
+  ],
+  "checkpoints": [
+    {
+      "id": "cp-shell-navigate",
+      "label": "Navigate a directory tree",
+      "type": "exercise",
+      "validates_skills": ["shell-pwd", "shell-ls", "shell-cd"],
+      "module_id": "shell-basics",
+      "prompt": "Starting from your home directory, navigate to /tmp, list its contents, then return home. Show each command and its output.",
+      "success_criteria": "Learner uses pwd, cd, and ls correctly and can explain where they are at each step."
+    },
+    {
+      "id": "cp-shell-create-organize",
+      "label": "Create and organize a project structure",
+      "type": "exercise",
+      "validates_skills": ["shell-mkdir", "shell-touch", "shell-cp", "shell-mv"],
+      "module_id": "shell-basics",
+      "prompt": "Create a directory called 'myproject' with subdirectories 'src' and 'docs'. Create a file in src, copy it to docs, then rename it.",
+      "success_criteria": "Correct directory structure exists and learner can verify it with ls -R."
+    },
+    {
+      "id": "cp-shell-cleanup",
+      "label": "Clean up files safely",
+      "type": "self_check",
+      "validates_skills": ["shell-rm"],
+      "module_id": "shell-basics",
+      "prompt": "Remove the test structure you created. Before each rm, explain what will be deleted and why it is safe to do so.",
+      "success_criteria": "Learner demonstrates awareness of what rm does and checks before deleting."
+    }
+  ],
+  "entity_resources": [
+    {
+      "id": "res-42-pedagogie",
+      "label": "42 Lausanne - pedagogie",
+      "url": "https://42lausanne.ch/pedagogie-42/",
+      "tier": "official_42",
+      "skill_ids": ["shell-pwd", "shell-ls", "shell-cd"],
+      "format": "article",
+      "language": "fr"
+    },
+    {
+      "id": "res-man-pages",
+      "label": "Linux man pages online",
+      "url": "https://man7.org/linux/man-pages/",
+      "tier": "community_docs",
+      "skill_ids": [
+        "shell-pwd", "shell-ls", "shell-cd", "shell-mkdir",
+        "shell-touch", "shell-cp", "shell-mv", "shell-rm"
+      ],
+      "format": "man_page",
+      "language": "en"
+    },
+    {
+      "id": "res-awesome-42",
+      "label": "awesome-42",
+      "url": "https://github.com/leeoocca/awesome-42",
+      "tier": "community_docs",
+      "skill_ids": ["shell-pwd", "shell-ls"],
+      "format": "repository",
+      "language": "en"
+    }
+  ],
+  "evidence_types": [
+    {
+      "id": "ev-shell-navigate-output",
+      "type": "command_output",
+      "skill_id": "shell-cd",
+      "checkpoint_id": "cp-shell-navigate",
+      "description": "Terminal session showing navigation between directories.",
+      "expected_content": "Sequence of cd, pwd and ls commands with correct output showing directory changes."
+    },
+    {
+      "id": "ev-shell-create-artifact",
+      "type": "file_artifact",
+      "skill_id": "shell-mkdir",
+      "checkpoint_id": "cp-shell-create-organize",
+      "description": "The directory tree created by the learner.",
+      "expected_content": "A myproject/ directory with src/ and docs/ subdirectories and correctly named files."
+    },
+    {
+      "id": "ev-shell-rm-explanation",
+      "type": "explanation",
+      "skill_id": "shell-rm",
+      "checkpoint_id": "cp-shell-cleanup",
+      "description": "Learner's reasoning about safe deletion.",
+      "expected_content": "Explanation of what each rm command will delete, why it is safe, and what could go wrong."
     }
   ],
   "bridges": [

--- a/packages/curriculum/schemas/checkpoint.schema.json
+++ b/packages/curriculum/schemas/checkpoint.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "checkpoint.schema.json",
+  "title": "Checkpoint",
+  "description": "A validation point where the learner demonstrates mastery of one or more skills. Checkpoints gate progression between phases or modules.",
+  "type": "object",
+  "required": ["id", "label", "type", "validates_skills"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the checkpoint.",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "label": {
+      "type": "string",
+      "description": "Human-readable name."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["self_check", "exercise", "peer_review", "project"],
+      "description": "How the checkpoint is evaluated. self_check = learner confirms understanding, exercise = small task, peer_review = validated by another learner, project = substantial deliverable."
+    },
+    "validates_skills": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "description": "List of skill IDs this checkpoint validates."
+    },
+    "module_id": {
+      "type": "string",
+      "description": "The module this checkpoint belongs to."
+    },
+    "prompt": {
+      "type": "string",
+      "description": "The question or task presented to the learner."
+    },
+    "success_criteria": {
+      "type": "string",
+      "description": "What counts as a pass."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/curriculum/schemas/evidence.schema.json
+++ b/packages/curriculum/schemas/evidence.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "evidence.schema.json",
+  "title": "Evidence",
+  "description": "A proof of mastery produced by the learner. Evidence is what the system collects to determine whether a skill is acquired and a checkpoint is passed.",
+  "type": "object",
+  "required": ["id", "type", "skill_id", "checkpoint_id"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the evidence record.",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["command_output", "file_artifact", "explanation", "test_result", "peer_feedback"],
+      "description": "What form the evidence takes. command_output = terminal output, file_artifact = a file the learner produced, explanation = learner's own words, test_result = automated test pass, peer_feedback = another learner's review."
+    },
+    "skill_id": {
+      "type": "string",
+      "description": "The skill this evidence demonstrates."
+    },
+    "checkpoint_id": {
+      "type": "string",
+      "description": "The checkpoint this evidence satisfies."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of what the evidence shows."
+    },
+    "expected_content": {
+      "type": "string",
+      "description": "What the evidence should contain or demonstrate to be valid."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/curriculum/schemas/resource.schema.json
+++ b/packages/curriculum/schemas/resource.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "resource.schema.json",
+  "title": "Resource",
+  "description": "A learning resource linked to one or more skills. Each resource carries a source tier indicating its level of trust according to the source governance policy.",
+  "type": "object",
+  "required": ["id", "label", "url", "tier", "skill_ids"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the resource.",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "label": {
+      "type": "string",
+      "description": "Human-readable name."
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the resource."
+    },
+    "tier": {
+      "type": "string",
+      "enum": [
+        "official_42",
+        "community_docs",
+        "testers_and_tooling",
+        "solution_metadata",
+        "blocked_solution_content"
+      ],
+      "description": "Source governance tier. Controls how the resource may be used."
+    },
+    "skill_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "description": "Skills this resource helps develop."
+    },
+    "format": {
+      "type": "string",
+      "enum": ["article", "video", "tool", "repository", "man_page", "interactive"],
+      "description": "Type of content."
+    },
+    "language": {
+      "type": "string",
+      "description": "Content language (ISO 639-1).",
+      "default": "en"
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/curriculum/schemas/skill.schema.json
+++ b/packages/curriculum/schemas/skill.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "skill.schema.json",
+  "title": "Skill",
+  "description": "An atomic competency that a learner acquires. Skills are the smallest unit of progression in the curriculum.",
+  "type": "object",
+  "required": ["id", "label", "track", "module_id"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the skill, e.g. 'shell-redirect-stdout'.",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "label": {
+      "type": "string",
+      "description": "Human-readable name of the skill."
+    },
+    "track": {
+      "type": "string",
+      "enum": ["shell", "c", "python_ai"],
+      "description": "Which track this skill belongs to."
+    },
+    "module_id": {
+      "type": "string",
+      "description": "The module this skill is part of."
+    },
+    "description": {
+      "type": "string",
+      "description": "One-sentence explanation of what this skill means concretely."
+    },
+    "prerequisites": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of skill IDs that should be acquired before this one.",
+      "default": []
+    },
+    "phase": {
+      "type": "string",
+      "enum": ["foundation", "practice", "core", "advanced"],
+      "description": "Learning phase this skill belongs to."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- Add formal JSON schemas (`packages/curriculum/schemas/`) for the four atomic pedagogical entities: **Skill**, **Checkpoint**, **Resource**, **Evidence**
- Update `42_lausanne_curriculum.json` to use fully qualified `skill_ids`, bump `schema_version` to `0.2.0`, and seed `shell-basics` module with exemplar skills, checkpoints, resources, and evidence types
- Schemas are exploitable by API and frontend without ad-hoc parsing logic

Closes #10

## Design decisions

- **Explicit enums** for track, phase, checkpoint type, evidence type, resource tier and format — prevents drift
- **`additionalProperties: false`** on all schemas — strict contract for consumers
- **Source tier enum** mirrors `source_policy.tiers` from curriculum JSON — single source of truth for governance
- **Prerequisite graph** via `prerequisites` array on Skill — enables dependency-aware progression

## Test plan

- [ ] Validate all 4 schemas load as valid JSON Schema draft 2020-12
- [ ] Validate seeded curriculum data against schemas
- [ ] Verify API can import and use schemas for request/response validation
- [ ] Confirm no regression on existing smoke checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)