### PR TITLE
feat: add abstract retrieval layer with SourceProvider interface (#30)

### DIFF
--- a/services/ai_gateway/app/retrieval.py
+++ b/services/ai_gateway/app/retrieval.py
@@ -1,0 +1,123 @@
+"""Abstract retrieval layer with SourceProvider interface.
+
+This module defines the contract for retrieving curriculum-related content
+from different source tiers, respecting the source-governance policy.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+from .repository import load_curriculum
+
+
+class SourceResult(BaseModel):
+    """A single result returned by a source provider."""
+
+    content: str
+    source_url: str | None = None
+    tier: str = Field(description="Source tier id from the source policy (e.g. official_42, community_docs)")
+    confidence: float = Field(ge=0.0, le=1.0, description="Relevance confidence between 0 and 1")
+
+
+class SourceProvider(ABC):
+    """Abstract interface for retrieval backends.
+
+    Any retrieval implementation (static, vector DB, API-based) must
+    implement this interface so the ai_gateway can swap backends without
+    changing the mentor orchestration logic.
+    """
+
+    @abstractmethod
+    def search(
+        self,
+        query: str,
+        tier_filter: list[str] | None = None,
+        max_results: int = 5,
+    ) -> list[SourceResult]:
+        """Search for relevant content.
+
+        Args:
+            query: Free-text search query.
+            tier_filter: If provided, only return results from these tiers.
+            max_results: Maximum number of results to return.
+
+        Returns:
+            List of SourceResult ordered by descending confidence.
+        """
+
+
+class StaticSourceProvider(SourceProvider):
+    """SourceProvider backed by the static curriculum JSON.
+
+    Performs simple keyword matching against tracks, modules, skills,
+    and recommended resources. Suitable for the MVP phase before a
+    proper vector store is introduced.
+    """
+
+    def __init__(self) -> None:
+        self._curriculum = load_curriculum()
+
+    def search(
+        self,
+        query: str,
+        tier_filter: list[str] | None = None,
+        max_results: int = 5,
+    ) -> list[SourceResult]:
+        results: list[SourceResult] = []
+        query_lower = query.lower()
+
+        # Search tracks and modules
+        for track in self._curriculum.get("tracks", []):
+            self._match_track(track, query_lower, results)
+
+        # Search recommended resources
+        for resource in self._curriculum.get("recommended_resources", []):
+            self._match_resource(resource, query_lower, results)
+
+        # Apply tier filter
+        if tier_filter is not None:
+            results = [r for r in results if r.tier in tier_filter]
+
+        # Sort by confidence descending, truncate
+        results.sort(key=lambda r: r.confidence, reverse=True)
+        return results[:max_results]
+
+    def _match_track(self, track: dict, query_lower: str, results: list[SourceResult]) -> None:
+        track_text = f"{track.get('title', '')} {track.get('summary', '')}".lower()
+        if query_lower in track_text:
+            results.append(
+                SourceResult(
+                    content=f"Track: {track['title']} — {track.get('summary', '')}",
+                    tier="official_42",
+                    confidence=0.7,
+                )
+            )
+
+        for module in track.get("modules", []):
+            module_text = f"{module.get('title', '')} {module.get('deliverable', '')}".lower()
+            skills_text = " ".join(module.get("skills", [])).lower()
+            combined = f"{module_text} {skills_text}"
+
+            if query_lower in combined:
+                results.append(
+                    SourceResult(
+                        content=f"Module: {module['title']} (track: {track['id']}, phase: {module.get('phase', 'unknown')}) — Skills: {', '.join(module.get('skills', []))}",
+                        tier="official_42",
+                        confidence=0.8,
+                    )
+                )
+
+    def _match_resource(self, resource: dict, query_lower: str, results: list[SourceResult]) -> None:
+        label = resource.get("label", "").lower()
+        if query_lower in label:
+            results.append(
+                SourceResult(
+                    content=f"Resource: {resource['label']}",
+                    source_url=resource.get("url"),
+                    tier=resource.get("tier", "community_docs"),
+                    confidence=0.6,
+                )
+            )

--- a/services/ai_gateway/tests/test_retrieval.py
+++ b/services/ai_gateway/tests/test_retrieval.py
@@ -1,0 +1,78 @@
+"""Tests for the abstract retrieval layer and StaticSourceProvider."""
+
+from app.retrieval import SourceProvider, SourceResult, StaticSourceProvider
+
+
+def test_source_result_model() -> None:
+    result = SourceResult(content="test", tier="official_42", confidence=0.9)
+    assert result.content == "test"
+    assert result.source_url is None
+    assert result.tier == "official_42"
+    assert result.confidence == 0.9
+
+
+def test_source_result_with_url() -> None:
+    result = SourceResult(
+        content="test",
+        source_url="https://example.com",
+        tier="community_docs",
+        confidence=0.5,
+    )
+    assert result.source_url == "https://example.com"
+
+
+def test_static_provider_is_source_provider() -> None:
+    provider = StaticSourceProvider()
+    assert isinstance(provider, SourceProvider)
+
+
+def test_static_search_shell_basics() -> None:
+    provider = StaticSourceProvider()
+    results = provider.search("navigation")
+    assert len(results) > 0
+    assert all(isinstance(r, SourceResult) for r in results)
+    assert all(0.0 <= r.confidence <= 1.0 for r in results)
+
+
+def test_static_search_by_skill() -> None:
+    provider = StaticSourceProvider()
+    results = provider.search("malloc")
+    assert len(results) > 0
+    # malloc is in c-memory module
+    assert any("memory" in r.content.lower() or "malloc" in r.content.lower() for r in results)
+
+
+def test_static_search_resource() -> None:
+    provider = StaticSourceProvider()
+    results = provider.search("norminette")
+    assert len(results) > 0
+    assert any(r.source_url is not None for r in results)
+
+
+def test_static_search_tier_filter() -> None:
+    provider = StaticSourceProvider()
+    # norminette is a testers_and_tooling resource
+    results_all = provider.search("norminette")
+    results_filtered = provider.search("norminette", tier_filter=["official_42"])
+    assert len(results_filtered) <= len(results_all)
+    assert all(r.tier == "official_42" for r in results_filtered)
+
+
+def test_static_search_max_results() -> None:
+    provider = StaticSourceProvider()
+    results = provider.search("shell", max_results=2)
+    assert len(results) <= 2
+
+
+def test_static_search_no_match() -> None:
+    provider = StaticSourceProvider()
+    results = provider.search("xyznonexistent999")
+    assert results == []
+
+
+def test_static_search_results_sorted_by_confidence() -> None:
+    provider = StaticSourceProvider()
+    results = provider.search("shell")
+    if len(results) > 1:
+        for i in range(len(results) - 1):
+            assert results[i].confidence >= results[i + 1].confidence


### PR DESCRIPTION
## Summary

Closes #30.

- Adds `SourceProvider` abstract interface with `search(query, tier_filter, max_results)` returning `list[SourceResult]`
- Adds `SourceResult` pydantic model with `content`, `source_url`, `tier`, and `confidence` fields
- Adds `StaticSourceProvider` implementation that searches curriculum JSON data (tracks, modules, skills, resources) with keyword matching, tier filtering, and confidence-based ranking
- All code lives in `services/ai_gateway/app/retrieval.py` per the architecture contract
- 9 new tests covering model validation, search, filtering, sorting, and edge cases

## Test plan

- [x] `pytest tests -q` in `services/ai_gateway/` — 12 passed (3 existing + 9 new)
- [ ] Verify integration when wired into mentor endpoint (future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)