### PR TITLE
feat: create module detail page with skills and prerequisites (#17)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -243,6 +243,232 @@ p {
   .hero-grid {
     grid-template-columns: 1fr;
   }
+
+  .module-detail-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Module detail page                                                 */
+/* ------------------------------------------------------------------ */
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.breadcrumb a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  color: var(--ink);
+}
+
+.breadcrumb-sep {
+  opacity: 0.4;
+}
+
+.module-detail-hero {
+  padding: 32px;
+}
+
+.module-detail-hero h1 {
+  margin: 12px 0 8px;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  line-height: 1.1;
+}
+
+.module-detail-topline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.module-detail-body {
+  grid-template-columns: 1.4fr 0.6fr;
+}
+
+.module-detail-main,
+.module-detail-sidebar {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+/* Action button */
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 20px;
+  padding: 12px 28px;
+  border: none;
+  border-radius: 14px;
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  background: var(--ink);
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+
+.action-btn:hover {
+  opacity: 0.85;
+}
+
+.action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.action-btn--done {
+  background: var(--muted);
+}
+
+.action-btn--in_progress {
+  background: var(--accent);
+  color: var(--ink);
+}
+
+/* Pill variants */
+
+.pill--done {
+  background: rgba(53, 95, 59, 0.12);
+  border-color: rgba(53, 95, 59, 0.2);
+  color: var(--python);
+}
+
+.pill--in_progress {
+  background: rgba(216, 166, 87, 0.18);
+  border-color: rgba(216, 166, 87, 0.3);
+  color: #7a5a16;
+}
+
+.pill--todo {
+  background: rgba(28, 26, 23, 0.06);
+  border-color: rgba(28, 26, 23, 0.08);
+}
+
+/* Skill grid */
+
+.skill-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.skill-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.5);
+  font-size: 14px;
+}
+
+.skill-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skill-item--done .skill-indicator {
+  background: var(--python);
+}
+
+.skill-item--in_progress .skill-indicator {
+  background: var(--accent);
+}
+
+.skill-item--todo .skill-indicator {
+  background: var(--line);
+}
+
+.skill-state-label {
+  margin-left: auto;
+  font-size: 12px;
+}
+
+/* Objective list */
+
+.objective-list {
+  margin: 8px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+  line-height: 1.5;
+}
+
+/* Prerequisite list */
+
+.prereq-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.prereq-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  font-size: 14px;
+}
+
+.prereq-indicator {
+  font-weight: 700;
+  width: 20px;
+  text-align: center;
+}
+
+.prereq-item--met .prereq-indicator {
+  color: var(--python);
+}
+
+.prereq-item--unmet .prereq-indicator {
+  color: var(--c);
+}
+
+/* Resource list */
+
+.resource-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.resource-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  font-size: 14px;
+}
+
+.resource-item a {
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.resource-item a:hover {
+  text-decoration: underline;
 }
 
 /* ------------------------------------------------------------------ */

--- a/apps/web/app/modules/[id]/page.tsx
+++ b/apps/web/app/modules/[id]/page.tsx
@@ -1,50 +1,299 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 
 import { getDashboardData } from "@/lib/api";
+import type { ModuleItem } from "@/lib/api";
 
-function Pill({ children }: { children: ReactNode }) {
-  return <span className="pill">{children}</span>;
+/* ------------------------------------------------------------------ */
+/*  Static prerequisite map (from documented dependency graph)         */
+/* ------------------------------------------------------------------ */
+
+const PREREQUISITE_MAP: Record<string, string[]> = {
+  "shell-basics": [],
+  "shell-streams": ["shell-basics"],
+  "shell-permissions": ["shell-basics"],
+  "shell-tooling": ["shell-streams", "shell-permissions"],
+  "c-basics": ["shell-basics"],
+  "c-memory": ["c-basics"],
+  "c-build-debug": ["c-basics", "shell-streams"],
+  "c-libft-pushswap-bridge": ["c-memory", "c-build-debug"],
+  "python-basics": ["shell-basics"],
+  "python-oop-scripting": ["python-basics"],
+  "ai-rag-agents": ["python-oop-scripting"],
+};
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function Pill({ children, variant }: { children: ReactNode; variant?: string }) {
+  const cls = variant ? `pill pill--${variant}` : "pill";
+  return <span className={cls}>{children}</span>;
 }
 
-export default async function ModulePage({ params }: { params: Promise<{ id: string }> }) {
+type ModuleState = "done" | "in_progress" | "todo";
+
+function deriveModuleState(
+  moduleId: string,
+  trackId: string,
+  activeTrack: string,
+  activeModule: string,
+  modules: ModuleItem[],
+): ModuleState {
+  if (trackId !== activeTrack) return "todo";
+  if (moduleId === activeModule) return "in_progress";
+  const activeIndex = modules.findIndex((m) => m.id === activeModule);
+  const currentIndex = modules.findIndex((m) => m.id === moduleId);
+  if (activeIndex === -1) return "todo";
+  return currentIndex < activeIndex ? "done" : "todo";
+}
+
+function stateLabel(state: ModuleState): string {
+  switch (state) {
+    case "done":
+      return "Completed";
+    case "in_progress":
+      return "In progress";
+    case "todo":
+      return "Not started";
+  }
+}
+
+function actionLabel(state: ModuleState): string {
+  switch (state) {
+    case "done":
+      return "Review module";
+    case "in_progress":
+      return "Continue";
+    case "todo":
+      return "Start module";
+  }
+}
+
+const ALLOWED_TIERS = new Set([
+  "official_42",
+  "community_docs",
+  "testers_and_tooling",
+]);
+
+function tierLabel(tier: string): string {
+  switch (tier) {
+    case "official_42":
+      return "Official 42";
+    case "community_docs":
+      return "Community";
+    case "testers_and_tooling":
+      return "Tooling";
+    default:
+      return tier;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
+
+export default async function ModuleDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
   const { id } = await params;
   const data = await getDashboardData();
+  const { curriculum, progression } = data;
 
-  let foundModule = null;
-  let parentTrack = null;
+  const activeTrack = progression.learning_plan?.active_course ?? "shell";
+  const activeModule = progression.learning_plan?.active_module ?? "";
 
-  for (const track of data.curriculum.tracks) {
+  /* Find the module and its parent track */
+  let foundModule: ModuleItem | undefined;
+  let foundTrackId = "";
+  let trackModules: ModuleItem[] = [];
+
+  for (const track of curriculum.tracks) {
     const mod = track.modules.find((m) => m.id === id);
     if (mod) {
       foundModule = mod;
-      parentTrack = track;
+      foundTrackId = track.id;
+      trackModules = track.modules;
       break;
     }
   }
 
-  if (!foundModule || !parentTrack) {
+  if (!foundModule) {
     return (
       <main className="page-shell">
-        <h1>Module not found</h1>
-        <p>No module matching &ldquo;{id}&rdquo;.</p>
+        <section className="panel" style={{ textAlign: "center", padding: 48 }}>
+          <h1>Module not found</h1>
+          <p className="muted">No module with id &ldquo;{id}&rdquo; exists in the curriculum.</p>
+          <Link href="/" className="action-btn" style={{ marginTop: 24, display: "inline-block" }}>
+            Back to dashboard
+          </Link>
+        </section>
       </main>
     );
   }
 
+  const state = deriveModuleState(id, foundTrackId, activeTrack, activeModule, trackModules);
+  const prerequisites = foundModule.prerequisites ?? PREREQUISITE_MAP[id] ?? [];
+
+  /* Derive prerequisite satisfaction */
+  const prereqStatus = prerequisites.map((prereqId) => {
+    const prereqState = deriveModuleState(prereqId, foundTrackId, activeTrack, activeModule, trackModules);
+    /* Cross-track prereqs: check all tracks */
+    let resolved = prereqState === "done";
+    if (!resolved) {
+      for (const track of curriculum.tracks) {
+        const prereqMod = track.modules.find((m) => m.id === prereqId);
+        if (prereqMod) {
+          const s = deriveModuleState(prereqId, track.id, activeTrack, activeModule, track.modules);
+          resolved = s === "done";
+          break;
+        }
+      }
+    }
+    return { id: prereqId, satisfied: resolved };
+  });
+
+  const allPrereqsMet = prereqStatus.every((p) => p.satisfied);
+
+  /* Gather authorized resources (filter by source policy) */
+  const moduleResources = foundModule.resources ?? [];
+  const globalResources = curriculum.recommended_resources ?? [];
+  const authorizedResources = [
+    ...moduleResources.filter((r) => ALLOWED_TIERS.has(r.tier)),
+    ...globalResources.filter((r) => ALLOWED_TIERS.has(r.tier)),
+  ];
+
+  /* Derive skill states from progression */
+  const completedItems = progression.progress?.completed ?? [];
+  const inProgressItems = progression.progress?.in_progress ?? [];
+
+  function skillState(skill: string): "done" | "in_progress" | "todo" {
+    const lower = skill.toLowerCase();
+    if (completedItems.some((c) => c.toLowerCase().includes(lower))) return "done";
+    if (inProgressItems.some((c) => c.toLowerCase().includes(lower))) return "in_progress";
+    return "todo";
+  }
+
   return (
     <main className="page-shell">
-      <section className="section">
-        <div className="section-heading">
-          <p className="eyebrow">Module &middot; {parentTrack.title}</p>
-          <h1>{foundModule.title}</h1>
+      {/* Breadcrumb */}
+      <nav className="breadcrumb">
+        <Link href="/">Dashboard</Link>
+        <span className="breadcrumb-sep">/</span>
+        <span>{foundTrackId}</span>
+        <span className="breadcrumb-sep">/</span>
+        <span>{foundModule.title}</span>
+      </nav>
+
+      {/* Header */}
+      <section className="module-detail-hero panel">
+        <div className="module-detail-topline">
+          <Pill variant={state}>{stateLabel(state)}</Pill>
+          <Pill>{foundModule.phase}</Pill>
+          {foundModule.estimated_hours != null && (
+            <span className="muted">{foundModule.estimated_hours}h estimated</span>
+          )}
         </div>
-        <Pill>{foundModule.phase}</Pill>
+        <h1>{foundModule.title}</h1>
         <p className="lead">{foundModule.deliverable}</p>
-        <div className="stack-list">
-          {foundModule.skills.map((skill) => (
-            <Pill key={skill}>{skill}</Pill>
-          ))}
+
+        <button
+          className={`action-btn action-btn--${state}`}
+          disabled={!allPrereqsMet && state === "todo"}
+        >
+          {!allPrereqsMet && state === "todo"
+            ? "Prerequisites not met"
+            : actionLabel(state)}
+        </button>
+      </section>
+
+      {/* Two-column body */}
+      <section className="section split module-detail-body">
+        <div className="module-detail-main">
+          {/* Objectives (if enriched data available) */}
+          {foundModule.objectives && foundModule.objectives.length > 0 && (
+            <article className="panel">
+              <p className="eyebrow">Objectives</p>
+              <ul className="objective-list">
+                {foundModule.objectives.map((obj) => (
+                  <li key={obj}>{obj}</li>
+                ))}
+              </ul>
+            </article>
+          )}
+
+          {/* Skills */}
+          <article className="panel">
+            <p className="eyebrow">Skills</p>
+            <h2>Competencies to acquire</h2>
+            <div className="skill-grid">
+              {foundModule.skills.map((skill) => {
+                const ss = state === "todo" ? "todo" : skillState(skill);
+                return (
+                  <div key={skill} className={`skill-item skill-item--${ss}`}>
+                    <span className="skill-indicator" />
+                    <span>{skill}</span>
+                    <span className="muted skill-state-label">{stateLabel(ss)}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </article>
+
+          {/* Exit criteria (if enriched data available) */}
+          {foundModule.exit_criteria && foundModule.exit_criteria.length > 0 && (
+            <article className="panel">
+              <p className="eyebrow">Exit criteria</p>
+              <ul className="objective-list">
+                {foundModule.exit_criteria.map((ec) => (
+                  <li key={ec}>{ec}</li>
+                ))}
+              </ul>
+            </article>
+          )}
         </div>
+
+        <aside className="module-detail-sidebar">
+          {/* Prerequisites */}
+          <article className="panel">
+            <p className="eyebrow">Prerequisites</p>
+            <h2>Required modules</h2>
+            {prerequisites.length === 0 ? (
+              <p className="muted">Entry point &mdash; no prerequisites.</p>
+            ) : (
+              <div className="prereq-list">
+                {prereqStatus.map((p) => (
+                  <div key={p.id} className={`prereq-item prereq-item--${p.satisfied ? "met" : "unmet"}`}>
+                    <span className="prereq-indicator">{p.satisfied ? "\u2713" : "\u2717"}</span>
+                    <span>{p.id}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </article>
+
+          {/* Authorized resources */}
+          <article className="panel">
+            <p className="eyebrow">Authorized resources</p>
+            <h2>Approved sources</h2>
+            {authorizedResources.length === 0 ? (
+              <p className="muted">No authorized resources available.</p>
+            ) : (
+              <div className="resource-list">
+                {authorizedResources.map((r) => (
+                  <div key={r.url} className="resource-item">
+                    <a href={r.url} target="_blank" rel="noopener noreferrer">
+                      {r.label}
+                    </a>
+                    <Pill>{tierLabel(r.tier)}</Pill>
+                  </div>
+                ))}
+              </div>
+            )}
+          </article>
+        </aside>
       </section>
     </main>
   );

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,9 +1,21 @@
+export type ModuleResource = {
+  label: string;
+  url: string;
+  tier: string;
+  why?: string;
+};
+
 export type ModuleItem = {
   id: string;
   title: string;
   phase: string;
   skills: string[];
   deliverable: string;
+  objectives?: string[];
+  exit_criteria?: string[];
+  resources?: ModuleResource[];
+  estimated_hours?: number;
+  prerequisites?: string[];
 };
 
 export type TrackItem = {
@@ -25,6 +37,7 @@ export type DashboardData = {
     };
     tracks: TrackItem[];
     bridges: Array<{ id: string; title: string; recommended_modules: string[] }>;
+    recommended_resources?: Array<{ label: string; url: string; tier: string }>;
   };
   progression: {
     learning_plan?: {


### PR DESCRIPTION
## Summary

Closes #17.

- Implements `/modules/[id]` page consuming `getDashboardData()` with module title, phase, deliverable, and estimated hours
- Skills list with progression-derived state indicators (done/in_progress/todo)
- Prerequisites with satisfied/not-satisfied indication using a static dependency graph
- Authorized resources filtered by source policy (blocked tiers excluded per governance contract)
- Start/continue/complete action button, gated on prerequisite satisfaction
- Graceful support for enriched module fields (objectives, exit_criteria, resources) when available
- Extended `ModuleItem` type with optional enriched fields
- Responsive two-column layout with breadcrumb navigation

## Architecture

- All changes in `apps/web` (presentation layer only, per CLAUDE.md contract)
- Data consumed from existing `getDashboardData()` — no new API endpoints
- Source policy filtering enforces the governance contract: only `official_42`, `community_docs`, and `testers_and_tooling` tiers are shown

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Visual check of `/modules/shell-basics` (entry point, no prerequisites)
- [ ] Visual check of `/modules/c-build-debug` (cross-track prerequisites)
- [ ] Visual check of `/modules/nonexistent` (404 state)
- [ ] Responsive layout at mobile breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)