### PR TITLE
feat: add Next.js routing for tracks, modules, progression (#15)

### DIFF
--- a/apps/web/app/modules/[id]/page.tsx
+++ b/apps/web/app/modules/[id]/page.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+
+import { getDashboardData } from "@/lib/api";
+
+function Pill({ children }: { children: ReactNode }) {
+  return <span className="pill">{children}</span>;
+}
+
+export default async function ModulePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const data = await getDashboardData();
+
+  let foundModule = null;
+  let parentTrack = null;
+
+  for (const track of data.curriculum.tracks) {
+    const mod = track.modules.find((m) => m.id === id);
+    if (mod) {
+      foundModule = mod;
+      parentTrack = track;
+      break;
+    }
+  }
+
+  if (!foundModule || !parentTrack) {
+    return (
+      <main className="page-shell">
+        <h1>Module not found</h1>
+        <p>No module matching &ldquo;{id}&rdquo;.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page-shell">
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Module &middot; {parentTrack.title}</p>
+          <h1>{foundModule.title}</h1>
+        </div>
+        <Pill>{foundModule.phase}</Pill>
+        <p className="lead">{foundModule.deliverable}</p>
+        <div className="stack-list">
+          {foundModule.skills.map((skill) => (
+            <Pill key={skill}>{skill}</Pill>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/progression/page.tsx
+++ b/apps/web/app/progression/page.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+
+import { getDashboardData } from "@/lib/api";
+
+function Pill({ children }: { children: ReactNode }) {
+  return <span className="pill">{children}</span>;
+}
+
+export default async function ProgressionPage() {
+  const data = await getDashboardData();
+  const { progression } = data;
+  const plan = progression.learning_plan;
+  const progress = progression.progress;
+
+  return (
+    <main className="page-shell">
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Progression</p>
+          <h1>Your learning progress</h1>
+        </div>
+
+        <div className="hero-grid">
+          <div className="metric-card">
+            <span>Active course</span>
+            <strong>{plan?.active_course ?? "n/a"}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Active module</span>
+            <strong>{plan?.active_module ?? "n/a"}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Pace mode</span>
+            <strong>{plan?.pace_mode ?? "self_paced"}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Next command</span>
+            <strong>{progression.next_command ?? "n/a"}</strong>
+          </div>
+        </div>
+      </section>
+
+      {progress && (
+        <section className="section">
+          <h2>Current exercise</h2>
+          <p><strong>{progress.current_exercise ?? "None"}</strong></p>
+          <p className="muted">{progress.current_step ?? "No current step"}</p>
+
+          <h3>Completed</h3>
+          <div className="stack-list">
+            {(progress.completed ?? []).map((item) => (
+              <Pill key={item}>{item}</Pill>
+            ))}
+          </div>
+
+          <h3>In progress</h3>
+          <div className="stack-list">
+            {(progress.in_progress ?? []).map((item) => (
+              <Pill key={item}>{item}</Pill>
+            ))}
+          </div>
+
+          <h3>To do</h3>
+          <div className="stack-list">
+            {(progress.todo ?? []).map((item) => (
+              <Pill key={item}>{item}</Pill>
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/tracks/[id]/page.tsx
+++ b/apps/web/app/tracks/[id]/page.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+
+import { getDashboardData } from "@/lib/api";
+
+function Pill({ children }: { children: ReactNode }) {
+  return <span className="pill">{children}</span>;
+}
+
+export default async function TrackPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const data = await getDashboardData();
+  const track = data.curriculum.tracks.find((t) => t.id === id);
+
+  if (!track) {
+    return (
+      <main className="page-shell">
+        <h1>Track not found</h1>
+        <p>No track matching &ldquo;{id}&rdquo;.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page-shell">
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Track</p>
+          <h1>{track.title}</h1>
+        </div>
+        <p className="lead">{track.summary}</p>
+        <p className="muted">{track.why_it_matters}</p>
+
+        <div className="module-list">
+          {track.modules.map((module) => (
+            <div key={module.id} className="module-item">
+              <div className="module-header">
+                <strong>{module.title}</strong>
+                <Pill>{module.phase}</Pill>
+              </div>
+              <p>{module.deliverable}</p>
+              <div className="stack-list">
+                {module.skills.map((skill) => (
+                  <Pill key={skill}>{skill}</Pill>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds App Router pages for `/tracks/[id]`, `/modules/[id]`, and `/progression`
- All pages use SSR via async server components consuming `getDashboardData()`
- Presentation-only — no business logic in web layer (per architecture contract)

Closes #15

## Validation
- TypeScript compiles with zero errors (`tsc --noEmit`)
- `npm run build` has a pre-existing `/_global-error` prerender failure unrelated to these changes (Next.js 16 + React 19 known issue)

## Test plan
- [ ] Visit `/tracks/shell`, `/tracks/c`, `/tracks/python_ia` — verify track detail renders
- [ ] Visit `/modules/shell_basics` — verify module detail with parent track context
- [ ] Visit `/progression` — verify learning progress view
- [ ] Verify `/` dashboard still renders correctly (SSR preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)