### PR TITLE
feat: add navigation header and sidebar between views (#20)

### DIFF
--- a/apps/web/app/components/NavHeader.tsx
+++ b/apps/web/app/components/NavHeader.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+import { getDashboardData } from "@/lib/api";
+
+const NAV_LINKS = [
+  { href: "/", label: "Dashboard" },
+  { href: "/progression", label: "Progression" },
+] as const;
+
+export async function NavHeader() {
+  const data = await getDashboardData();
+  const activeTrack = data.progression.learning_plan?.active_course ?? "shell";
+
+  return (
+    <header className="nav-header">
+      <div className="nav-brand">
+        <Link href="/" className="nav-logo">42-training</Link>
+        <span className="nav-track-indicator">{activeTrack}</span>
+      </div>
+      <nav className="nav-links">
+        {NAV_LINKS.map((link) => (
+          <Link key={link.href} href={link.href} className="nav-link">
+            {link.label}
+          </Link>
+        ))}
+        {data.curriculum.tracks.map((track) => (
+          <Link
+            key={track.id}
+            href={`/tracks/${track.id}`}
+            className={`nav-link ${track.id === activeTrack ? "nav-link--active" : ""}`}
+          >
+            {track.title}
+          </Link>
+        ))}
+      </nav>
+    </header>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -30,7 +30,11 @@ body {
 }
 
 body {
-  padding: 32px;
+  padding: 0;
+}
+
+.app-content {
+  padding: 24px 32px 32px;
 }
 
 h1,
@@ -228,10 +232,6 @@ p {
 }
 
 @media (max-width: 720px) {
-  body {
-    padding: 18px;
-  }
-
   .hero-copy,
   .status-panel,
   .track-card,
@@ -244,6 +244,96 @@ p {
   .prog-stats-grid {
     grid-template-columns: 1fr;
   }
+
+  .app-content {
+    padding: 18px;
+  }
+
+  .nav-header {
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 18px;
+  }
+
+  .nav-links {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Navigation header                                                  */
+/* ------------------------------------------------------------------ */
+
+.nav-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 32px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.nav-logo {
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.nav-track-indicator {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(28, 93, 99, 0.1);
+  border: 1px solid rgba(28, 93, 99, 0.18);
+  color: var(--shell);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.nav-link {
+  padding: 6px 14px;
+  border-radius: 10px;
+  font-size: 13px;
+  color: var(--muted);
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+
+.nav-link:hover {
+  background: rgba(28, 26, 23, 0.05);
+  color: var(--ink);
+}
+
+.nav-link--active {
+  background: rgba(216, 166, 87, 0.12);
+  color: var(--ink);
+  font-weight: 600;
 }
 
 /* ------------------------------------------------------------------ */

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import "./globals.css";
 
+import { NavHeader } from "@/app/components/NavHeader";
+
 export const metadata = {
   title: "42 Training",
   description: "Triple-track self-paced preparation for 42 Lausanne",
@@ -9,7 +11,10 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <NavHeader />
+        <div className="app-content">{children}</div>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary

Closes #20.

- Creates `NavHeader` server component in `apps/web/app/components/` with:
  - App name linking to dashboard
  - Active track indicator (pill showing current track from progression data)
  - Navigation links: Dashboard, Progression, and each curriculum track
  - Active track link highlighted with accent background
- Integrates into `layout.tsx` so all pages share the same navigation
- Sticky header with glass-morphism backdrop matching existing design
- Responsive: horizontal scroll nav on mobile, stacked layout on small screens
- Moves body padding to `.app-content` wrapper to accommodate the sticky header

## Architecture

- All changes in `apps/web` (presentation layer only)
- `NavHeader` consumes `getDashboardData()` for track list and active track — no new API endpoints
- Server component — no client-side state or JavaScript

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Visual check: header visible on all pages (dashboard, tracks/[id], modules/[id], progression)
- [ ] Navigation links work correctly
- [ ] Active track highlighted
- [ ] Responsive layout at mobile breakpoint
- [ ] Sticky behavior on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)