### PR TITLE
feat: implement Reviewer role with peer-style code critique (#32)

### DIFF
--- a/services/ai_gateway/app/main.py
+++ b/services/ai_gateway/app/main.py
@@ -8,12 +8,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from .llm_client import get_mentor_response
 from .repository import load_curriculum, load_progression
 from .retrieval import StaticSourceProvider
+from .reviewer import build_review
 from .schemas import (
     LibrarianRequest,
     LibrarianResponse,
     LibrarianResult,
     MentorRequest,
     MentorResponse,
+    ReviewerRequest,
+    ReviewerResponse,
     SourceUsed,
 )
 
@@ -264,4 +267,38 @@ def librarian_search(request: LibrarianRequest) -> LibrarianResponse:
         ],
         tiers_used=sorted({r.tier for r in raw_results}),
         blocked_tiers=blocked,
+    )
+
+
+@app.post("/api/v1/reviewer/review", response_model=ReviewerResponse)
+def reviewer_review(request: ReviewerRequest) -> ReviewerResponse:
+    curriculum = load_curriculum()
+    track = next(
+        (t for t in curriculum["tracks"] if t["id"] == request.track_id), None
+    )
+    if track is None:
+        raise HTTPException(status_code=404, detail="Track not found")
+
+    module = None
+    if request.module_id:
+        module = next(
+            (m for m in track.get("modules", []) if m["id"] == request.module_id),
+            None,
+        )
+
+    review = build_review(
+        code=request.code,
+        language=request.language,
+        track=track,
+        module=module,
+        phase=request.phase,
+    )
+
+    return ReviewerResponse(
+        status="ok",
+        observation=review["observation"],
+        questions=review["questions"],
+        hint=review["hint"],
+        next_action=review["next_action"],
+        corrected_code=None,
     )

--- a/services/ai_gateway/app/reviewer.py
+++ b/services/ai_gateway/app/reviewer.py
@@ -1,0 +1,167 @@
+"""Reviewer role — peer-style code critique.
+
+The Reviewer follows the pedagogical contract: it produces an observation,
+questions, a hint, and a next action. It NEVER corrects code directly.
+This mirrors the 42 peer-review philosophy: challenge, question, guide.
+
+The system prompt below defines the reviewer persona. In the MVP phase
+the review logic is rule-based. When an LLM backend is added later,
+the system prompt will be sent as-is.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --- System prompt for future LLM integration ---
+REVIEWER_SYSTEM_PROMPT = """\
+You are a peer reviewer in a 42-style learning environment.
+
+RULES — you MUST follow all of these:
+1. NEVER provide corrected code, fixed code, or solution code.
+2. NEVER rewrite the student's code.
+3. Ask questions that lead the student to find the issue themselves.
+4. Point out what you observe without telling them what to change.
+5. Give one small hint — not the answer.
+6. Suggest one concrete next action the student can take to verify or improve.
+
+Your output must contain:
+- observation: what you notice about the code (factual, no judgment)
+- questions: 2-3 questions that guide the student toward the issue
+- hint: one small directional hint
+- next_action: one concrete step the student should try next
+
+You must REFUSE to provide corrected code even if asked directly.
+"""
+
+
+def build_review(
+    code: str,
+    language: str,
+    track: dict[str, Any],
+    module: dict[str, Any] | None,
+    phase: str,
+) -> dict[str, Any]:
+    """Build a peer-style review for the given code snippet.
+
+    This is the MVP rule-based implementation. It inspects the code
+    for common patterns per language and generates pedagogical feedback
+    without ever providing corrections.
+    """
+    focus = module["title"] if module else track["title"]
+    code_lines = code.strip().splitlines()
+    line_count = len(code_lines)
+
+    observation = _build_observation(code, language, focus, line_count)
+    questions = _build_questions(code, language, module)
+    hint = _build_hint(code, language)
+    next_action = _build_next_action(language, phase)
+
+    return {
+        "observation": observation,
+        "questions": questions,
+        "hint": hint,
+        "next_action": next_action,
+    }
+
+
+def _build_observation(code: str, language: str, focus: str, line_count: int) -> str:
+    """Factual observation about the submitted code."""
+    parts = [f"Code submitted for review in context of {focus} ({line_count} lines, language: {language})."]
+
+    if language == "c":
+        if "malloc" in code and "free" not in code:
+            parts.append("Memory allocation detected without a visible free.")
+        if "#include" not in code and line_count > 3:
+            parts.append("No includes visible in this snippet.")
+    elif language == "shell":
+        if "rm " in code and "-f" in code:
+            parts.append("Destructive command with force flag detected.")
+        if "$(" in code or "`" in code:
+            parts.append("Command substitution detected.")
+    elif language == "python":
+        if "except:" in code or "except Exception:" in code:
+            parts.append("Broad exception handling detected.")
+        if "import *" in code:
+            parts.append("Wildcard import detected.")
+
+    return " ".join(parts)
+
+
+def _build_questions(code: str, language: str, module: dict | None) -> list[str]:
+    """Generate 2-3 peer-style questions — never corrections."""
+    questions: list[str] = []
+
+    # Universal questions
+    questions.append("What is the expected output of this code for a simple test case?")
+
+    if language == "c":
+        if "malloc" in code:
+            questions.append("What happens to the allocated memory when this function returns?")
+        if "while" in code or "for" in code:
+            questions.append("How do you know the loop will terminate?")
+        if "*" in code:
+            questions.append("Can you trace the pointer value at each step?")
+    elif language == "shell":
+        if "|" in code:
+            questions.append("What does each stage of this pipeline produce?")
+        if ">" in code or ">>" in code:
+            questions.append("What happens if the target file already exists?")
+        if "$" in code:
+            questions.append("What value does each variable hold at this point?")
+    elif language == "python":
+        if "def " in code:
+            questions.append("What does this function return for edge-case inputs?")
+        if "for " in code or "while " in code:
+            questions.append("What happens when the input is empty?")
+        if "open(" in code:
+            questions.append("What happens if the file does not exist?")
+
+    if module and module.get("skills"):
+        skill_sample = module["skills"][0]
+        questions.append(f"How does this code relate to the skill '{skill_sample}' you are practicing?")
+
+    # Keep 2-3 questions
+    return questions[:3]
+
+
+def _build_hint(code: str, language: str) -> str:
+    """One small directional hint — never the answer."""
+    if language == "c":
+        if "malloc" in code and "free" not in code:
+            return "Think about the lifecycle of every allocated block."
+        if "printf" in code and "\\n" not in code and '"' in code:
+            return "Check what happens to your output without a newline at the end."
+        return "Try running with -Wall -Wextra -Werror and read each warning carefully."
+    elif language == "shell":
+        if "rm " in code:
+            return "Before running destructive commands, try echoing the arguments first."
+        if "|" in code:
+            return "Test each segment of the pipeline in isolation before chaining."
+        return "Run the command, then check the exit code with echo $?."
+    else:
+        if "except:" in code:
+            return "Consider what specific exception types you actually expect here."
+        if "import *" in code:
+            return "Try importing only what you need and see if anything breaks."
+        return "Add a print statement at the point where you are least sure of the value."
+
+
+def _build_next_action(language: str, phase: str) -> str:
+    """One concrete step the student should try next."""
+    if phase == "foundation":
+        if language == "c":
+            return "Compile with warnings enabled, pick the first warning, and explain it in your own words."
+        elif language == "shell":
+            return "Run the command on a test file, then describe what changed using ls -la."
+        else:
+            return "Run the script with a minimal input and print every intermediate value."
+    elif phase == "practice":
+        if language == "c":
+            return "Run your code through valgrind and investigate the first error it reports."
+        elif language == "shell":
+            return "Write a second version using a different approach and compare the outputs."
+        else:
+            return "Write a simple test case that covers the most likely failure and run it."
+    else:
+        return "Explain your approach to a peer in two sentences, then check if the code matches that explanation."

--- a/services/ai_gateway/app/schemas.py
+++ b/services/ai_gateway/app/schemas.py
@@ -54,3 +54,23 @@ class LibrarianResponse(BaseModel):
     results: list[LibrarianResult]
     tiers_used: list[str]
     blocked_tiers: list[str]
+
+
+class ReviewerRequest(BaseModel):
+    code: str = Field(min_length=1, max_length=5000)
+    track_id: str = Field(default="shell")
+    module_id: str | None = None
+    phase: Literal["foundation", "practice", "core", "advanced"] = "foundation"
+    language: Literal["shell", "c", "python"] = "shell"
+
+
+class ReviewerResponse(BaseModel):
+    status: str
+    observation: str
+    questions: list[str]
+    hint: str
+    next_action: str
+    corrected_code: None = Field(
+        default=None,
+        description="Always null — the Reviewer never provides corrected code",
+    )

--- a/services/ai_gateway/tests/test_reviewer.py
+++ b/services/ai_gateway/tests/test_reviewer.py
@@ -1,0 +1,235 @@
+"""Tests for the Reviewer endpoint — peer-style code critique.
+
+Key invariant: the Reviewer NEVER provides corrected code.
+"""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.reviewer import REVIEWER_SYSTEM_PROMPT, build_review
+
+client = TestClient(app)
+
+ENDPOINT = "/api/v1/reviewer/review"
+
+# --- Sample code snippets for testing ---
+
+C_CODE_MALLOC = """\
+#include <stdlib.h>
+
+char *ft_strdup(char *s)
+{
+    char *dup;
+    int i;
+
+    dup = malloc(strlen(s) + 1);
+    i = 0;
+    while (s[i])
+    {
+        dup[i] = s[i];
+        i++;
+    }
+    dup[i] = '\\0';
+    return (dup);
+}
+"""
+
+SHELL_CODE_PIPE = """\
+cat /etc/passwd | grep root | cut -d: -f1 > result.txt
+"""
+
+PYTHON_CODE_BROAD_EXCEPT = """\
+def read_config(path):
+    try:
+        with open(path) as f:
+            return f.read()
+    except:
+        return None
+"""
+
+
+# === Endpoint tests ===
+
+
+def test_reviewer_basic_c_review() -> None:
+    response = client.post(
+        ENDPOINT,
+        json={"code": C_CODE_MALLOC, "track_id": "c", "language": "c"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["observation"]
+    assert len(data["questions"]) >= 2
+    assert data["hint"]
+    assert data["next_action"]
+
+
+def test_reviewer_basic_shell_review() -> None:
+    response = client.post(
+        ENDPOINT,
+        json={"code": SHELL_CODE_PIPE, "track_id": "shell", "language": "shell"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert len(data["questions"]) >= 2
+
+
+def test_reviewer_basic_python_review() -> None:
+    response = client.post(
+        ENDPOINT,
+        json={
+            "code": PYTHON_CODE_BROAD_EXCEPT,
+            "track_id": "python_ai",
+            "language": "python",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+def test_reviewer_never_returns_corrected_code() -> None:
+    """The corrected_code field must ALWAYS be null."""
+    for payload in [
+        {"code": C_CODE_MALLOC, "track_id": "c", "language": "c"},
+        {"code": SHELL_CODE_PIPE, "track_id": "shell", "language": "shell"},
+        {"code": PYTHON_CODE_BROAD_EXCEPT, "track_id": "python_ai", "language": "python"},
+    ]:
+        response = client.post(ENDPOINT, json=payload)
+        data = response.json()
+        assert data["corrected_code"] is None, (
+            f"corrected_code must be null, got: {data['corrected_code']}"
+        )
+
+
+def test_reviewer_observation_is_factual_not_corrective() -> None:
+    """Observation should describe what is seen, not fix anything."""
+    response = client.post(
+        ENDPOINT,
+        json={"code": C_CODE_MALLOC, "track_id": "c", "language": "c"},
+    )
+    data = response.json()
+    obs = data["observation"].lower()
+    # Should not contain corrective language
+    assert "should be" not in obs
+    assert "fix" not in obs
+    assert "change to" not in obs
+    assert "replace" not in obs
+
+
+def test_reviewer_questions_are_questions() -> None:
+    """Every question must end with a question mark."""
+    response = client.post(
+        ENDPOINT,
+        json={"code": C_CODE_MALLOC, "track_id": "c", "language": "c"},
+    )
+    data = response.json()
+    for q in data["questions"]:
+        assert q.endswith("?"), f"Question must end with '?': {q}"
+
+
+def test_reviewer_with_module_context() -> None:
+    response = client.post(
+        ENDPOINT,
+        json={
+            "code": C_CODE_MALLOC,
+            "track_id": "c",
+            "module_id": "c-memory",
+            "language": "c",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["questions"]) >= 2
+
+
+def test_reviewer_detects_malloc_without_free() -> None:
+    """C code with malloc but no free should trigger a memory observation."""
+    response = client.post(
+        ENDPOINT,
+        json={"code": C_CODE_MALLOC, "track_id": "c", "language": "c"},
+    )
+    data = response.json()
+    obs_lower = data["observation"].lower()
+    assert "memory" in obs_lower or "alloc" in obs_lower
+
+
+def test_reviewer_detects_broad_except() -> None:
+    """Python code with bare except should trigger a hint about it."""
+    response = client.post(
+        ENDPOINT,
+        json={
+            "code": PYTHON_CODE_BROAD_EXCEPT,
+            "track_id": "python_ai",
+            "language": "python",
+        },
+    )
+    data = response.json()
+    assert "except" in data["hint"].lower() or "exception" in data["hint"].lower()
+
+
+def test_reviewer_shell_pipe_questions() -> None:
+    """Shell code with pipes should get pipeline-related questions."""
+    response = client.post(
+        ENDPOINT,
+        json={"code": SHELL_CODE_PIPE, "track_id": "shell", "language": "shell"},
+    )
+    data = response.json()
+    all_questions = " ".join(data["questions"]).lower()
+    assert "pipeline" in all_questions or "stage" in all_questions or "file" in all_questions
+
+
+def test_reviewer_invalid_track_returns_404() -> None:
+    response = client.post(
+        ENDPOINT,
+        json={"code": "echo hello", "track_id": "nonexistent", "language": "shell"},
+    )
+    assert response.status_code == 404
+
+
+def test_reviewer_empty_code_rejected() -> None:
+    response = client.post(
+        ENDPOINT,
+        json={"code": "", "track_id": "shell", "language": "shell"},
+    )
+    assert response.status_code == 422
+
+
+def test_reviewer_phase_affects_next_action() -> None:
+    """Different phases should produce different next_action guidance."""
+    resp_foundation = client.post(
+        ENDPOINT,
+        json={"code": C_CODE_MALLOC, "track_id": "c", "language": "c", "phase": "foundation"},
+    )
+    resp_practice = client.post(
+        ENDPOINT,
+        json={"code": C_CODE_MALLOC, "track_id": "c", "language": "c", "phase": "practice"},
+    )
+    assert resp_foundation.json()["next_action"] != resp_practice.json()["next_action"]
+
+
+# === Unit tests for review logic ===
+
+
+def test_build_review_returns_all_fields() -> None:
+    track = {"id": "c", "title": "C / Core 42", "modules": []}
+    result = build_review(
+        code="int main() { return 0; }",
+        language="c",
+        track=track,
+        module=None,
+        phase="foundation",
+    )
+    assert "observation" in result
+    assert "questions" in result
+    assert "hint" in result
+    assert "next_action" in result
+
+
+def test_system_prompt_forbids_corrections() -> None:
+    """The system prompt must explicitly forbid corrected code."""
+    prompt_lower = REVIEWER_SYSTEM_PROMPT.lower()
+    assert "never provide corrected code" in prompt_lower
+    assert "never rewrite" in prompt_lower


### PR DESCRIPTION
## Summary

Closes #32.

Adds `POST /api/v1/reviewer/review` endpoint to `ai_gateway` that provides peer-style code critique following the 42 peer-review philosophy.

### Key design decisions

- **Never corrects code** — `corrected_code` field is always `null`, enforced by schema and tested
- **Pedagogical contract** — every review contains: observation (factual), questions (guiding), hint (directional), next_action (concrete)
- **Rule-based MVP** — pattern detection per language (C: malloc/free, shell: pipes/rm, Python: except/imports), ready for LLM backend later
- **System prompt included** — `REVIEWER_SYSTEM_PROMPT` explicitly forbids corrections, ready for direct use with an LLM
- **Phase-aware** — foundation/practice/core/advanced phases produce different next_action guidance

### Files changed

- `app/reviewer.py` — review logic, system prompt, per-language pattern detection
- `app/schemas.py` — `ReviewerRequest`, `ReviewerResponse` models
- `app/main.py` — `POST /api/v1/reviewer/review` endpoint
- `tests/test_reviewer.py` — 15 tests

### Source-governance compliance

The Reviewer does not access or surface source content. It only analyzes submitted code snippets and produces questions. The AI layer remains an assistance layer, not a source of truth.

## Test plan

- [x] `pytest tests -q` — 17 passed (2 existing + 15 new)
- [x] `corrected_code` is always null across all languages (tested)
- [x] Observations contain no corrective language (tested)
- [x] All questions end with `?` (tested)
- [x] System prompt forbids corrections (tested)
- [x] Phase differentiation verified (tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)