### PR TITLE
feat: add checkpoint submission endpoint (#37)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -8,6 +8,9 @@ from fastapi.responses import RedirectResponse
 
 from .repository import load_curriculum, load_progression, write_progression
 from .schemas import (
+    CheckpointListResponse,
+    CheckpointRecord,
+    CheckpointSubmission,
     DashboardResponse,
     HealthResponse,
     MetaResponse,
@@ -324,3 +327,82 @@ def legacy_tracks() -> RedirectResponse:
 @app.get("/api/v1/tracks/{track_id}")
 def legacy_track_detail(track_id: str) -> RedirectResponse:
     return RedirectResponse(url=f"/api/v1/curriculum/tracks/{track_id}", status_code=301)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint submission (Issue #37)
+# ---------------------------------------------------------------------------
+
+
+def _find_module_in_curriculum(module_id: str) -> dict[str, object] | None:
+    """Return the module dict from curriculum, or None."""
+    curriculum = load_curriculum()
+    for track in curriculum.get("tracks", []):
+        for module in track.get("modules", []):
+            if module["id"] == module_id:
+                return module
+    return None
+
+
+@app.post("/api/v1/checkpoints/submit")
+def submit_checkpoint(payload: CheckpointSubmission) -> CheckpointRecord:
+    module = _find_module_in_curriculum(payload.module_id)
+    if module is None:
+        raise HTTPException(status_code=404, detail=f"Module '{payload.module_id}' not found")
+
+    exit_criteria: list[str] = module.get("exit_criteria", [])
+    if payload.checkpoint_index >= len(exit_criteria):
+        raise HTTPException(
+            status_code=422,
+            detail=f"checkpoint_index {payload.checkpoint_index} out of range (module has {len(exit_criteria)} exit criteria)",
+        )
+
+    prompt = exit_criteria[payload.checkpoint_index]
+    now = datetime.now(timezone.utc).isoformat()
+
+    record = CheckpointRecord(
+        module_id=payload.module_id,
+        checkpoint_index=payload.checkpoint_index,
+        type=payload.type,
+        prompt=prompt,
+        evidence=payload.evidence,
+        self_evaluation=payload.self_evaluation,
+        submitted_at=now,
+    )
+
+    # Persist to progression.json under checkpoints key
+    progression_data = load_progression()
+    checkpoints = progression_data.setdefault("checkpoints", [])
+    checkpoints.append(record.model_dump())
+    write_progression(progression_data)
+
+    return record
+
+
+@app.get("/api/v1/checkpoints/{module_id}")
+def list_checkpoints(module_id: str) -> CheckpointListResponse:
+    module = _find_module_in_curriculum(module_id)
+    if module is None:
+        raise HTTPException(status_code=404, detail=f"Module '{module_id}' not found")
+
+    exit_criteria: list[str] = module.get("exit_criteria", [])
+    progression_data = load_progression()
+    submissions = progression_data.get("checkpoints", [])
+
+    # Build checkpoint list with submission status
+    result: list[dict[str, object]] = []
+    for idx, criterion in enumerate(exit_criteria):
+        matching = [
+            s for s in submissions
+            if s.get("module_id") == module_id and s.get("checkpoint_index") == idx
+        ]
+        latest = matching[-1] if matching else None
+        result.append({
+            "index": idx,
+            "prompt": criterion,
+            "submitted": latest is not None,
+            "self_evaluation": latest["self_evaluation"] if latest else None,
+            "submitted_at": latest["submitted_at"] if latest else None,
+        })
+
+    return CheckpointListResponse(module_id=module_id, checkpoints=result)

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -204,3 +204,37 @@ class DefenseSession(BaseModel):
     answers: list[str] = Field(default_factory=list)
     scores: list[int] = Field(default_factory=list)
     status: DefenseStatus = "scheduled"
+
+
+# --- Checkpoint submission schemas (Issue #37) ---
+
+EvaluationResult = Literal["pass", "partial", "fail"]
+
+
+class CheckpointSubmission(BaseModel):
+    """Payload for submitting evidence against a checkpoint."""
+
+    module_id: str = Field(min_length=1)
+    checkpoint_index: int = Field(ge=0)
+    type: CheckpointType = "exit_criteria"
+    evidence: str = Field(min_length=1, max_length=10000)
+    self_evaluation: EvaluationResult
+
+
+class CheckpointRecord(BaseModel):
+    """Stored record of a checkpoint submission and its evaluation."""
+
+    module_id: str
+    checkpoint_index: int
+    type: CheckpointType
+    prompt: str
+    evidence: str
+    self_evaluation: EvaluationResult
+    submitted_at: str
+
+
+class CheckpointListResponse(BaseModel):
+    """Response listing checkpoints for a module with submission status."""
+
+    module_id: str
+    checkpoints: list[dict[str, object]]

--- a/services/api/tests/test_checkpoints.py
+++ b/services/api/tests/test_checkpoints.py
@@ -1,0 +1,373 @@
+"""Tests for checkpoint submission and listing endpoints (Issue #37)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas import CheckpointSubmission
+
+client = TestClient(app)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_CURRICULUM = {
+    "metadata": {"campus": "42 Lausanne"},
+    "tracks": [
+        {
+            "id": "shell",
+            "title": "Shell",
+            "summary": "Shell track",
+            "why_it_matters": "Fundamentals",
+            "modules": [
+                {
+                    "id": "shell-basics",
+                    "title": "Navigation",
+                    "phase": "foundation",
+                    "skills": ["pwd", "ls"],
+                    "deliverable": "Navigate.",
+                    "exit_criteria": [
+                        "Complete a blind navigation exercise without errors",
+                        "Recreate a given directory tree from a textual spec",
+                        "Explain the difference between cp and mv in own words",
+                    ],
+                },
+                {
+                    "id": "shell-streams",
+                    "title": "Pipes",
+                    "phase": "foundation",
+                    "skills": ["pipe"],
+                    "deliverable": "Pipe.",
+                    "exit_criteria": [
+                        "Build a 3-stage pipeline",
+                    ],
+                },
+            ],
+        },
+        {
+            "id": "c",
+            "title": "C",
+            "summary": "C track",
+            "why_it_matters": "Low-level",
+            "modules": [
+                {
+                    "id": "c-basics",
+                    "title": "Syntax",
+                    "phase": "foundation",
+                    "skills": [],
+                    "deliverable": "Compile.",
+                    # No exit_criteria — tests empty case
+                },
+            ],
+        },
+    ],
+}
+
+
+def _prog(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {"learning_plan": {}, "progress": {}}
+    base.update(overrides)
+    return base
+
+
+def _patch_repo(progression: dict[str, object] | None = None):
+    prog = progression if progression is not None else _prog()
+    written: list[dict[str, object]] = []
+
+    def fake_write(data: dict[str, object]) -> None:
+        prog.clear()
+        prog.update(data)
+        written.append(json.loads(json.dumps(data)))
+
+    return (
+        patch("app.main.load_curriculum", return_value=_CURRICULUM),
+        patch("app.main.load_progression", side_effect=lambda: json.loads(json.dumps(prog))),
+        patch("app.main.write_progression", side_effect=fake_write),
+        prog,
+        written,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/checkpoints/submit
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitCheckpoint:
+    def test_submit_happy_path(self) -> None:
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 0,
+                "type": "exit_criteria",
+                "evidence": "cd /tmp && pwd => /tmp",
+                "self_evaluation": "pass",
+            })
+        assert r.status_code == 200
+        data = r.json()
+        assert data["module_id"] == "shell-basics"
+        assert data["checkpoint_index"] == 0
+        assert data["prompt"] == "Complete a blind navigation exercise without errors"
+        assert data["evidence"] == "cd /tmp && pwd => /tmp"
+        assert data["self_evaluation"] == "pass"
+        assert "submitted_at" in data
+        assert len(written) == 1
+        assert len(written[0]["checkpoints"]) == 1
+
+    def test_submit_second_checkpoint(self) -> None:
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 1,
+                "type": "exit_criteria",
+                "evidence": "mkdir -p a/b/c && tree a",
+                "self_evaluation": "partial",
+            })
+        assert r.status_code == 200
+        assert r.json()["checkpoint_index"] == 1
+        assert r.json()["self_evaluation"] == "partial"
+
+    def test_submit_fail_evaluation(self) -> None:
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 2,
+                "type": "exit_criteria",
+                "evidence": "I'm not sure about the difference",
+                "self_evaluation": "fail",
+            })
+        assert r.status_code == 200
+        assert r.json()["self_evaluation"] == "fail"
+
+    def test_submit_unknown_module_404(self) -> None:
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "nonexistent",
+                "checkpoint_index": 0,
+                "type": "exit_criteria",
+                "evidence": "test",
+                "self_evaluation": "pass",
+            })
+        assert r.status_code == 404
+
+    def test_submit_index_out_of_range(self) -> None:
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 99,
+                "type": "exit_criteria",
+                "evidence": "test",
+                "self_evaluation": "pass",
+            })
+        assert r.status_code == 422
+        assert "out of range" in r.json()["detail"]
+
+    def test_submit_module_no_exit_criteria(self) -> None:
+        """c-basics has no exit_criteria — index 0 should be out of range."""
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "c-basics",
+                "checkpoint_index": 0,
+                "type": "exit_criteria",
+                "evidence": "test",
+                "self_evaluation": "pass",
+            })
+        assert r.status_code == 422
+
+    def test_submit_empty_evidence_rejected(self) -> None:
+        """Evidence must be non-empty."""
+        r = client.post("/api/v1/checkpoints/submit", json={
+            "module_id": "shell-basics",
+            "checkpoint_index": 0,
+            "type": "exit_criteria",
+            "evidence": "",
+            "self_evaluation": "pass",
+        })
+        assert r.status_code == 422
+
+    def test_submit_invalid_self_evaluation_rejected(self) -> None:
+        r = client.post("/api/v1/checkpoints/submit", json={
+            "module_id": "shell-basics",
+            "checkpoint_index": 0,
+            "type": "exit_criteria",
+            "evidence": "some evidence",
+            "self_evaluation": "maybe",
+        })
+        assert r.status_code == 422
+
+    def test_submit_invalid_type_rejected(self) -> None:
+        r = client.post("/api/v1/checkpoints/submit", json={
+            "module_id": "shell-basics",
+            "checkpoint_index": 0,
+            "type": "exam",
+            "evidence": "some evidence",
+            "self_evaluation": "pass",
+        })
+        assert r.status_code == 422
+
+    def test_submit_persists_to_progression(self) -> None:
+        """Verify the checkpoint record is written to progression data."""
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 0,
+                "type": "exit_criteria",
+                "evidence": "pwd => /tmp",
+                "self_evaluation": "pass",
+            })
+        assert len(written) == 1
+        record = written[0]["checkpoints"][0]
+        assert record["module_id"] == "shell-basics"
+        assert record["evidence"] == "pwd => /tmp"
+        assert record["self_evaluation"] == "pass"
+
+    def test_submit_appends_to_existing_checkpoints(self) -> None:
+        """Multiple submissions should accumulate."""
+        existing = _prog(checkpoints=[{
+            "module_id": "shell-basics",
+            "checkpoint_index": 0,
+            "type": "exit_criteria",
+            "prompt": "old",
+            "evidence": "old evidence",
+            "self_evaluation": "fail",
+            "submitted_at": "2026-01-01T00:00:00+00:00",
+        }])
+        p_cur, p_load, p_write, prog, written = _patch_repo(existing)
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 0,
+                "type": "exit_criteria",
+                "evidence": "new evidence",
+                "self_evaluation": "pass",
+            })
+        assert r.status_code == 200
+        assert len(written) == 1
+        assert len(written[0]["checkpoints"]) == 2
+
+    def test_submit_deliverable_type(self) -> None:
+        p_cur, p_load, p_write, prog, written = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/checkpoints/submit", json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 0,
+                "type": "deliverable",
+                "evidence": "I can navigate freely",
+                "self_evaluation": "pass",
+            })
+        assert r.status_code == 200
+        assert r.json()["type"] == "deliverable"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/checkpoints/{module_id}
+# ---------------------------------------------------------------------------
+
+
+class TestListCheckpoints:
+    def test_list_no_submissions(self) -> None:
+        p_cur, p_load, p_write, _p, _w = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.get("/api/v1/checkpoints/shell-basics")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["module_id"] == "shell-basics"
+        assert len(data["checkpoints"]) == 3
+        for cp in data["checkpoints"]:
+            assert cp["submitted"] is False
+            assert cp["self_evaluation"] is None
+            assert cp["submitted_at"] is None
+
+    def test_list_with_submission(self) -> None:
+        prog = _prog(checkpoints=[{
+            "module_id": "shell-basics",
+            "checkpoint_index": 0,
+            "type": "exit_criteria",
+            "prompt": "Complete a blind navigation exercise without errors",
+            "evidence": "cd /tmp && pwd => /tmp",
+            "self_evaluation": "pass",
+            "submitted_at": "2026-03-27T10:00:00+00:00",
+        }])
+        p_cur, p_load, p_write, _p, _w = _patch_repo(prog)
+        with p_cur, p_load, p_write:
+            r = client.get("/api/v1/checkpoints/shell-basics")
+        data = r.json()
+        assert data["checkpoints"][0]["submitted"] is True
+        assert data["checkpoints"][0]["self_evaluation"] == "pass"
+        assert data["checkpoints"][1]["submitted"] is False
+
+    def test_list_shows_latest_submission(self) -> None:
+        """When multiple submissions exist, the latest is shown."""
+        prog = _prog(checkpoints=[
+            {
+                "module_id": "shell-basics", "checkpoint_index": 0,
+                "type": "exit_criteria", "prompt": "p",
+                "evidence": "first", "self_evaluation": "fail",
+                "submitted_at": "2026-03-27T09:00:00+00:00",
+            },
+            {
+                "module_id": "shell-basics", "checkpoint_index": 0,
+                "type": "exit_criteria", "prompt": "p",
+                "evidence": "second", "self_evaluation": "pass",
+                "submitted_at": "2026-03-27T10:00:00+00:00",
+            },
+        ])
+        p_cur, p_load, p_write, _p, _w = _patch_repo(prog)
+        with p_cur, p_load, p_write:
+            r = client.get("/api/v1/checkpoints/shell-basics")
+        cp0 = r.json()["checkpoints"][0]
+        assert cp0["self_evaluation"] == "pass"
+        assert cp0["submitted_at"] == "2026-03-27T10:00:00+00:00"
+
+    def test_list_unknown_module_404(self) -> None:
+        p_cur, p_load, p_write, _p, _w = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.get("/api/v1/checkpoints/nonexistent")
+        assert r.status_code == 404
+
+    def test_list_module_no_exit_criteria(self) -> None:
+        """c-basics has no exit_criteria — should return empty list."""
+        p_cur, p_load, p_write, _p, _w = _patch_repo()
+        with p_cur, p_load, p_write:
+            r = client.get("/api/v1/checkpoints/c-basics")
+        assert r.status_code == 200
+        assert r.json()["checkpoints"] == []
+
+    def test_list_different_modules_isolated(self) -> None:
+        """Submissions for one module should not appear in another."""
+        prog = _prog(checkpoints=[{
+            "module_id": "shell-basics", "checkpoint_index": 0,
+            "type": "exit_criteria", "prompt": "p",
+            "evidence": "e", "self_evaluation": "pass",
+            "submitted_at": "2026-03-27T10:00:00+00:00",
+        }])
+        p_cur, p_load, p_write, _p, _w = _patch_repo(prog)
+        with p_cur, p_load, p_write:
+            r = client.get("/api/v1/checkpoints/shell-streams")
+        data = r.json()
+        assert len(data["checkpoints"]) == 1
+        assert data["checkpoints"][0]["submitted"] is False
+
+    def test_list_checkpoint_has_correct_prompts(self) -> None:
+        p_cur, p_load, p_write, _p, _w = _patch_repo()
+        with p_cur, p_load, p_write:
+            data = client.get("/api/v1/checkpoints/shell-basics").json()
+        prompts = [cp["prompt"] for cp in data["checkpoints"]]
+        assert prompts == [
+            "Complete a blind navigation exercise without errors",
+            "Recreate a given directory tree from a textual spec",
+            "Explain the difference between cp and mv in own words",
+        ]


### PR DESCRIPTION
## Summary

Closes #37.

Adds endpoints for learners to submit evidence against module exit criteria and self-evaluate their progress.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/v1/checkpoints/submit` | Submit evidence for a checkpoint with self-evaluation |
| GET | `/api/v1/checkpoints/{module_id}` | List all checkpoints for a module with submission status |

## Design

- Checkpoint prompts are derived from the curriculum's `exit_criteria` array (per module)
- Learner submits `evidence` (command output, explanation, artifact) + `self_evaluation` (pass/partial/fail)
- Submissions persisted to `progression.json` under `checkpoints` key
- Multiple submissions per checkpoint supported — GET shows the latest
- Validates: module exists (404), checkpoint_index in range (422), evidence non-empty (422), valid evaluation type (422)

## New schemas

- `CheckpointSubmission` — request payload (module_id, checkpoint_index, type, evidence, self_evaluation)
- `CheckpointRecord` — stored record with prompt and timestamp
- `CheckpointListResponse` — module checkpoints with submission status

## Test plan

- [x] 69 tests pass (50 existing + 19 new)
- [x] Submit: happy path, all evaluation types, persistence, appending to existing
- [x] Submit errors: unknown module (404), index out of range (422), empty evidence (422), invalid type/evaluation (422)
- [x] List: no submissions, with submissions, latest-wins, module isolation, correct prompts, empty exit_criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)