### PR TITLE
feat: add Pydantic LearnerProfile and ProgressState schemas (#22)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from .repository import load_curriculum, load_progression, write_progression
+from .schemas import ProgressUpdate
 
 app = FastAPI(title="42-training API", version="0.1.0")
 
@@ -73,21 +74,23 @@ def progression() -> dict[str, object]:
 
 
 @app.post("/api/v1/progression")
-def update_progression(payload: dict[str, object]) -> dict[str, object]:
+def update_progression(payload: ProgressUpdate) -> dict[str, object]:
     current = load_progression()
     learning_plan = current.setdefault("learning_plan", {})
     progress = current.setdefault("progress", {})
 
+    updates = payload.model_dump(exclude_none=True)
+
     for key in ("active_course", "active_module", "pace_mode"):
-        if key in payload:
-            learning_plan[key] = payload[key]
+        if key in updates:
+            learning_plan[key] = updates[key]
 
     for key in ("current_exercise", "current_step"):
-        if key in payload:
-            progress[key] = payload[key]
+        if key in updates:
+            progress[key] = updates[key]
 
-    if "next_command" in payload:
-        current["next_command"] = payload["next_command"]
+    if "next_command" in updates:
+        current["next_command"] = updates["next_command"]
 
     write_progression(current)
     return current

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -29,3 +29,41 @@ class MentorResponse(BaseModel):
     next_action: str
     source_policy: list[str]
     direct_solution_allowed: bool
+
+
+# --- Learner profile & progression schemas (Issue #22) ---
+
+Track = Literal["shell", "c", "python_ai"]
+Phase = Literal["foundation", "practice", "core", "advanced"]
+PaceMode = Literal["slow", "normal", "intensive", "self_paced"]
+
+
+class LearnerProfile(BaseModel):
+    """Core identity of a learner on the platform."""
+
+    username: str = Field(min_length=1, max_length=64)
+    active_course: Track = "shell"
+    active_module: str | None = None
+    pace_mode: PaceMode = "normal"
+    profile: dict[str, str] = Field(default_factory=dict)
+
+
+class ProgressState(BaseModel):
+    """Tracks a learner's current progression state."""
+
+    current_exercise: str | None = None
+    current_step: str | None = None
+    completed: list[str] = Field(default_factory=list)
+    in_progress: list[str] = Field(default_factory=list)
+    todo: list[str] = Field(default_factory=list)
+
+
+class ProgressUpdate(BaseModel):
+    """Payload for POST /api/v1/progression."""
+
+    active_course: Track | None = None
+    active_module: str | None = None
+    pace_mode: PaceMode | None = None
+    current_exercise: str | None = None
+    current_step: str | None = None
+    next_command: str | None = None

--- a/services/api/tests/test_schemas.py
+++ b/services/api/tests/test_schemas.py
@@ -1,0 +1,93 @@
+"""Tests for LearnerProfile, ProgressState and ProgressUpdate schemas (Issue #22)."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas import LearnerProfile, ProgressState, ProgressUpdate
+
+
+# -- LearnerProfile ----------------------------------------------------------
+
+
+class TestLearnerProfile:
+    def test_minimal_creation(self) -> None:
+        profile = LearnerProfile(username="edecarva")
+        assert profile.username == "edecarva"
+        assert profile.active_course == "shell"
+        assert profile.active_module is None
+        assert profile.pace_mode == "normal"
+        assert profile.profile == {}
+
+    def test_full_creation(self) -> None:
+        profile = LearnerProfile(
+            username="jdoe",
+            active_course="c",
+            active_module="c-pointers",
+            pace_mode="intensive",
+            profile={"campus": "lausanne"},
+        )
+        assert profile.active_course == "c"
+        assert profile.active_module == "c-pointers"
+        assert profile.pace_mode == "intensive"
+        assert profile.profile["campus"] == "lausanne"
+
+    def test_invalid_track_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LearnerProfile(username="x", active_course="rust")  # type: ignore[arg-type]
+
+    def test_empty_username_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LearnerProfile(username="")
+
+    def test_long_username_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LearnerProfile(username="a" * 65)
+
+
+# -- ProgressState ------------------------------------------------------------
+
+
+class TestProgressState:
+    def test_minimal_creation(self) -> None:
+        state = ProgressState()
+        assert state.current_exercise is None
+        assert state.current_step is None
+        assert state.completed == []
+        assert state.in_progress == []
+        assert state.todo == []
+
+    def test_full_creation(self) -> None:
+        state = ProgressState(
+            current_exercise="shell-basics-ex01",
+            current_step="step-3",
+            completed=["shell-basics-ex00"],
+            in_progress=["shell-basics-ex01"],
+            todo=["shell-basics-ex02"],
+        )
+        assert state.current_exercise == "shell-basics-ex01"
+        assert state.completed == ["shell-basics-ex00"]
+        assert len(state.in_progress) == 1
+        assert len(state.todo) == 1
+
+
+# -- ProgressUpdate -----------------------------------------------------------
+
+
+class TestProgressUpdate:
+    def test_empty_payload_valid(self) -> None:
+        update = ProgressUpdate()
+        dump = update.model_dump(exclude_none=True)
+        assert dump == {}
+
+    def test_partial_update(self) -> None:
+        update = ProgressUpdate(active_course="c", current_step="step-1")
+        dump = update.model_dump(exclude_none=True)
+        assert dump == {"active_course": "c", "current_step": "step-1"}
+
+    def test_invalid_track_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ProgressUpdate(active_course="rust")  # type: ignore[arg-type]
+
+    def test_invalid_pace_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ProgressUpdate(pace_mode="turbo")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Adds `LearnerProfile` (active_course, active_module, pace_mode, profile), `ProgressState` (current_exercise, current_step, completed, in_progress, todo), and `ProgressUpdate` Pydantic models
- Replaces untyped `dict[str, object]` on `POST /api/v1/progression` with validated `ProgressUpdate` payload
- Adds comprehensive schema tests (13 tests passing)

Closes #22

## Test plan
- [x] `pytest tests -q` — 13 tests pass (2 existing API + 11 new schema tests)
- [ ] Manual smoke: `POST /api/v1/progression` with valid/invalid payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)