### PR TITLE
refactor: add repository abstraction for future PostgreSQL switch (#28)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -34,8 +34,12 @@ def meta(r: CurriculumRepository = Depends(get_repo)) -> dict[str, object]:
     return {
         "app": "42-training",
         "campus": curriculum["metadata"]["campus"],
-        "active_course": progression.get("learning_plan", {}).get("active_course", "shell"),
-        "pace_mode": progression.get("learning_plan", {}).get("pace_mode", "self_paced"),
+        "active_course": progression.get("learning_plan", {}).get(
+            "active_course", "shell"
+        ),
+        "pace_mode": progression.get("learning_plan", {}).get(
+            "pace_mode", "self_paced"
+        ),
     }
 
 
@@ -53,7 +57,9 @@ def tracks(r: CurriculumRepository = Depends(get_repo)) -> list[dict[str, object
 
 
 @app.get("/api/v1/tracks/{track_id}")
-def track_detail(track_id: str, r: CurriculumRepository = Depends(get_repo)) -> dict[str, object]:
+def track_detail(
+    track_id: str, r: CurriculumRepository = Depends(get_repo)
+) -> dict[str, object]:
     track = r.get_track(track_id)
     if track is None:
         raise HTTPException(status_code=404, detail="Track not found")
@@ -66,6 +72,8 @@ def progression(r: CurriculumRepository = Depends(get_repo)) -> dict[str, object
 
 
 @app.post("/api/v1/progression")
-def update_progression(payload: ProgressUpdate, r: CurriculumRepository = Depends(get_repo)) -> dict[str, object]:
+def update_progression(
+    payload: ProgressUpdate, r: CurriculumRepository = Depends(get_repo)
+) -> dict[str, object]:
     updates = payload.model_dump(exclude_none=True)
     return r.update_progression(updates)

--- a/services/api/app/repository.py
+++ b/services/api/app/repository.py
@@ -44,7 +44,9 @@ class CurriculumRepository(ABC):
         """Return progression state for a learner."""
 
     @abstractmethod
-    def update_progression(self, data: dict[str, Any], learner_id: str = "default") -> dict[str, Any]:
+    def update_progression(
+        self, data: dict[str, Any], learner_id: str = "default"
+    ) -> dict[str, Any]:
         """Merge *data* into the learner's progression and return the updated state."""
 
 
@@ -65,7 +67,9 @@ def _find_root() -> Path:
 
 
 ROOT = _find_root()
-CURRICULUM_PATH = ROOT / "packages" / "curriculum" / "data" / "42_lausanne_curriculum.json"
+CURRICULUM_PATH = (
+    ROOT / "packages" / "curriculum" / "data" / "42_lausanne_curriculum.json"
+)
 PROGRESSION_PATH = ROOT / "progression.json"
 
 
@@ -127,7 +131,9 @@ class JsonCurriculumRepository(CurriculumRepository):
     def get_progression(self, learner_id: str = "default") -> dict[str, Any]:
         return json.loads(self._progression_path.read_text(encoding="utf-8"))
 
-    def update_progression(self, data: dict[str, Any], learner_id: str = "default") -> dict[str, Any]:
+    def update_progression(
+        self, data: dict[str, Any], learner_id: str = "default"
+    ) -> dict[str, Any]:
         current = self.get_progression(learner_id)
         learning_plan = current.setdefault("learning_plan", {})
         progress = current.setdefault("progress", {})

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -30,8 +29,20 @@ _CURRICULUM = {
             "summary": "Linux-first recovery track.",
             "why_it_matters": "Command fluency.",
             "modules": [
-                {"id": "shell-basics", "title": "Navigation", "phase": "foundation", "skills": ["pwd", "ls"], "deliverable": "Navigate."},
-                {"id": "shell-streams", "title": "Pipes", "phase": "foundation", "skills": ["pipe"], "deliverable": "Pipe."},
+                {
+                    "id": "shell-basics",
+                    "title": "Navigation",
+                    "phase": "foundation",
+                    "skills": ["pwd", "ls"],
+                    "deliverable": "Navigate.",
+                },
+                {
+                    "id": "shell-streams",
+                    "title": "Pipes",
+                    "phase": "foundation",
+                    "skills": ["pipe"],
+                    "deliverable": "Pipe.",
+                },
             ],
         },
         {
@@ -40,7 +51,13 @@ _CURRICULUM = {
             "summary": "Low-level rigor.",
             "why_it_matters": "Memory discipline.",
             "modules": [
-                {"id": "c-basics", "title": "Syntax", "phase": "foundation", "skills": ["variables"], "deliverable": "Compile."},
+                {
+                    "id": "c-basics",
+                    "title": "Syntax",
+                    "phase": "foundation",
+                    "skills": ["variables"],
+                    "deliverable": "Compile.",
+                },
             ],
         },
     ],
@@ -70,9 +87,15 @@ def _fresh_progression() -> dict[str, object]:
 class FakeRepository(CurriculumRepository):
     """In-memory repository for tests."""
 
-    def __init__(self, curriculum: dict[str, Any] = _CURRICULUM, progression: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        curriculum: dict[str, Any] = _CURRICULUM,
+        progression: dict[str, Any] | None = None,
+    ) -> None:
         self._curriculum = curriculum
-        self._progression = progression if progression is not None else _fresh_progression()
+        self._progression = (
+            progression if progression is not None else _fresh_progression()
+        )
         self.writes: list[dict[str, Any]] = []
 
     def get_curriculum(self) -> dict[str, Any]:
@@ -114,7 +137,9 @@ class FakeRepository(CurriculumRepository):
     def get_progression(self, learner_id: str = "default") -> dict[str, Any]:
         return json.loads(json.dumps(self._progression))
 
-    def update_progression(self, data: dict[str, Any], learner_id: str = "default") -> dict[str, Any]:
+    def update_progression(
+        self, data: dict[str, Any], learner_id: str = "default"
+    ) -> dict[str, Any]:
         current = self.get_progression(learner_id)
         learning_plan = current.setdefault("learning_plan", {})
         progress = current.setdefault("progress", {})
@@ -135,7 +160,9 @@ class FakeRepository(CurriculumRepository):
         return current
 
 
-def _use_fake(progression: dict[str, Any] | None = None, curriculum: dict[str, Any] = _CURRICULUM) -> FakeRepository:
+def _use_fake(
+    progression: dict[str, Any] | None = None, curriculum: dict[str, Any] = _CURRICULUM
+) -> FakeRepository:
     """Install a FakeRepository and return it."""
     fake = FakeRepository(curriculum=curriculum, progression=progression)
     app.dependency_overrides[get_repo] = lambda: fake
@@ -371,7 +398,11 @@ class TestUpdateProgression:
         _use_fake()
         r = client.post(
             "/api/v1/progression",
-            json={"active_course": "c", "current_exercise": "Ex5", "next_command": "gcc main.c"},
+            json={
+                "active_course": "c",
+                "current_exercise": "Ex5",
+                "next_command": "gcc main.c",
+            },
         )
         assert r.status_code == 200
         data = r.json()
@@ -456,7 +487,11 @@ class TestProgressionConsistency:
 class TestValidationErrors:
     def test_post_progression_invalid_json(self) -> None:
         """Sending non-JSON body should return 422."""
-        r = client.post("/api/v1/progression", content=b"not json", headers={"content-type": "application/json"})
+        r = client.post(
+            "/api/v1/progression",
+            content=b"not json",
+            headers={"content-type": "application/json"},
+        )
         assert r.status_code == 422
 
     def test_post_progression_non_object_body(self) -> None:
@@ -477,7 +512,12 @@ class TestEdgeCases:
         curriculum_no_modules = {
             "metadata": {"campus": "42 Lausanne"},
             "tracks": [
-                {"id": "empty", "title": "Empty", "summary": "No modules", "why_it_matters": "Test"},
+                {
+                    "id": "empty",
+                    "title": "Empty",
+                    "summary": "No modules",
+                    "why_it_matters": "Test",
+                },
             ],
         }
         _use_fake(curriculum=curriculum_no_modules)


### PR DESCRIPTION
## Summary

Closes #28.

Extracts JSON data access into an abstract repository pattern, preparing for the future switch from JSON files to PostgreSQL.

### Changes

- **`repository.py`**: Added `CurriculumRepository` ABC defining the data access contract: `get_curriculum()`, `get_tracks()`, `get_track(id)`, `get_modules(track_id)`, `get_module(id)`, `get_progression(learner_id)`, `update_progression(data, learner_id)`. The `learner_id` param prepares for multi-user support.
- **`JsonCurriculumRepository`**: Implements the interface using existing JSON file logic. Progression mutation logic moved here from the endpoint.
- **`main.py`**: Endpoints now receive the repository via `Depends(get_repo)` — easy to override in tests or swap for a PostgreSQL implementation later.
- **Legacy functions preserved**: `load_curriculum()`, `load_progression()`, `write_progression()` still work for `ai_gateway` backward compatibility.
- **Tests rewritten**: Use `FakeRepository` + FastAPI `dependency_overrides` instead of patching individual functions — cleaner and implementation-agnostic.

### To add PostgreSQL later

1. Create `PostgresCurriculumRepository(CurriculumRepository)`
2. Override `get_repo()` to return it
3. No endpoint changes needed

## Test plan

- [x] All 50 API tests pass
- [x] All 71 AI gateway tests pass (backward compat)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)