### PR TITLE
feat: add CI smoke test with docker-compose health verification (#44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,72 @@ jobs:
       - name: Build web app
         working-directory: apps/web
         run: npm run build
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and start services
+        working-directory: infra
+        run: docker compose -f docker-compose.dev.example.yml up -d --build
+
+      - name: Wait for API health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health; then
+              echo ""
+              echo "API is healthy"
+              exit 0
+            fi
+            echo "Waiting for API... ($i/30)"
+            sleep 5
+          done
+          echo "API failed to become healthy"
+          docker compose -f infra/docker-compose.dev.example.yml logs api
+          exit 1
+
+      - name: Wait for AI Gateway health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8100/health; then
+              echo ""
+              echo "AI Gateway is healthy"
+              exit 0
+            fi
+            echo "Waiting for AI Gateway... ($i/30)"
+            sleep 5
+          done
+          echo "AI Gateway failed to become healthy"
+          docker compose -f infra/docker-compose.dev.example.yml logs ai_gateway
+          exit 1
+
+      - name: Wait for Web
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000; then
+              echo ""
+              echo "Web is healthy"
+              exit 0
+            fi
+            echo "Waiting for Web... ($i/30)"
+            sleep 5
+          done
+          echo "Web failed to become healthy"
+          docker compose -f infra/docker-compose.dev.example.yml logs web
+          exit 1
+
+      - name: Verify health responses
+        run: |
+          set -e
+          echo "=== API ==="
+          curl -sf http://localhost:8000/health | python3 -m json.tool
+          echo "=== AI Gateway ==="
+          curl -sf http://localhost:8100/health | python3 -m json.tool
+          echo "=== Web ==="
+          curl -sf -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3000
+
+      - name: Tear down
+        if: always()
+        working-directory: infra
+        run: docker compose -f docker-compose.dev.example.yml down -v


### PR DESCRIPTION
## Summary

Closes #44.

Adds a `smoke-test` job to `.github/workflows/ci.yml` that validates the full Docker stack works end-to-end:

- Builds all images and starts the stack via `docker compose -f infra/docker-compose.dev.example.yml up -d --build`
- Polls each service health endpoint with retries (30 attempts x 5s = 150s max per service):
  - API: `curl http://localhost:8000/health`
  - AI Gateway: `curl http://localhost:8100/health`
  - Web: `curl http://localhost:3000`
- Dumps container logs on failure for easy debugging
- Verifies JSON health responses in a final assertion step
- Tears down with `docker compose down -v` (runs `if: always()`)

Runs on PRs to `develop` and `main`, alongside existing unit test and build jobs.

## Test plan

- [ ] CI workflow YAML validates (`python3 -c "import yaml; yaml.safe_load(open(...))"` — done locally)
- [ ] Smoke test job appears in GitHub Actions on this PR
- [ ] All three health endpoints respond successfully
- [ ] Teardown step runs even if a health check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)