### PR TITLE
feat: create source-policy trust badge component (#19)

### DIFF
--- a/apps/web/app/components/SourcePolicyBadge.tsx
+++ b/apps/web/app/components/SourcePolicyBadge.tsx
@@ -1,0 +1,88 @@
+/**
+ * SourcePolicyBadge — visual trust-tier indicator for source-policy governance.
+ *
+ * Maps each curriculum source tier to a trust level with a color-coded badge
+ * so learners can instantly see how much weight a resource carries.
+ *
+ * Tier mapping (from CLAUDE.md governance contract):
+ *   official_42           → high   (green)  — ground truth
+ *   community_docs        → medium (blue)   — explanation and mapping
+ *   testers_and_tooling   → medium (teal)   — verification
+ *   solution_metadata     → low    (yellow) — path mapping only
+ *   blocked_solution_content → blocked (red) — blocked by default
+ */
+
+type TrustLevel = "high" | "medium" | "low" | "blocked";
+
+type TierConfig = {
+  trust: TrustLevel;
+  label: string;
+  icon: string;
+};
+
+const TIER_CONFIG: Record<string, TierConfig> = {
+  official_42: {
+    trust: "high",
+    label: "Official",
+    icon: "\u2713",
+  },
+  community_docs: {
+    trust: "medium",
+    label: "Community",
+    icon: "\u25CB",
+  },
+  testers_and_tooling: {
+    trust: "medium",
+    label: "Tooling",
+    icon: "\u25CB",
+  },
+  solution_metadata: {
+    trust: "low",
+    label: "Metadata only",
+    icon: "\u25B3",
+  },
+  blocked_solution_content: {
+    trust: "blocked",
+    label: "Blocked",
+    icon: "\u2717",
+  },
+};
+
+const FALLBACK: TierConfig = {
+  trust: "low",
+  label: "Unknown",
+  icon: "?",
+};
+
+export function SourcePolicyBadge({ tier }: { tier: string }) {
+  const config = TIER_CONFIG[tier] ?? FALLBACK;
+
+  return (
+    <span className={`spb spb--${config.trust}`} title={`Trust: ${config.trust} — ${tier}`}>
+      <span className="spb-icon">{config.icon}</span>
+      <span className="spb-label">{config.label}</span>
+    </span>
+  );
+}
+
+export function SourcePolicyLegend() {
+  const levels: { trust: TrustLevel; label: string; description: string }[] = [
+    { trust: "high", label: "Official", description: "Ground truth — reference baseline" },
+    { trust: "medium", label: "Community / Tooling", description: "Explanation, mapping and verification" },
+    { trust: "low", label: "Metadata only", description: "Path mapping — no direct content" },
+    { trust: "blocked", label: "Blocked", description: "Direct solution content — blocked by default" },
+  ];
+
+  return (
+    <div className="spb-legend">
+      {levels.map((l) => (
+        <div key={l.trust} className="spb-legend-item">
+          <span className={`spb spb--${l.trust}`}>
+            <span className="spb-label">{l.label}</span>
+          </span>
+          <span className="muted">{l.description}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -244,3 +244,68 @@ p {
     grid-template-columns: 1fr;
   }
 }
+
+/* ------------------------------------------------------------------ */
+/*  Source policy badge                                                 */
+/* ------------------------------------------------------------------ */
+
+.spb {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+
+.spb-icon {
+  font-size: 11px;
+  line-height: 1;
+}
+
+.spb--high {
+  background: rgba(53, 95, 59, 0.12);
+  border-color: rgba(53, 95, 59, 0.22);
+  color: var(--python);
+}
+
+.spb--medium {
+  background: rgba(28, 93, 99, 0.1);
+  border-color: rgba(28, 93, 99, 0.2);
+  color: var(--shell);
+}
+
+.spb--low {
+  background: rgba(216, 166, 87, 0.15);
+  border-color: rgba(216, 166, 87, 0.3);
+  color: #7a5a16;
+}
+
+.spb--blocked {
+  background: rgba(178, 76, 43, 0.1);
+  border-color: rgba(178, 76, 43, 0.2);
+  color: var(--c);
+}
+
+/* Legend */
+
+.spb-legend {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.spb-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.spb-legend-item .muted {
+  font-size: 12px;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { getDashboardData } from "@/lib/api";
+import { SourcePolicyBadge } from "@/app/components/SourcePolicyBadge";
 
 function Pill({ children }: { children: ReactNode }) {
   return <span className="pill">{children}</span>;
@@ -112,7 +113,7 @@ export default async function HomePage() {
             {curriculum.source_policy.tiers.map((tier) => (
               <div key={tier.id} className="policy-item">
                 <strong>{tier.label}</strong>
-                <span>{tier.allowed_usage}</span>
+                <SourcePolicyBadge tier={tier.id} />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

Closes #19.

- Creates `SourcePolicyBadge` component in `apps/web/app/components/` that maps curriculum source tiers to visual trust levels:
  - **High** (green): `official_42` — ground truth baseline
  - **Medium** (teal): `community_docs`, `testers_and_tooling` — explanation and verification
  - **Low** (yellow): `solution_metadata` — path mapping only
  - **Blocked** (red): `blocked_solution_content` — blocked by default
- Also exports `SourcePolicyLegend` for documentation/help views
- Integrates badges into the dashboard source policy section, replacing plain text usage labels with color-coded trust indicators
- Follows the source-governance contract from CLAUDE.md

## Architecture

- Component in `apps/web/app/components/` (presentation layer only)
- Pure server component, no client state
- Styling via CSS classes in `globals.css` using existing CSS variable color system

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Visual check of dashboard source policy section with badges
- [ ] Verify all 5 tiers render with correct colors and labels
- [ ] Badge renders gracefully for unknown tier ids (fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)