### PR TITLE
feat: add module prerequisites to curriculum JSON (#11)

### DIFF
--- a/packages/curriculum/data/42_lausanne_curriculum.json
+++ b/packages/curriculum/data/42_lausanne_curriculum.json
@@ -45,6 +45,7 @@
           "id": "shell-basics",
           "title": "Navigation and files",
           "phase": "foundation",
+          "prerequisites": [],
           "skills": ["pwd", "ls", "cd", "mkdir", "touch", "cp", "mv", "rm"],
           "deliverable": "Navigate, create, copy and clean files without hesitation."
         },
@@ -52,6 +53,7 @@
           "id": "shell-streams",
           "title": "Redirections and pipes",
           "phase": "foundation",
+          "prerequisites": ["shell-basics"],
           "skills": ["stdin", "stdout", "stderr", "redirect", "append", "pipe", "grep"],
           "deliverable": "Compose useful shell chains and inspect text quickly."
         },
@@ -59,6 +61,7 @@
           "id": "shell-permissions",
           "title": "Permissions and execution",
           "phase": "foundation",
+          "prerequisites": ["shell-basics"],
           "skills": ["chmod", "ownership", "executable bit", "PATH"],
           "deliverable": "Understand why a script runs or fails."
         },
@@ -66,6 +69,7 @@
           "id": "shell-tooling",
           "title": "Linux work habits",
           "phase": "practice",
+          "prerequisites": ["shell-streams", "shell-permissions"],
           "skills": ["find", "history", "man", "vim basics", "git basics"],
           "deliverable": "Operate daily in Linux without depending on GUI reflexes."
         }
@@ -81,6 +85,7 @@
           "id": "c-basics",
           "title": "Syntax and control flow",
           "phase": "foundation",
+          "prerequisites": ["shell-basics"],
           "skills": ["variables", "conditions", "loops", "functions", "headers"],
           "deliverable": "Write small programs cleanly and compile with warnings enabled."
         },
@@ -88,6 +93,7 @@
           "id": "c-memory",
           "title": "Pointers and memory",
           "phase": "foundation",
+          "prerequisites": ["c-basics"],
           "skills": ["addresses", "pointers", "arrays", "strings", "malloc", "free"],
           "deliverable": "Explain memory decisions and avoid basic leaks."
         },
@@ -95,6 +101,7 @@
           "id": "c-build-debug",
           "title": "Build, tests and debug",
           "phase": "practice",
+          "prerequisites": ["c-basics", "shell-streams"],
           "skills": ["cc", "Wall", "Wextra", "Werror", "gdb", "valgrind"],
           "deliverable": "Investigate failures instead of guessing."
         },
@@ -102,6 +109,7 @@
           "id": "c-libft-pushswap-bridge",
           "title": "Library and algorithm bridge",
           "phase": "core",
+          "prerequisites": ["c-memory", "c-build-debug"],
           "skills": ["libft mindset", "API naming", "sorting logic", "complexity intuition"],
           "deliverable": "Prepare for libft, printf, gnl and push_swap logic."
         }
@@ -117,6 +125,7 @@
           "id": "python-basics",
           "title": "Python foundations",
           "phase": "foundation",
+          "prerequisites": ["shell-basics"],
           "skills": ["variables", "conditions", "loops", "functions", "collections"],
           "deliverable": "Write and explain small scripts confidently."
         },
@@ -124,6 +133,7 @@
           "id": "python-oop-scripting",
           "title": "Objects and automation",
           "phase": "practice",
+          "prerequisites": ["python-basics"],
           "skills": ["classes", "methods", "files", "json", "argparse"],
           "deliverable": "Build useful utilities and simple models."
         },
@@ -131,6 +141,7 @@
           "id": "ai-rag-agents",
           "title": "AI, RAG and agent literacy",
           "phase": "advanced",
+          "prerequisites": ["python-oop-scripting"],
           "skills": ["prompt design", "retrieval", "evaluation", "agent workflow", "source policy"],
           "deliverable": "Use AI as a disciplined tool without outsourcing understanding."
         }

--- a/packages/curriculum/data/PREREQUISITES.md
+++ b/packages/curriculum/data/PREREQUISITES.md
@@ -1,0 +1,56 @@
+# Module Prerequisites — Pedagogical Reasoning
+
+## Source classification
+
+The prerequisite relationships below are **inferred mapping**, not official 42 curriculum rules.
+They reflect pedagogical logic based on skill dependencies observed in Linux/C/Python learning paths.
+
+Official 42 projects define their own ordering. This graph is a preparation aid, not a substitute.
+
+## Prerequisite graph
+
+```
+shell-basics (entry point)
+├── shell-streams        — redirections need filesystem fluency first
+├── shell-permissions    — ownership/chmod assume you can navigate and create files
+├── c-basics             — compiling C requires terminal navigation
+└── python-basics        — running scripts requires terminal navigation
+
+shell-streams
+├── shell-tooling        — find, pipes, man pages build on stream concepts
+└── c-build-debug        — compiler output, piping to tools, reading error streams
+
+shell-permissions
+└── shell-tooling        — executable bit, PATH, script permissions
+
+c-basics
+├── c-memory             — pointers require solid syntax and control flow
+└── c-build-debug        — you must write code before you can compile and debug it
+
+c-memory + c-build-debug
+└── c-libft-pushswap-bridge — library and algorithm work needs both memory and build skills
+
+python-basics
+└── python-oop-scripting — OOP and file handling build on language foundations
+
+python-oop-scripting
+└── ai-rag-agents        — RAG/agent work requires scripting, file I/O, and OOP patterns
+```
+
+## Design decisions
+
+### Cross-track prerequisites
+
+Three modules have cross-track prerequisites:
+
+- **c-basics <- shell-basics**: You cannot compile and run C without navigating the filesystem and using the terminal. This is a practical dependency, not a conceptual one.
+- **c-build-debug <- shell-streams**: Understanding compiler output, piping through grep, and reading stderr are stream skills applied to a C context.
+- **python-basics <- shell-basics**: Running Python scripts, managing files, and using the terminal are prerequisites for any scripting work.
+
+### Why not more cross-track links?
+
+We avoid making the graph overly connected. For example, `ai-rag-agents` could depend on `shell-tooling` (for git and general Linux habits), but this would over-constrain the learner. The current graph enforces only what is pedagogically necessary — a learner blocked on a prerequisite should genuinely need that skill before proceeding.
+
+### Transitive dependencies
+
+The graph is intentionally shallow. `ai-rag-agents` depends on `python-oop-scripting`, which depends on `python-basics`, which depends on `shell-basics`. We do not list `python-basics` as a direct prerequisite of `ai-rag-agents` because the chain is already enforced transitively.

--- a/packages/curriculum/scripts/validate_prerequisites.py
+++ b/packages/curriculum/scripts/validate_prerequisites.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate the prerequisite graph in 42_lausanne_curriculum.json.
+
+Checks:
+1. Every prerequisite reference points to an existing module id.
+2. The prerequisite graph is acyclic (no circular dependencies).
+3. Every module has a "prerequisites" field (list, may be empty).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+CURRICULUM = Path(__file__).resolve().parent.parent / "data" / "42_lausanne_curriculum.json"
+
+
+def load_modules(path: Path) -> list[dict]:
+    with open(path) as f:
+        data = json.load(f)
+    modules = []
+    for track in data["tracks"]:
+        for mod in track["modules"]:
+            modules.append(mod)
+    return modules
+
+
+def check_prerequisites_field(modules: list[dict]) -> list[str]:
+    errors = []
+    for mod in modules:
+        if "prerequisites" not in mod:
+            errors.append(f"Module '{mod['id']}' is missing the 'prerequisites' field.")
+        elif not isinstance(mod["prerequisites"], list):
+            errors.append(f"Module '{mod['id']}': prerequisites must be a list.")
+    return errors
+
+
+def check_references(modules: list[dict]) -> list[str]:
+    ids = {m["id"] for m in modules}
+    errors = []
+    for mod in modules:
+        for prereq in mod.get("prerequisites", []):
+            if prereq not in ids:
+                errors.append(f"Module '{mod['id']}' has unknown prerequisite '{prereq}'.")
+    return errors
+
+
+def check_acyclic(modules: list[dict]) -> list[str]:
+    """Detect cycles using iterative DFS with three-color marking."""
+    adj = {m["id"]: m.get("prerequisites", []) for m in modules}
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {mid: WHITE for mid in adj}
+    errors = []
+
+    for start in adj:
+        if color[start] != WHITE:
+            continue
+        stack = [(start, False)]
+        while stack:
+            node, backtrack = stack.pop()
+            if backtrack:
+                color[node] = BLACK
+                continue
+            if color[node] == GRAY:
+                color[node] = BLACK
+                continue
+            color[node] = GRAY
+            stack.append((node, True))
+            for dep in adj[node]:
+                if dep not in adj:
+                    continue
+                if color[dep] == GRAY:
+                    errors.append(f"Cycle detected involving '{dep}' (reached from '{node}').")
+                elif color[dep] == WHITE:
+                    stack.append((dep, False))
+    return errors
+
+
+def main() -> int:
+    if not CURRICULUM.exists():
+        print(f"ERROR: curriculum file not found at {CURRICULUM}", file=sys.stderr)
+        return 1
+
+    modules = load_modules(CURRICULUM)
+    errors = []
+    errors.extend(check_prerequisites_field(modules))
+    errors.extend(check_references(modules))
+    errors.extend(check_acyclic(modules))
+
+    if errors:
+        print("Prerequisite validation FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(modules)} modules validated, prerequisite graph is acyclic.")
+
+    # Print the graph for visibility
+    for mod in modules:
+        prereqs = mod.get("prerequisites", [])
+        label = ", ".join(prereqs) if prereqs else "(entry point)"
+        print(f"  {mod['id']} <- {label}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a `"prerequisites"` field to all 11 modules in `42_lausanne_curriculum.json`
- Includes 3 cross-track prerequisites where pedagogically necessary (c-basics ← shell-basics, c-build-debug ← shell-streams, python-basics ← shell-basics)
- Validates the prerequisite graph is acyclic via a new Python script (`packages/curriculum/scripts/validate_prerequisites.py`)
- Documents pedagogical reasoning and source classification in `PREREQUISITES.md`

## Prerequisite graph

```
shell-basics (entry point)
├── shell-streams, shell-permissions, c-basics, python-basics

shell-streams + shell-permissions → shell-tooling
c-basics → c-memory, c-build-debug (+ shell-streams)
c-memory + c-build-debug → c-libft-pushswap-bridge
python-basics → python-oop-scripting → ai-rag-agents
```

## Source governance note

All prerequisite relationships are **inferred mapping** from pedagogical logic, not official 42 curriculum rules. This is explicitly documented per the project's source-governance contract.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)