### PR TITLE
fix(ci): update smoke-test docker-compose path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build and start services
-        working-directory: infra
-        run: docker compose -f docker-compose.dev.example.yml up -d --build
+        run: docker compose -f docker-compose.yml up -d --build
 
       - name: Wait for API health
         run: |
@@ -95,7 +94,7 @@ jobs:
             sleep 5
           done
           echo "API failed to become healthy"
-          docker compose -f infra/docker-compose.dev.example.yml logs api
+          docker compose -f docker-compose.yml logs api
           exit 1
 
       - name: Wait for AI Gateway health
@@ -110,7 +109,7 @@ jobs:
             sleep 5
           done
           echo "AI Gateway failed to become healthy"
-          docker compose -f infra/docker-compose.dev.example.yml logs ai_gateway
+          docker compose -f docker-compose.yml logs ai_gateway
           exit 1
 
       - name: Wait for Web
@@ -125,7 +124,7 @@ jobs:
             sleep 5
           done
           echo "Web failed to become healthy"
-          docker compose -f infra/docker-compose.dev.example.yml logs web
+          docker compose -f docker-compose.yml logs web
           exit 1
 
       - name: Verify health responses
@@ -140,5 +139,4 @@ jobs:
 
       - name: Tear down
         if: always()
-        working-directory: infra
-        run: docker compose -f docker-compose.dev.example.yml down -v
+        run: docker compose -f docker-compose.yml down -v


### PR DESCRIPTION
## Summary
- Fix smoke-test CI job that referenced the old `infra/docker-compose.dev.example.yml` path
- Update to `docker-compose.yml` at repo root (moved by PR #68)
- This was causing ALL CI runs on develop to fail

## Impact
Fixes CI failures on develop and all open PR branches.