### PR TITLE
feat: make docker-compose dev actually executable (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,26 @@ L'architecture suit volontairement des patterns inspirés de RBOK:
 |-- packages/shared-types/
 |-- scripts/
 |-- progression.json
-`-- infra/docker-compose.dev.example.yml
+`-- docker-compose.yml
 ```
 
 ### Lancer le MVP en local
+
+#### Option 1: Docker (recommande)
+
+```bash
+./scripts/dev-up.sh
+```
+
+Le script copie les `.env.example` si necessaire, demarre tous les services via docker-compose, attend les healthchecks et affiche les URLs.
+
+Pour arreter:
+
+```bash
+docker compose down
+```
+
+#### Option 2: Sans Docker (services individuels)
 
 API:
 
@@ -164,10 +180,26 @@ The architecture deliberately follows RBOK-inspired patterns:
 |-- packages/shared-types/
 |-- scripts/
 |-- progression.json
-`-- infra/docker-compose.dev.example.yml
+`-- docker-compose.yml
 ```
 
 ### Run the MVP locally
+
+#### Option 1: Docker (recommended)
+
+```bash
+./scripts/dev-up.sh
+```
+
+The script copies `.env.example` files if needed, starts all services via docker-compose, waits for healthchecks and prints service URLs.
+
+To stop:
+
+```bash
+docker compose down
+```
+
+#### Option 2: Without Docker (individual services)
 
 API:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:16-alpine
@@ -11,6 +9,11 @@ services:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U training"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   redis:
     image: redis:7-alpine
@@ -19,36 +22,56 @@ services:
       - "6379:6379"
     volumes:
       - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   api:
     build:
-      context: ../services/api
+      context: ./services/api
       dockerfile: Dockerfile
     environment:
       API_PORT: 8000
       DATABASE_URL: postgresql+asyncpg://training:training@postgres:5432/training
       REDIS_URL: redis://redis:6379/0
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   ai_gateway:
     build:
-      context: ../services/ai_gateway
+      context: ./services/ai_gateway
       dockerfile: Dockerfile
     environment:
       AI_GATEWAY_PORT: 8100
       AI_GATEWAY_API_BASE_URL: http://api:8000
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     ports:
       - "8100:8100"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8100/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   web:
     build:
-      context: ../apps/web
+      context: ./apps/web
       dockerfile: Dockerfile
       target: dev
     environment:
@@ -56,8 +79,10 @@ services:
       NEXT_PUBLIC_AI_GATEWAY_URL: http://localhost:8100
       PORT: 3000
     depends_on:
-      - api
-      - ai_gateway
+      api:
+        condition: service_healthy
+      ai_gateway:
+        condition: service_healthy
     ports:
       - "3000:3000"
 

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# dev-up.sh — Start the full dev stack via docker-compose.
+# Linux-first. Requires: docker, docker-compose (or docker compose plugin).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Detect compose command ---
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE="docker-compose"
+else
+  echo "ERROR: docker compose not found. Install Docker with the compose plugin."
+  exit 1
+fi
+
+# --- Copy .env.example -> .env where missing ---
+for dir in services/api services/ai_gateway apps/web; do
+  if [ -f "$dir/.env.example" ] && [ ! -f "$dir/.env" ]; then
+    cp "$dir/.env.example" "$dir/.env"
+    echo "Created $dir/.env from .env.example"
+  fi
+done
+
+# --- Start services ---
+echo "Starting dev stack..."
+$COMPOSE up -d --build
+
+# --- Wait for healthchecks ---
+echo "Waiting for services to become healthy..."
+TIMEOUT=120
+ELAPSED=0
+INTERVAL=5
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  UNHEALTHY=$($COMPOSE ps --format json 2>/dev/null \
+    | grep -c '"Health":"starting"' || true)
+  HEALTH_STATUS=$($COMPOSE ps 2>/dev/null)
+
+  if echo "$HEALTH_STATUS" | grep -q "(unhealthy)"; then
+    echo "ERROR: A service is unhealthy."
+    $COMPOSE ps
+    exit 1
+  fi
+
+  if [ "$UNHEALTHY" -eq 0 ] && ! echo "$HEALTH_STATUS" | grep -q "(health: starting)"; then
+    break
+  fi
+
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+  echo "WARNING: Timed out waiting for healthchecks (${TIMEOUT}s)."
+  $COMPOSE ps
+  exit 1
+fi
+
+# --- Print service URLs ---
+echo ""
+echo "=== Dev stack is up ==="
+echo "  Web:        http://localhost:3000"
+echo "  API:        http://localhost:8000"
+echo "  AI Gateway: http://localhost:8100"
+echo "  Postgres:   localhost:5432 (training/training)"
+echo "  Redis:      localhost:6379"
+echo ""
+echo "Logs:  $COMPOSE logs -f"
+echo "Stop:  $COMPOSE down"


### PR DESCRIPTION
## Summary

Closes #42.

- Renames `infra/docker-compose.dev.example.yml` → `docker-compose.yml` at repo root with fixed build context paths
- Adds proper healthchecks (postgres, redis, api, ai_gateway) and `depends_on` with `service_healthy` conditions
- Adds `scripts/dev-up.sh`: copies `.env.example` files, starts the stack, waits for healthchecks, prints service URLs
- Updates README.md (FR + EN) with Docker quickstart as the recommended local dev option

## Test plan

- [ ] Run `./scripts/dev-up.sh` on a fresh clone — verify .env files are copied and services start
- [ ] Verify healthchecks pass and URLs are printed (localhost:3000, :8000, :8100)
- [ ] Run `docker compose down` — verify clean teardown
- [ ] Verify `./scripts/start_api.sh` etc. still work for non-Docker workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)