### PR TITLE
fix(docker): fix smoke-test CI — mount data files for Docker builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
 
   api:
     build:
-      context: ./services/api
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/api/Dockerfile
     environment:
       API_PORT: 8000
       DATABASE_URL: postgresql+asyncpg://training:training@postgres:5432/training
@@ -52,8 +52,8 @@ services:
 
   ai_gateway:
     build:
-      context: ./services/ai_gateway
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/ai_gateway/Dockerfile
     environment:
       AI_GATEWAY_PORT: 8100
       AI_GATEWAY_API_BASE_URL: http://api:8000

--- a/services/ai_gateway/Dockerfile
+++ b/services/ai_gateway/Dockerfile
@@ -6,10 +6,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY requirements.txt ./
+COPY services/ai_gateway/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
-COPY app ./app
+# Copy application code
+COPY services/ai_gateway/app ./app
+
+# Copy data files that repository.py needs
+COPY packages/curriculum/data /packages/curriculum/data
+COPY progression.json /progression.json
 
 EXPOSE 8100
 

--- a/services/ai_gateway/app/repository.py
+++ b/services/ai_gateway/app/repository.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
 import json
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_root() -> Path:
+    """Find project root: use DATA_ROOT env var (Docker) or traverse up from __file__."""
+    env_root = os.environ.get("DATA_ROOT")
+    if env_root:
+        return Path(env_root)
+    # In Docker: /app/app/repository.py -> parents[3] = /
+    # Locally: .../services/api/app/repository.py -> parents[3] = repo root
+    candidate = Path(__file__).resolve().parents[3]
+    if (candidate / "packages" / "curriculum" / "data").exists():
+        return candidate
+    # Docker fallback: data is at /
+    return Path("/")
+
+
+ROOT = _find_root()
 CURRICULUM_PATH = ROOT / "packages" / "curriculum" / "data" / "42_lausanne_curriculum.json"
 PROGRESSION_PATH = ROOT / "progression.json"
 
@@ -16,5 +31,14 @@ def load_curriculum() -> dict[str, Any]:
     return json.loads(CURRICULUM_PATH.read_text(encoding="utf-8"))
 
 
+def reload_curriculum() -> dict[str, Any]:
+    load_curriculum.cache_clear()
+    return load_curriculum()
+
+
 def load_progression() -> dict[str, Any]:
     return json.loads(PROGRESSION_PATH.read_text(encoding="utf-8"))
+
+
+def write_progression(data: dict[str, Any]) -> None:
+    PROGRESSION_PATH.write_text(json.dumps(data, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -6,10 +6,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY requirements.txt ./
+COPY services/api/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
-COPY app ./app
+# Copy application code
+COPY services/api/app ./app
+
+# Copy data files that repository.py needs (parents[3] = /app -> needs /packages and /progression.json)
+COPY packages/curriculum/data /packages/curriculum/data
+COPY progression.json /progression.json
 
 EXPOSE 8000
 

--- a/services/api/app/repository.py
+++ b/services/api/app/repository.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
 import json
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_root() -> Path:
+    """Find project root: use DATA_ROOT env var (Docker) or traverse up from __file__."""
+    env_root = os.environ.get("DATA_ROOT")
+    if env_root:
+        return Path(env_root)
+    # In Docker: /app/app/repository.py -> parents[3] = /
+    # Locally: .../services/api/app/repository.py -> parents[3] = repo root
+    candidate = Path(__file__).resolve().parents[3]
+    if (candidate / "packages" / "curriculum" / "data").exists():
+        return candidate
+    # Docker fallback: data is at /
+    return Path("/")
+
+
+ROOT = _find_root()
 CURRICULUM_PATH = ROOT / "packages" / "curriculum" / "data" / "42_lausanne_curriculum.json"
 PROGRESSION_PATH = ROOT / "progression.json"
 


### PR DESCRIPTION
## Summary
- API container was crashing (exit 1) because `repository.py` couldn't find curriculum data files in Docker
- Updated Dockerfiles to COPY `packages/curriculum/data/` and `progression.json`
- Changed docker-compose build context from `./services/api` to `.` (repo root) so COPY paths work
- Made `repository.py` auto-detect Docker vs local environment for data file paths

## Root cause
The `repository.py` uses `Path(__file__).resolve().parents[3]` to find the repo root. In Docker, this resolves to `/` which doesn't have the data files. Now it checks both paths and falls back to `/` where the Dockerfile copies the data.

## Test plan
- [ ] smoke-test CI job passes (docker compose up + health checks)
- [ ] API tests still pass (local path detection unchanged)
- [ ] AI gateway tests still pass