### PR TITLE
docs: define branch and PR conventions for multi-agent workflow (#47)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,83 @@ Pour tout travail sur retrieval, prompts, assistance ou documentation:
 
 Ne pas affaiblir cette politique sans raison explicite.
 
+### Agents actifs
+
+Cinq agents CLI travaillent en parallele sur ce depot:
+
+| Agent | Area principale | Exemples |
+|-------|-----------------|----------|
+| `claude` | curriculum, product, architecture | schemas curriculum, milestones, conventions |
+| `codex` | backend | API endpoints, schemas Pydantic, tests |
+| `copilot` | frontend | pages Next.js, composants, navigation |
+| `cursor` | ai | AI gateway, mentor, retrieval, garde-fous |
+| `gemini` | devops | CI, Docker, linting, healthchecks |
+
+Chaque agent travaille sur une issue a la fois, assignee via `gh issue list --assignee`.
+
+### Convention de branches et PR
+
+#### Nommage des branches
+
+```
+feat/<agent>/<issue>-<description-courte>
+fix/<agent>/<issue>-<description-courte>
+docs/<agent>/<issue>-<description-courte>
+```
+
+Exemples reels:
+
+```
+feat/claude/13-source-confidence-levels
+feat/codex/24-module-progression-crud
+feat/copilot/17-module-detail-page
+feat/cursor/30-retrieval-source-provider
+feat/gemini/42-docker-compose-dev
+```
+
+#### Workflow complet
+
+1. **Prendre une issue** — verifier qu'elle est assignee et pas deja en cours par un autre agent.
+2. **Creer la branche** — toujours depuis `develop` a jour:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b feat/<agent>/<issue>-<slug>
+   ```
+3. **Commiter** — style conventional commits:
+   - `feat:` nouvelle fonctionnalite
+   - `fix:` correction de bug
+   - `docs:` documentation uniquement
+   - `refactor:` restructuration sans changement de comportement
+   - `test:` ajout ou correction de tests
+   - `chore:` maintenance, config, outillage
+   - Inclure `(#<issue>)` dans le message pour la tracabilite.
+4. **Tester avant push** — lancer les tests pertinents pour l'area modifiee.
+5. **Pousser et creer la PR:**
+   ```bash
+   git push -u origin feat/<agent>/<issue>-<slug>
+   gh pr create --base develop --title '<type>: <description> (#<issue>)' --body 'Closes #<issue>. ...'
+   ```
+6. **Review** — un autre agent ou le mainteneur review. Ne pas merger soi-meme sans review.
+
+#### Cible PR
+
+Toutes les PR ciblent `develop`. Jamais `main` directement.
+
+`main` est mis a jour uniquement par merge de `develop` apres validation.
+
+#### Resolution de conflits entre agents
+
+Quand deux agents modifient le meme fichier:
+
+1. **Prevention** — les areas sont reparties par agent. Les fichiers partages (`42_lausanne_curriculum.json`, `AGENTS.md`) sont reserves a `claude` par defaut.
+2. **Detection** — avant de push, faire `git fetch && git rebase origin/develop`. Si conflit, le resoudre localement.
+3. **Priorite** — si deux PR touchent le meme fichier:
+   - la PR la plus avancee (deja approuvee) passe en premier
+   - l'autre agent rebase apres merge
+   - en cas d'egalite, l'agent dont l'area est proprietaire du fichier a priorite
+4. **Fichiers partages** — les fichiers listes dans "Zones sensibles" ne doivent etre modifies que par l'agent responsable de l'area, sauf coordination explicite.
+5. **Escalade** — si un conflit ne peut pas etre resolu mecaniquement, le signaler dans la PR et attendre une decision du mainteneur.
+
 ### Zones sensibles du repo
 
 - `packages/curriculum/data/42_lausanne_curriculum.json`
@@ -174,6 +251,83 @@ For work involving retrieval, prompts, assistance flows or documentation:
 - direct solution content is blocked by default in foundation phases
 
 Do not weaken this policy casually.
+
+### Active agents
+
+Five CLI agents work in parallel on this repository:
+
+| Agent | Primary area | Examples |
+|-------|-------------|----------|
+| `claude` | curriculum, product, architecture | curriculum schemas, milestones, conventions |
+| `codex` | backend | API endpoints, Pydantic schemas, tests |
+| `copilot` | frontend | Next.js pages, components, navigation |
+| `cursor` | ai | AI gateway, mentor, retrieval, guardrails |
+| `gemini` | devops | CI, Docker, linting, healthchecks |
+
+Each agent works on one issue at a time, assigned via `gh issue list --assignee`.
+
+### Branch and PR convention
+
+#### Branch naming
+
+```
+feat/<agent>/<issue>-<short-description>
+fix/<agent>/<issue>-<short-description>
+docs/<agent>/<issue>-<short-description>
+```
+
+Real examples:
+
+```
+feat/claude/13-source-confidence-levels
+feat/codex/24-module-progression-crud
+feat/copilot/17-module-detail-page
+feat/cursor/30-retrieval-source-provider
+feat/gemini/42-docker-compose-dev
+```
+
+#### Full workflow
+
+1. **Pick an issue** — verify it is assigned and not already in progress by another agent.
+2. **Create the branch** — always from up-to-date `develop`:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b feat/<agent>/<issue>-<slug>
+   ```
+3. **Commit** — use conventional commits:
+   - `feat:` new feature
+   - `fix:` bug fix
+   - `docs:` documentation only
+   - `refactor:` restructuring without behavior change
+   - `test:` adding or fixing tests
+   - `chore:` maintenance, config, tooling
+   - Include `(#<issue>)` in the message for traceability.
+4. **Test before push** — run the relevant tests for the area you modified.
+5. **Push and create the PR:**
+   ```bash
+   git push -u origin feat/<agent>/<issue>-<slug>
+   gh pr create --base develop --title '<type>: <description> (#<issue>)' --body 'Closes #<issue>. ...'
+   ```
+6. **Review** — another agent or the maintainer reviews. Do not self-merge without review.
+
+#### PR target
+
+All PRs target `develop`. Never `main` directly.
+
+`main` is updated only by merging `develop` after validation.
+
+#### Conflict resolution between agents
+
+When two agents modify the same file:
+
+1. **Prevention** — areas are split by agent. Shared files (`42_lausanne_curriculum.json`, `AGENTS.md`) default to `claude`.
+2. **Detection** — before pushing, run `git fetch && git rebase origin/develop`. If conflicts arise, resolve them locally.
+3. **Priority** — if two PRs touch the same file:
+   - the more advanced PR (already approved) merges first
+   - the other agent rebases after merge
+   - if tied, the agent whose area owns the file has priority
+4. **Shared files** — files listed under "Current repo hotspots" should only be modified by the area-owning agent unless explicitly coordinated.
+5. **Escalation** — if a conflict cannot be resolved mechanically, flag it in the PR and wait for a maintainer decision.
 
 ### Current repo hotspots
 


### PR DESCRIPTION
Closes #47.

## Summary

- Documents the 5 active agents and their area ownership in a table
- Defines branch naming: `feat/<agent>/<issue>-<slug>`, `fix/...`, `docs/...`
- Documents the full workflow: branch from develop, conventional commits with `(#issue)`, test, push, PR to develop, review
- PR target rule: always `develop`, never `main` directly
- Adds conflict resolution protocol between agents:
  - Prevention via area ownership
  - Detection via rebase before push
  - Priority rules when two PRs touch the same file
  - Escalation path when mechanical resolution fails
- Both FR and EN sections updated

## Test plan

- [x] AGENTS.md renders correctly in GitHub markdown
- [x] Convention matches the branch patterns already in use across all 5 agents
- [x] Conflict resolution rules are consistent with area ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)