### PR TITLE
feat: create personal progression view with checklist (#18)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -240,7 +240,242 @@ p {
     padding: 18px;
   }
 
-  .hero-grid {
+  .hero-grid,
+  .prog-stats-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Progression page                                                   */
+/* ------------------------------------------------------------------ */
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.breadcrumb a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  color: var(--ink);
+}
+
+.breadcrumb-sep {
+  opacity: 0.4;
+}
+
+.progression-hero {
+  padding: 32px;
+}
+
+.progression-hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  line-height: 1.1;
+}
+
+.prog-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 20px;
+}
+
+/* Progress bar */
+
+.progress-bar {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--line);
+  margin-top: 8px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+/* Next action */
+
+.prog-next-action {
+  border-left: 5px solid var(--accent);
+}
+
+.prog-next-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.prog-next-content h2 {
+  margin: 0 0 4px;
+}
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 28px;
+  border: none;
+  border-radius: 14px;
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  background: var(--ink);
+  text-decoration: none;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+
+.action-btn:hover {
+  opacity: 0.85;
+}
+
+/* Pill variants */
+
+.pill--done {
+  background: rgba(53, 95, 59, 0.12);
+  border-color: rgba(53, 95, 59, 0.2);
+  color: var(--python);
+}
+
+.pill--in_progress {
+  background: rgba(216, 166, 87, 0.18);
+  border-color: rgba(216, 166, 87, 0.3);
+  color: #7a5a16;
+}
+
+.pill--todo {
+  background: rgba(28, 26, 23, 0.06);
+  border-color: rgba(28, 26, 23, 0.08);
+}
+
+/* Checklist */
+
+.prog-body {
+  grid-template-columns: 1.2fr 0.8fr;
+}
+
+.prog-checklist {
+  display: grid;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.prog-checklist-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.5);
+  text-decoration: none;
+  color: var(--ink);
+  transition: background 0.15s;
+}
+
+.prog-checklist-item:hover {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.prog-checklist-item--done {
+  opacity: 0.7;
+}
+
+.prog-checklist-item--blocked {
+  opacity: 0.55;
+}
+
+.prog-checklist-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.prog-checklist-info strong {
+  display: block;
+  font-size: 14px;
+}
+
+.prog-checklist-info .muted {
+  font-size: 12px;
+}
+
+.prog-blocked-label {
+  display: block;
+  font-size: 11px;
+  color: var(--c);
+  margin-top: 2px;
+}
+
+/* Check indicator */
+
+.prog-check {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.prog-check--done {
+  background: rgba(53, 95, 59, 0.15);
+  color: var(--python);
+}
+
+.prog-check--in_progress {
+  background: rgba(216, 166, 87, 0.2);
+  color: #7a5a16;
+  animation: pulse 2s infinite;
+}
+
+.prog-check--ready {
+  background: rgba(28, 26, 23, 0.06);
+  color: var(--muted);
+}
+
+.prog-check--blocked {
+  background: rgba(178, 76, 43, 0.1);
+  color: var(--c);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* Code inline */
+
+.prog-code {
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: rgba(28, 26, 23, 0.06);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 13px;
+}
+
+@media (max-width: 1080px) {
+  .prog-stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .prog-body {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/app/progression/page.tsx
+++ b/apps/web/app/progression/page.tsx
@@ -1,71 +1,309 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 
 import { getDashboardData } from "@/lib/api";
+import type { ModuleItem } from "@/lib/api";
 
-function Pill({ children }: { children: ReactNode }) {
-  return <span className="pill">{children}</span>;
+/* ------------------------------------------------------------------ */
+/*  Static prerequisite map (from documented dependency graph)         */
+/* ------------------------------------------------------------------ */
+
+const PREREQUISITE_MAP: Record<string, string[]> = {
+  "shell-basics": [],
+  "shell-streams": ["shell-basics"],
+  "shell-permissions": ["shell-basics"],
+  "shell-tooling": ["shell-streams", "shell-permissions"],
+  "c-basics": ["shell-basics"],
+  "c-memory": ["c-basics"],
+  "c-build-debug": ["c-basics", "shell-streams"],
+  "c-libft-pushswap-bridge": ["c-memory", "c-build-debug"],
+  "python-basics": ["shell-basics"],
+  "python-oop-scripting": ["python-basics"],
+  "ai-rag-agents": ["python-oop-scripting"],
+};
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function Pill({ children, variant }: { children: ReactNode; variant?: string }) {
+  const cls = variant ? `pill pill--${variant}` : "pill";
+  return <span className={cls}>{children}</span>;
 }
+
+type ModuleState = "done" | "in_progress" | "todo";
+
+function deriveModuleState(
+  moduleId: string,
+  trackId: string,
+  activeTrack: string,
+  activeModule: string,
+  modules: ModuleItem[],
+): ModuleState {
+  if (trackId !== activeTrack) return "todo";
+  if (moduleId === activeModule) return "in_progress";
+  const activeIndex = modules.findIndex((m) => m.id === activeModule);
+  const currentIndex = modules.findIndex((m) => m.id === moduleId);
+  if (activeIndex === -1) return "todo";
+  return currentIndex < activeIndex ? "done" : "todo";
+}
+
+function stateLabel(state: ModuleState): string {
+  switch (state) {
+    case "done":
+      return "Completed";
+    case "in_progress":
+      return "In progress";
+    case "todo":
+      return "Not started";
+  }
+}
+
+const TRACK_COLORS: Record<string, string> = {
+  shell: "var(--shell)",
+  c: "var(--c)",
+  python_ai: "var(--python)",
+};
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
 
 export default async function ProgressionPage() {
   const data = await getDashboardData();
-  const { progression } = data;
-  const plan = progression.learning_plan;
-  const progress = progression.progress;
+  const { curriculum, progression } = data;
+
+  const activeTrack = progression.learning_plan?.active_course ?? "shell";
+  const activeModule = progression.learning_plan?.active_module ?? "";
+
+  /* Build a flat list of all modules with their state and track */
+  type ModuleWithContext = {
+    module: ModuleItem;
+    trackId: string;
+    trackTitle: string;
+    state: ModuleState;
+  };
+
+  const allModules: ModuleWithContext[] = [];
+
+  for (const track of curriculum.tracks) {
+    for (const mod of track.modules) {
+      const state = deriveModuleState(mod.id, track.id, activeTrack, activeModule, track.modules);
+      allModules.push({
+        module: mod,
+        trackId: track.id,
+        trackTitle: track.title,
+        state,
+      });
+    }
+  }
+
+  const doneModules = allModules.filter((m) => m.state === "done");
+  const inProgressModules = allModules.filter((m) => m.state === "in_progress");
+  const todoModules = allModules.filter((m) => m.state === "todo");
+
+  /* Per-track completion stats */
+  type TrackStats = {
+    id: string;
+    title: string;
+    total: number;
+    done: number;
+    percent: number;
+  };
+
+  const trackStats: TrackStats[] = curriculum.tracks.map((track) => {
+    const trackModules = allModules.filter((m) => m.trackId === track.id);
+    const done = trackModules.filter((m) => m.state === "done").length;
+    const total = trackModules.length;
+    return {
+      id: track.id,
+      title: track.title,
+      total,
+      done,
+      percent: total > 0 ? Math.round((done / total) * 100) : 0,
+    };
+  });
+
+  const totalModules = allModules.length;
+  const totalDone = doneModules.length;
+  const globalPercent = totalModules > 0 ? Math.round((totalDone / totalModules) * 100) : 0;
+
+  /* Next recommended action: first todo module whose prerequisites are all done */
+  function prerequisitesMet(moduleId: string): boolean {
+    const prereqs = PREREQUISITE_MAP[moduleId] ?? [];
+    return prereqs.every((pid) => {
+      const entry = allModules.find((m) => m.module.id === pid);
+      return entry?.state === "done";
+    });
+  }
+
+  const nextRecommended = todoModules.find((m) => prerequisitesMet(m.module.id));
 
   return (
     <main className="page-shell">
-      <section className="section">
-        <div className="section-heading">
-          <p className="eyebrow">Progression</p>
-          <h1>Your learning progress</h1>
-        </div>
+      {/* Breadcrumb */}
+      <nav className="breadcrumb">
+        <Link href="/">Dashboard</Link>
+        <span className="breadcrumb-sep">/</span>
+        <span>Progression</span>
+      </nav>
 
-        <div className="hero-grid">
+      {/* Header */}
+      <section className="progression-hero panel">
+        <p className="eyebrow">Personal progression</p>
+        <h1>Your learning journey</h1>
+        <p className="lead">
+          Track your progress across Shell, C and Python + AI.
+          Complete prerequisites to unlock the next modules.
+        </p>
+
+        {/* Global stats */}
+        <div className="prog-stats-grid">
           <div className="metric-card">
-            <span>Active course</span>
-            <strong>{plan?.active_course ?? "n/a"}</strong>
+            <span>Overall</span>
+            <strong>{globalPercent}%</strong>
+            <p className="muted">{totalDone} / {totalModules} modules</p>
           </div>
-          <div className="metric-card">
-            <span>Active module</span>
-            <strong>{plan?.active_module ?? "n/a"}</strong>
-          </div>
-          <div className="metric-card">
-            <span>Pace mode</span>
-            <strong>{plan?.pace_mode ?? "self_paced"}</strong>
-          </div>
-          <div className="metric-card">
-            <span>Next command</span>
-            <strong>{progression.next_command ?? "n/a"}</strong>
-          </div>
+          {trackStats.map((ts) => (
+            <div key={ts.id} className="metric-card">
+              <span>{ts.title}</span>
+              <strong>{ts.percent}%</strong>
+              <div className="progress-bar">
+                <div
+                  className="progress-bar-fill"
+                  style={{
+                    width: `${ts.percent}%`,
+                    backgroundColor: TRACK_COLORS[ts.id] ?? "var(--accent)",
+                  }}
+                />
+              </div>
+              <p className="muted">{ts.done} / {ts.total} modules</p>
+            </div>
+          ))}
         </div>
       </section>
 
-      {progress && (
-        <section className="section">
-          <h2>Current exercise</h2>
-          <p><strong>{progress.current_exercise ?? "None"}</strong></p>
-          <p className="muted">{progress.current_step ?? "No current step"}</p>
-
-          <h3>Completed</h3>
-          <div className="stack-list">
-            {(progress.completed ?? []).map((item) => (
-              <Pill key={item}>{item}</Pill>
-            ))}
+      {/* Next recommended action */}
+      {nextRecommended && (
+        <section className="panel prog-next-action">
+          <p className="eyebrow">Next recommended action</p>
+          <div className="prog-next-content">
+            <div>
+              <h2>{nextRecommended.module.title}</h2>
+              <p className="muted">
+                {nextRecommended.trackTitle} &middot; {nextRecommended.module.phase}
+              </p>
+              <p>{nextRecommended.module.deliverable}</p>
+            </div>
+            <Link
+              href={`/modules/${nextRecommended.module.id}`}
+              className="action-btn"
+            >
+              Start module
+            </Link>
           </div>
+        </section>
+      )}
 
-          <h3>In progress</h3>
-          <div className="stack-list">
-            {(progress.in_progress ?? []).map((item) => (
-              <Pill key={item}>{item}</Pill>
-            ))}
-          </div>
+      {/* Two-column body: in-progress + backlog */}
+      <section className="section split prog-body">
+        {/* In-progress checklist */}
+        <article className="panel">
+          <p className="eyebrow">In progress</p>
+          <h2>Active modules ({inProgressModules.length})</h2>
+          {inProgressModules.length === 0 ? (
+            <p className="muted">No modules in progress.</p>
+          ) : (
+            <div className="prog-checklist">
+              {inProgressModules.map((m) => (
+                <Link
+                  key={m.module.id}
+                  href={`/modules/${m.module.id}`}
+                  className="prog-checklist-item prog-checklist-item--active"
+                >
+                  <span className="prog-check prog-check--in_progress" />
+                  <div className="prog-checklist-info">
+                    <strong>{m.module.title}</strong>
+                    <span className="muted">{m.trackTitle}</span>
+                  </div>
+                  <Pill variant="in_progress">{m.module.phase}</Pill>
+                </Link>
+              ))}
+            </div>
+          )}
 
-          <h3>To do</h3>
-          <div className="stack-list">
-            {(progress.todo ?? []).map((item) => (
-              <Pill key={item}>{item}</Pill>
-            ))}
-          </div>
+          {/* Completed checklist */}
+          {doneModules.length > 0 && (
+            <>
+              <h2 style={{ marginTop: 24 }}>Completed ({doneModules.length})</h2>
+              <div className="prog-checklist">
+                {doneModules.map((m) => (
+                  <Link
+                    key={m.module.id}
+                    href={`/modules/${m.module.id}`}
+                    className="prog-checklist-item prog-checklist-item--done"
+                  >
+                    <span className="prog-check prog-check--done">{"\u2713"}</span>
+                    <div className="prog-checklist-info">
+                      <strong>{m.module.title}</strong>
+                      <span className="muted">{m.trackTitle}</span>
+                    </div>
+                    <Pill variant="done">{stateLabel("done")}</Pill>
+                  </Link>
+                ))}
+              </div>
+            </>
+          )}
+        </article>
+
+        {/* Backlog */}
+        <article className="panel">
+          <p className="eyebrow">Backlog</p>
+          <h2>Upcoming modules ({todoModules.length})</h2>
+          {todoModules.length === 0 ? (
+            <p className="muted">All modules started or completed.</p>
+          ) : (
+            <div className="prog-checklist">
+              {todoModules.map((m) => {
+                const met = prerequisitesMet(m.module.id);
+                return (
+                  <Link
+                    key={m.module.id}
+                    href={`/modules/${m.module.id}`}
+                    className={`prog-checklist-item ${met ? "prog-checklist-item--ready" : "prog-checklist-item--blocked"}`}
+                  >
+                    <span className={`prog-check ${met ? "prog-check--ready" : "prog-check--blocked"}`}>
+                      {met ? "\u25CB" : "\u2022"}
+                    </span>
+                    <div className="prog-checklist-info">
+                      <strong>{m.module.title}</strong>
+                      <span className="muted">{m.trackTitle}</span>
+                      {!met && (
+                        <span className="prog-blocked-label">
+                          Requires: {(PREREQUISITE_MAP[m.module.id] ?? []).join(", ")}
+                        </span>
+                      )}
+                    </div>
+                    <Pill>{m.module.phase}</Pill>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </article>
+      </section>
+
+      {/* Current session detail */}
+      {progression.progress?.current_exercise && (
+        <section className="panel">
+          <p className="eyebrow">Current session</p>
+          <h2>{progression.progress.current_exercise}</h2>
+          <p>{progression.progress.current_step ?? ""}</p>
+          {progression.next_command && (
+            <p style={{ marginTop: 8 }}>
+              Next command: <code className="prog-code">{progression.next_command}</code>
+            </p>
+          )}
         </section>
       )}
     </main>


### PR DESCRIPTION
## Summary

Closes #18.

- Implements `/progression` page with global completion stats (percent per track with progress bars)
- In-progress checklist showing active modules with links to `/modules/[id]`
- Completed modules checklist with done state
- Backlog of todo modules with prerequisite-gated readiness indication (ready vs blocked)
- Next recommended action: highlights the first todo module whose prerequisites are all satisfied
- Current session detail showing active exercise and next command
- Prerequisite dependency graph (static map from documented PREREQUISITES.md) drives unlock logic

## Architecture

- All changes in `apps/web` (presentation layer only, per CLAUDE.md contract)
- Data consumed from existing `getDashboardData()` — no new API endpoints
- Shared CSS classes (pill variants, breadcrumb, action button) added to `globals.css`

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Visual check of `/progression` with fallback data
- [ ] Verify progress bars render correctly per track
- [ ] Verify prerequisite gating shows blocked vs ready modules
- [ ] Responsive layout at mobile breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)