### PR TITLE
docs: integrate official 42 reference stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Le depot contient maintenant deux couches qui coexistent:
 Documentation principale:
 
 - `docs/APPROCHE_ARCHITECTURE_EXHAUSTIVE.md`
+- `docs/42_REFERENCE_STACK.md`
+- `docs/NEW_TC_PROJECT_PREDICTIONS.md`
 - `ARCHITECTURE_TARGET.md`
 - `docs/DEVOPS_RBOK_ADAPTATION.md`
 - `docs/adr/README.md`
@@ -124,6 +126,8 @@ The repository now contains two coexisting layers:
 Core documentation:
 
 - `docs/APPROCHE_ARCHITECTURE_EXHAUSTIVE.md`
+- `docs/42_REFERENCE_STACK.md`
+- `docs/NEW_TC_PROJECT_PREDICTIONS.md`
 - `ARCHITECTURE_TARGET.md`
 - `docs/DEVOPS_RBOK_ADAPTATION.md`
 - `docs/adr/README.md`

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -203,16 +203,125 @@ p {
 
 .module-list,
 .bridge-list,
-.policy-list {
+.policy-list,
+.reference-list,
+.tool-list,
+.confidence-list {
   display: grid;
   gap: 14px;
 }
 
 .module-item,
 .bridge-item,
-.policy-item {
+.policy-item,
+.reference-item,
+.tool-item,
+.confidence-item {
   padding-top: 14px;
   border-top: 1px solid var(--line);
+}
+
+.reference-item {
+  display: grid;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.reference-item:hover,
+.tool-link:hover {
+  opacity: 0.9;
+}
+
+.tool-link {
+  display: grid;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.reference-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.reference-topline span {
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+}
+
+.tool-item,
+.confidence-item,
+.milestone-card,
+.quality-card,
+.prediction-card,
+.analogy-item,
+.module-reference-item {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.52);
+  padding: 16px;
+}
+
+.tool-item,
+.confidence-item {
+  padding-top: 16px;
+}
+
+.quality-grid,
+.milestone-grid,
+.prediction-grid,
+.analogy-list,
+.module-reference-list {
+  display: grid;
+  gap: 16px;
+}
+
+.quality-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.milestone-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 20px;
+}
+
+.quality-card {
+  display: grid;
+  gap: 14px;
+}
+
+.prediction-card,
+.module-reference-item {
+  display: grid;
+  gap: 10px;
+}
+
+.module-reference-item {
+  color: inherit;
+  text-decoration: none;
+}
+
+.module-note {
+  margin-top: 12px;
+  color: var(--muted);
+}
+
+.analogy-list {
+  margin-bottom: 20px;
+}
+
+.prediction-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.quality-subsection {
+  display: grid;
+  gap: 8px;
 }
 
 .section.split {
@@ -222,7 +331,10 @@ p {
 @media (max-width: 1080px) {
   .hero,
   .track-grid,
-  .section.split {
+  .section.split,
+  .quality-grid,
+  .milestone-grid,
+  .prediction-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,10 @@ export default async function HomePage() {
   const data = await getDashboardData();
   const { curriculum, progression } = data;
   const activeCourse = progression.learning_plan?.active_course ?? "shell";
+  const officialReferences = [
+    ...curriculum.reference_stack.official_documents,
+    ...curriculum.reference_stack.official_document_mirrors
+  ];
 
   return (
     <main className="page-shell">
@@ -31,8 +35,8 @@ export default async function HomePage() {
               <strong>{activeCourse}</strong>
             </div>
             <div className="metric-card">
-              <span>Pace mode</span>
-              <strong>{progression.learning_plan?.pace_mode ?? "self_paced"}</strong>
+              <span>Reference posture</span>
+              <strong>{curriculum.metadata.reference_posture ?? "official docs first"}</strong>
             </div>
             <div className="metric-card">
               <span>Next command</span>
@@ -80,6 +84,30 @@ export default async function HomePage() {
                         <Pill key={skill}>{skill}</Pill>
                       ))}
                     </div>
+                    {module.reference_note ? <p className="module-note">{module.reference_note}</p> : null}
+                    {(module.subject_refs ?? []).length > 0 ? (
+                      <div className="module-reference-list">
+                        {(module.subject_refs ?? []).map((reference) => (
+                          <a
+                            key={`${module.id}-${reference.label}`}
+                            className="module-reference-item"
+                            href={reference.url}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <div className="reference-topline">
+                              <strong>{reference.document_title}</strong>
+                              <span>{reference.coverage}</span>
+                            </div>
+                            <p>{reference.label}</p>
+                            <p className="muted">
+                              {reference.confidence} / {reference.tier}
+                            </p>
+                            {reference.mirror_path ? <p className="muted">{reference.mirror_path}</p> : null}
+                          </a>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
                 ))}
               </div>
@@ -114,6 +142,197 @@ export default async function HomePage() {
                 <strong>{tier.label}</strong>
                 <span>{tier.allowed_usage}</span>
               </div>
+            ))}
+          </div>
+          <div className="confidence-list">
+            {(curriculum.source_policy.confidence_model ?? []).map((item) => (
+              <div key={item.level} className="confidence-item">
+                <strong>{item.level}</strong>
+                <p>{item.meaning}</p>
+              </div>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="section split">
+        <article className="panel">
+          <p className="eyebrow">Reference Stack</p>
+          <h2>Official documents and mirrors</h2>
+          <div className="reference-list">
+            {officialReferences.map((reference) => (
+              <a key={reference.label} className="reference-item" href={reference.url} target="_blank" rel="noreferrer">
+                <div className="reference-topline">
+                  <strong>{reference.label}</strong>
+                  <span>{reference.confidence ?? reference.tier}</span>
+                </div>
+                {reference.usage ? <p>{reference.usage}</p> : null}
+                {reference.note ? <p className="muted">{reference.note}</p> : null}
+              </a>
+            ))}
+          </div>
+        </article>
+        <article className="panel">
+          <p className="eyebrow">Quality Toolchain</p>
+          <h2>Available verification layers</h2>
+          <div className="tool-list">
+            {curriculum.reference_stack.quality_stack.map((tool) => (
+              <a key={tool.id} className="tool-item tool-link" href={tool.url} target="_blank" rel="noreferrer">
+                <div className="reference-topline">
+                  <strong>{tool.label}</strong>
+                  <span>{tool.language}</span>
+                </div>
+                <p>{tool.role}</p>
+                <p className="muted">
+                  {tool.authority} / {tool.kind}
+                </p>
+                {tool.note ? <p className="muted">{tool.note}</p> : null}
+              </a>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Quality Model</p>
+          <h2>Equivalent rigor by language</h2>
+        </div>
+        <div className="quality-grid">
+          {curriculum.reference_stack.quality_equivalents.map((item) => (
+            <article key={item.language} className="quality-card">
+              <div className="card-topline">
+                <span>{item.language}</span>
+                <span>quality contract</span>
+              </div>
+              <h3>{item.positioning}</h3>
+              <p>{item.quality_contract}</p>
+              <div className="quality-subsection">
+                <strong>Automated gates</strong>
+                <div className="stack-list">
+                  {item.automated_gates.map((gate) => (
+                    <Pill key={gate}>{gate}</Pill>
+                  ))}
+                </div>
+              </div>
+              <div className="quality-subsection">
+                <strong>Human review focus</strong>
+                <div className="stack-list">
+                  {item.human_review_focus.map((focus) => (
+                    <Pill key={focus}>{focus}</Pill>
+                  ))}
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Curriculum Mapping</p>
+          <h2>Legacy backbone, emerging Python lane</h2>
+        </div>
+        <article className="panel">
+          <p>{curriculum.curriculum_mapping.new_common_core_interpretation.summary}</p>
+          <p className="muted">
+            Confidence: {curriculum.curriculum_mapping.new_common_core_interpretation.confidence}.{" "}
+            {curriculum.curriculum_mapping.new_common_core_interpretation.note}
+          </p>
+          <div className="milestone-grid">
+            {(curriculum.curriculum_mapping.new_common_core_interpretation.milestones ?? []).map((item) => (
+              <div key={item.milestone} className="milestone-card">
+                <div className="reference-topline">
+                  <strong>{item.milestone}</strong>
+                  <span>{item.confidence}</span>
+                </div>
+                <div className="stack-list">
+                  {item.projects.map((project) => (
+                    <Pill key={project}>{project}</Pill>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="quality-subsection">
+            <strong>Preserved legacy dimensions</strong>
+            <div className="stack-list">
+              {(curriculum.curriculum_mapping.legacy_common_core.preserved_dimensions ?? []).map((item) => (
+                <Pill key={item}>{item}</Pill>
+              ))}
+            </div>
+          </div>
+          <div className="quality-subsection">
+            <strong>Synthesis</strong>
+            <div className="stack-list">
+              {(curriculum.curriculum_mapping.synthesis?.principles ?? []).map((item) => (
+                <Pill key={item}>{item}</Pill>
+              ))}
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Predictions</p>
+          <h2>Imagined subjects for the new Python and AI lane</h2>
+        </div>
+        <article className="panel">
+          <div className="analogy-list">
+            {(curriculum.curriculum_mapping.new_common_core_interpretation.style_analogies ?? []).map((item) => (
+              <div key={`${item.legacy_anchor}-${item.new_project}`} className="analogy-item">
+                <div className="reference-topline">
+                  <strong>{item.new_project}</strong>
+                  <span>{item.legacy_anchor}</span>
+                </div>
+                <p>{item.rationale}</p>
+              </div>
+            ))}
+          </div>
+          <div className="prediction-grid">
+            {(curriculum.curriculum_mapping.new_common_core_interpretation.predicted_project_models ?? []).map((item) => (
+              <article key={item.id} className="prediction-card">
+                <div className="reference-topline">
+                  <strong>{item.title}</strong>
+                  <span>
+                    {item.milestone} / {item.confidence}
+                  </span>
+                </div>
+                <p>{item.predicted_subject_style}</p>
+                <div className="quality-subsection">
+                  <strong>Legacy style anchors</strong>
+                  <div className="stack-list">
+                    {item.legacy_style_anchors.map((anchor) => (
+                      <Pill key={anchor}>{anchor}</Pill>
+                    ))}
+                  </div>
+                </div>
+                <div className="quality-subsection">
+                  <strong>Likely constraints</strong>
+                  <div className="stack-list">
+                    {item.predicted_constraints.map((constraint) => (
+                      <Pill key={constraint}>{constraint}</Pill>
+                    ))}
+                  </div>
+                </div>
+                <div className="quality-subsection">
+                  <strong>Likely deliverables</strong>
+                  <div className="stack-list">
+                    {item.predicted_deliverables.map((deliverable) => (
+                      <Pill key={deliverable}>{deliverable}</Pill>
+                    ))}
+                  </div>
+                </div>
+                <div className="quality-subsection">
+                  <strong>Target skills</strong>
+                  <div className="stack-list">
+                    {item.predicted_core_skills.map((skill) => (
+                      <Pill key={skill}>{skill}</Pill>
+                    ))}
+                  </div>
+                </div>
+              </article>
             ))}
           </div>
         </article>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -4,6 +4,8 @@ export type ModuleItem = {
   phase: string;
   skills: string[];
   deliverable: string;
+  reference_note?: string;
+  subject_refs?: SubjectRef[];
 };
 
 export type TrackItem = {
@@ -14,17 +16,93 @@ export type TrackItem = {
   modules: ModuleItem[];
 };
 
+export type ReferenceItem = {
+  label: string;
+  url: string;
+  tier: string;
+  confidence?: string;
+  usage?: string;
+  note?: string;
+};
+
+export type SubjectRef = {
+  label: string;
+  document_title: string;
+  url: string;
+  mirror_path?: string;
+  tier: string;
+  confidence: string;
+  coverage: string;
+  note?: string;
+};
+
+export type QualityTool = {
+  id: string;
+  label: string;
+  url: string;
+  language: string;
+  kind: string;
+  authority: string;
+  role: string;
+  note?: string;
+};
+
+export type QualityEquivalent = {
+  language: string;
+  positioning: string;
+  quality_contract: string;
+  automated_gates: string[];
+  human_review_focus: string[];
+};
+
 export type DashboardData = {
   curriculum: {
     metadata: {
       campus: string;
       updated_on: string;
+      status?: string;
+      reference_posture?: string;
     };
     source_policy: {
       tiers: Array<{ id: string; label: string; allowed_usage: string }>;
+      confidence_model?: Array<{ level: string; meaning: string }>;
+    };
+    reference_stack: {
+      official_documents: ReferenceItem[];
+      official_document_mirrors: ReferenceItem[];
+      quality_stack: QualityTool[];
+      quality_equivalents: QualityEquivalent[];
     };
     tracks: TrackItem[];
     bridges: Array<{ id: string; title: string; recommended_modules: string[] }>;
+    curriculum_mapping: {
+      legacy_common_core: {
+        summary: string;
+        preserved_dimensions?: string[];
+      };
+      new_common_core_interpretation: {
+        summary: string;
+        confidence: string;
+        note: string;
+        milestones?: Array<{ milestone: string; projects: string[]; confidence: string }>;
+        style_analogies?: Array<{ legacy_anchor: string; new_project: string; rationale: string }>;
+        predicted_project_models?: Array<{
+          id: string;
+          title: string;
+          milestone: string;
+          confidence: string;
+          legacy_style_anchors: string[];
+          predicted_subject_style: string;
+          predicted_constraints: string[];
+          predicted_deliverables: string[];
+          predicted_core_skills: string[];
+        }>;
+      };
+      synthesis?: {
+        summary: string;
+        principles: string[];
+      };
+    };
   };
   progression: {
     learning_plan?: {
@@ -48,16 +126,124 @@ const fallbackData: DashboardData = {
   curriculum: {
     metadata: {
       campus: "42 Lausanne",
-      updated_on: "2026-03-27",
+      updated_on: "2026-03-29",
+      status: "reference-refresh",
+      reference_posture: "official public documents first, verified mirrors second, community tooling as verification only"
     },
     source_policy: {
       tiers: [
         { id: "official_42", label: "Official 42 sources", allowed_usage: "ground_truth" },
+        {
+          id: "official_document_mirrors",
+          label: "Mirrors of official documents",
+          allowed_usage: "ground_truth_when_origin_is_verified"
+        },
         { id: "community_docs", label: "Community docs", allowed_usage: "explanation_and_mapping" },
         { id: "testers_and_tooling", label: "Testers and tooling", allowed_usage: "verification" },
         { id: "solution_metadata", label: "Solution metadata", allowed_usage: "path_mapping_only" },
         { id: "blocked_solution_content", label: "Direct solution content", allowed_usage: "blocked_by_default" }
       ],
+      confidence_model: [
+        { level: "high", meaning: "Official public page or official normative PDF." },
+        { level: "medium", meaning: "Verified mirror or staff-corroborated signal." },
+        { level: "interpreted", meaning: "Inference kept explicit as interpretation." }
+      ]
+    },
+    reference_stack: {
+      official_documents: [
+        {
+          label: "42 Lausanne - pedagogie",
+          url: "https://42lausanne.ch/pedagogie-42/",
+          tier: "official_42",
+          confidence: "high",
+          usage: "campus pedagogy and learning model"
+        },
+        {
+          label: "The Norm v4.1 (English PDF)",
+          url: "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+          tier: "official_42",
+          confidence: "high",
+          usage: "absolute C reference"
+        }
+      ],
+      official_document_mirrors: [
+        {
+          label: "Ninjarsenic/42-piscine",
+          url: "https://github.com/Ninjarsenic/42-piscine",
+          tier: "official_document_mirrors",
+          confidence: "medium",
+          note: "Private mirror of official Piscine assets."
+        },
+        {
+          label: "Ninjarsenic/42-Tronc_commun",
+          url: "https://github.com/Ninjarsenic/42-Tronc_commun",
+          tier: "official_document_mirrors",
+          confidence: "medium",
+          note: "Private mirror of Common Core subjects."
+        }
+      ],
+      quality_stack: [
+        {
+          id: "norminette",
+          label: "norminette",
+          url: "https://github.com/42school/norminette",
+          language: "c",
+          kind: "official_checker",
+          authority: "official_tool",
+          role: "Objective Norm checks."
+        },
+        {
+          id: "francinette",
+          label: "francinette",
+          url: "https://github.com/xicodomingues/francinette",
+          language: "c",
+          kind: "community_local_moulinette",
+          authority: "verification_only",
+          role: "Local make + norm + tester battery.",
+          note: "Archived upstream."
+        },
+        {
+          id: "ruff",
+          label: "ruff",
+          url: "https://github.com/astral-sh/ruff",
+          language: "python",
+          kind: "lint_and_format",
+          authority: "equivalent_quality_gate",
+          role: "Formatting and lint baseline for Python."
+        },
+        {
+          id: "shellcheck",
+          label: "ShellCheck",
+          url: "https://www.shellcheck.net/",
+          language: "bash",
+          kind: "lint",
+          authority: "equivalent_quality_gate",
+          role: "Quoting and portability guardrails for shell."
+        }
+      ],
+      quality_equivalents: [
+        {
+          language: "c",
+          positioning: "Absolute reference track.",
+          quality_contract: "The Norm plus norminette plus project-specific testers.",
+          automated_gates: ["norminette", "cc -Wall -Wextra -Werror", "tester suites"],
+          human_review_focus: ["clarity", "defense readiness", "subjective Norm items"]
+        },
+        {
+          language: "python",
+          positioning: "Equivalent rigor, not C mimicry.",
+          quality_contract: "Short explicit functions, typed boundaries, readable flow, test coverage.",
+          automated_gates: ["ruff check", "ruff format", "mypy", "pytest"],
+          human_review_focus: ["algorithmic explanation", "controlled abstraction", "debuggability"]
+        },
+        {
+          language: "bash",
+          positioning: "Terminal-first discipline.",
+          quality_contract: "Readable scripts, explicit quoting, small units, fail-fast habits.",
+          automated_gates: ["shellcheck", "shfmt", "smoke scripts"],
+          human_review_focus: ["pipeline clarity", "error handling", "debugging under shell constraints"]
+        }
+      ]
     },
     tracks: [
       {
@@ -66,9 +252,45 @@ const fallbackData: DashboardData = {
         summary: "Linux-first recovery track before Piscine pressure.",
         why_it_matters: "Rebuild confidence, command fluency and process awareness.",
         modules: [
-          { id: "shell-basics", title: "Navigation and files", phase: "foundation", skills: ["pwd", "ls", "cd", "cp"], deliverable: "Navigate and manipulate files with confidence." },
-          { id: "shell-streams", title: "Redirections and pipes", phase: "foundation", skills: ["stdin", "stdout", "pipe"], deliverable: "Chain commands effectively." }
-        ],
+          {
+            id: "shell-basics",
+            title: "Navigation and files",
+            phase: "foundation",
+            skills: ["pwd", "ls", "cd", "cp"],
+            deliverable: "Navigate and manipulate files with confidence.",
+            reference_note: "Anchored to the exact Shell00 official subject mirror.",
+            subject_refs: [
+              {
+                label: "Shell00 subject PDF",
+                document_title: "Piscine C Shell 00",
+                url: "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell00/fr.subject.pdf",
+                mirror_path: "Shell00/fr.subject.pdf",
+                tier: "official_document_mirrors",
+                confidence: "medium",
+                coverage: "exact_subject"
+              }
+            ]
+          },
+          {
+            id: "shell-streams",
+            title: "Redirections and pipes",
+            phase: "foundation",
+            skills: ["stdin", "stdout", "pipe"],
+            deliverable: "Chain commands effectively.",
+            reference_note: "Extracted from the broader Shell01 official subject.",
+            subject_refs: [
+              {
+                label: "Shell01 subject PDF",
+                document_title: "Piscine C Shell 01",
+                url: "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell01/fr.subject%20(1).pdf",
+                mirror_path: "Shell01/fr.subject (1).pdf",
+                tier: "official_document_mirrors",
+                confidence: "medium",
+                coverage: "partial_subject_mapping"
+              }
+            ]
+          }
+        ]
       },
       {
         id: "c",
@@ -76,9 +298,45 @@ const fallbackData: DashboardData = {
         summary: "Low-level rigor track aligned with the core 42 mindset.",
         why_it_matters: "Build algorithmic reasoning and memory discipline.",
         modules: [
-          { id: "c-basics", title: "Syntax and control flow", phase: "foundation", skills: ["if", "while", "functions"], deliverable: "Write and compile small programs." },
-          { id: "c-memory", title: "Pointers and memory", phase: "foundation", skills: ["pointers", "malloc", "free"], deliverable: "Understand memory choices and avoid basic leaks." }
-        ],
+          {
+            id: "c-basics",
+            title: "Syntax and control flow",
+            phase: "foundation",
+            skills: ["if", "while", "functions"],
+            deliverable: "Write and compile small programs.",
+            reference_note: "Condenses multiple official Piscine C subjects.",
+            subject_refs: [
+              {
+                label: "C00 subject PDF",
+                document_title: "Piscine C C 00",
+                url: "https://github.com/Ninjarsenic/42-piscine/blob/main/C00/fr.subject.pdf",
+                mirror_path: "C00/fr.subject.pdf",
+                tier: "official_document_mirrors",
+                confidence: "medium",
+                coverage: "partial_subject_mapping"
+              }
+            ]
+          },
+          {
+            id: "c-memory",
+            title: "Pointers and memory",
+            phase: "foundation",
+            skills: ["pointers", "malloc", "free"],
+            deliverable: "Understand memory choices and avoid basic leaks.",
+            reference_note: "Spans pointer, string and allocation subjects from the official Piscine.",
+            subject_refs: [
+              {
+                label: "C01 subject PDF",
+                document_title: "Piscine C C 01",
+                url: "https://github.com/Ninjarsenic/42-piscine/blob/main/C01/fr.subject%20(1).pdf",
+                mirror_path: "C01/fr.subject (1).pdf",
+                tier: "official_document_mirrors",
+                confidence: "medium",
+                coverage: "partial_subject_mapping"
+              }
+            ]
+          }
+        ]
       },
       {
         id: "python_ai",
@@ -86,15 +344,105 @@ const fallbackData: DashboardData = {
         summary: "Python foundations plus the modern AI axis.",
         why_it_matters: "Prepare for the new branch while keeping fundamentals intact.",
         modules: [
-          { id: "python-basics", title: "Python foundations", phase: "foundation", skills: ["conditions", "loops", "functions"], deliverable: "Write small scripts confidently." },
-          { id: "ai-rag-agents", title: "AI, RAG and agent literacy", phase: "advanced", skills: ["retrieval", "evaluation", "source policy"], deliverable: "Use AI with discipline." }
-        ],
+          {
+            id: "python-basics",
+            title: "Python foundations",
+            phase: "foundation",
+            skills: ["conditions", "loops", "functions"],
+            deliverable: "Write small scripts confidently.",
+            reference_note: "No exact official Python subject PDF was found in the current mirror pack.",
+            subject_refs: [
+              {
+                label: "42 Lausanne - IA",
+                document_title: "42 Lausanne IA page",
+                url: "https://42lausanne.ch/ia/",
+                mirror_path: "42lausanne.ch/ia",
+                tier: "official_42",
+                confidence: "high",
+                coverage: "official_program_signal"
+              }
+            ]
+          },
+          {
+            id: "ai-rag-agents",
+            title: "AI, RAG and agent literacy",
+            phase: "advanced",
+            skills: ["retrieval", "evaluation", "source policy"],
+            deliverable: "Use AI with discipline.",
+            reference_note: "Grounded in the official Lausanne AI page; exact Common Core AI subjects remain interpreted.",
+            subject_refs: [
+              {
+                label: "42 Lausanne - IA",
+                document_title: "42 Lausanne IA page",
+                url: "https://42lausanne.ch/ia/",
+                mirror_path: "42lausanne.ch/ia",
+                tier: "official_42",
+                confidence: "high",
+                coverage: "official_program_signal"
+              }
+            ]
+          }
+        ]
       }
     ],
     bridges: [
       { id: "before_piscine", title: "Before the Piscine", recommended_modules: ["shell:shell-basics", "c:c-basics"] },
       { id: "before_new_common_core", title: "Before the new common core", recommended_modules: ["c:c-memory", "python_ai:ai-rag-agents"] }
-    ]
+    ],
+    curriculum_mapping: {
+      legacy_common_core: {
+        summary: "Historically C and Unix heavy, then concurrency, graphics, C++, network and devops.",
+        preserved_dimensions: ["terminal autonomy", "memory rigor", "oral defense readiness"]
+      },
+      new_common_core_interpretation: {
+        summary: "Algorithms earlier, Python earlier, AI inside the common core.",
+        confidence: "medium",
+        note: "Project naming is still partially interpreted from mirrored packs and infographic signals.",
+        milestones: [
+          { milestone: "M1", projects: ["libft", "push_swap", "printf", "get_next_line"], confidence: "medium" },
+          { milestone: "M2", projects: ["piscine python", "a maze ing", "born2beroot"], confidence: "interpreted" }
+        ],
+        style_analogies: [
+          {
+            legacy_anchor: "C Piscine modules",
+            new_project: "piscine python",
+            rationale: "Bootcamp role preserved, but translated to Python."
+          }
+        ],
+        predicted_project_models: [
+          {
+            id: "piscine-python",
+            title: "piscine python",
+            milestone: "M2",
+            confidence: "interpreted",
+            legacy_style_anchors: ["C Piscine modules C00-C13", "Shell00", "Shell01"],
+            predicted_subject_style: "Small escalating exercises with strict mastery of foundations.",
+            predicted_constraints: ["small scripts", "stdlib only", "explicit functions"],
+            predicted_deliverables: ["ex00..exNN scripts", "tiny CLIs", "simple tests"],
+            predicted_core_skills: ["syntax", "functions", "strings", "objects"]
+          },
+          {
+            id: "a-maze-ing",
+            title: "a maze ing",
+            milestone: "M2",
+            confidence: "interpreted",
+            legacy_style_anchors: ["so_long", "fdf", "fract'ol"],
+            predicted_subject_style: "Maze or grid project mixing parsing, movement and visuals.",
+            predicted_constraints: ["map parsing", "path validation", "loop handling"],
+            predicted_deliverables: ["maze loader", "visualizer", "solver"],
+            predicted_core_skills: ["graphs", "pathfinding", "state handling"]
+          }
+        ]
+      },
+      synthesis: {
+        summary: "Keep old Common Core rigor while preparing for the Python and AI branch.",
+        principles: [
+          "Preserve legacy C rigor.",
+          "Make Python and Bash quality expectations explicit.",
+          "Surface confidence levels for interpreted curriculum elements."
+        ]
+      }
+    }
   },
   progression: {
     learning_plan: {

--- a/docs/42_REFERENCE_STACK.md
+++ b/docs/42_REFERENCE_STACK.md
@@ -1,0 +1,167 @@
+# 42 Training Reference Stack
+
+## Purpose
+
+This document defines the pedagogical and code-quality reference hierarchy for
+`42-training`.
+
+The goal is not to collapse every source into one bucket. The goal is to keep a
+clear order of authority:
+
+1. official public 42 material
+2. verified mirrors of official documents
+3. tooling used to pre-check work
+4. community explanations and mappings
+
+This is especially important because the product now needs to support both:
+
+- the historical C-heavy Common Core
+- the emerging Python and AI lane seen in Lausanne signals and mirrored subject packs
+
+## Absolute References
+
+### Public official sources
+
+- 42 Lausanne pedagogy page
+- 42 Lausanne AI page
+- The Norm v4.1
+- the official `42school/norminette` repository
+
+These sources define the top-level truth model for pedagogy, code quality and
+language expectations where they are explicit.
+
+### Verified mirrors of official documents
+
+Two private reference repositories are now available locally for research:
+
+- `Ninjarsenic/42-piscine`
+- `Ninjarsenic/42-Tronc_commun`
+
+They should be treated as mirrors of official subject packs and support files,
+not as public official publication endpoints.
+
+Practical rule:
+
+- if the mirrored file is clearly an official PDF or support asset, it can be used
+  as ground truth
+- if origin is unclear, keep the source as `medium` confidence until corroborated
+
+## Quality Stack
+
+### C
+
+For C, the reference stack is strict and ordered:
+
+1. The Norm v4.1
+2. norminette
+3. project-specific testers
+4. evaluator review and oral defense
+
+Important nuance:
+
+- norminette checks many objective rules
+- it does not check every subjective or starred rule in the Norm
+- evaluator review still matters for clarity, decomposition and readability
+
+Key Norm constraints that matter product-wise:
+
+- short functions
+- limited parameters and local variables
+- predictable formatting
+- explicit declarations
+- constrained macros and headers
+- English-readable names
+- no hidden global-state shortcuts
+
+### francinette
+
+Francinette is not an official 42 tool and its upstream is archived, but it is
+still pedagogically useful because it models the broader pre-submit workflow.
+
+Reverse-engineered behavior:
+
+- detects the project from the folder and delivery artifacts
+- copies code to a temp workspace
+- runs `norminette`
+- runs `make`
+- dispatches to project-specific testers
+- supports strict modes for memory allocation checks in some projects
+
+This makes francinette useful as a verification harness, not as a source of
+truth.
+
+### mini-moulinette / mini-norminette variants
+
+The exact campus naming is not fully canonical in public sources, but the tool
+family is real and matches the role described by school discussion:
+
+- very fast local pre-submit checks
+- bundled exercise-level test cases
+- score-like feedback that approximates a local moulinette
+
+Use these tools as quick verification aids, never as the pedagogical authority.
+
+## Python and Bash Equivalence
+
+Python and Bash should not imitate the C Norm at the syntax level. They should
+match it in spirit:
+
+- explicitness
+- small understandable units
+- limited hidden behavior
+- readable naming
+- observable test coverage
+- easy debugging
+
+### Python equivalent
+
+Recommended baseline:
+
+- `ruff check`
+- `ruff format`
+- `mypy`
+- `pytest`
+
+What this replaces conceptually:
+
+- Norm formatting discipline -> formatter and lint baseline
+- limited implicit behavior -> typed boundaries and simpler functions
+- evaluator readability pressure -> explicit data flow and testable behavior
+
+### Bash equivalent
+
+Recommended baseline:
+
+- `shellcheck`
+- `shfmt`
+- smoke scripts or `bats`
+
+What this replaces conceptually:
+
+- Norm formatting discipline -> `shfmt`
+- constrained syntax and clarity -> ShellCheck plus quoting discipline
+- reviewer pressure -> readable pipelines, explicit error handling and debuggable scripts
+
+## Curriculum Interpretation Policy
+
+The new Common Core naming visible in the infographic and mirrored documents must
+stay explicitly labeled as interpreted whenever public official publication is
+still incomplete.
+
+Rules:
+
+- keep legacy C/Common Core projects as first-class references
+- expose emerging Python and AI milestones with confidence labels
+- never present inferred project names as fully canonical without saying so
+
+## Product Impact
+
+The application should surface:
+
+- official references
+- mirror references with confidence levels
+- the quality stack per language
+- the distinction between truth, verification and interpretation
+
+This lets the learner train for the old and new tracks at the same time without
+losing the original 42 rigor.

--- a/docs/NEW_TC_PROJECT_PREDICTIONS.md
+++ b/docs/NEW_TC_PROJECT_PREDICTIONS.md
@@ -1,0 +1,230 @@
+# New Common Core Project Predictions
+
+## Status
+
+This document is explicitly interpretive.
+
+It uses three inputs:
+
+- the old versus new Common Core infographic shared in the thread
+- the historical 42 C project sequence
+- the official public Lausanne signals about AI and the currently available mirror packs
+
+It does **not** claim that the predicted subjects below are canon.
+
+## Method
+
+The working hypothesis is that the new Python and AI projects preserve the 42
+pedagogical style of the old C track:
+
+- constrained briefs
+- project-based progression
+- rising system and algorithm difficulty
+- peer evaluation pressure
+- oral defense expectations
+
+What changes is the thematic wrapper and the dominant language.
+
+## Predicted Mappings
+
+### `piscine python`
+
+Legacy style anchor:
+
+- C Piscine modules `C00` to `C13`
+
+Predicted subject style:
+
+- many small Python exercises
+- strict basics before abstraction
+- visible command-line behavior
+- progressive move from syntax to data structures to small OOP units
+
+Likely deliverables:
+
+- `ex00..exNN` scripts
+- tiny CLIs
+- elementary utility functions
+- local test examples
+
+Likely constraints:
+
+- stdlib-first
+- no framework magic
+- clear function boundaries
+- strong edge-case pressure
+
+### `a maze ing`
+
+Legacy style anchors:
+
+- `so_long`
+- `fdf`
+- `fract'ol`
+
+Predicted subject style:
+
+- maze or grid problem
+- parsing + movement + validation
+- light graphics or visual feedback
+- algorithmic traversal, not just rendering
+
+Likely deliverables:
+
+- map parser
+- maze visualizer
+- solver or validator
+- game loop or turn loop
+
+### `codexion`
+
+Legacy style anchor:
+
+- `philo`
+
+Predicted subject style:
+
+- concurrency under Python constraints
+- scheduling, coordination, workers, locks or queues
+- emphasis on observability and race debugging
+
+Likely deliverables:
+
+- multi-worker engine
+- task orchestration layer
+- reproducible logs
+- timeout and shutdown handling
+
+### `fly in`
+
+Legacy style anchor:
+
+- `push_swap`
+
+Predicted subject style:
+
+- scored algorithm challenge
+- optimization under an action model
+- explanation of strategy matters
+
+Likely deliverables:
+
+- solver
+- trace of actions
+- benchmark or scorer
+- comparison of strategies
+
+### `call me maybe`
+
+Legacy style anchors:
+
+- `pipex`
+- `minitalk`
+
+Predicted subject style:
+
+- communication-oriented Python project
+- protocol or payload discipline
+- possible model-calling or function-calling semantics
+- strong focus on failure handling and tracing
+
+Likely deliverables:
+
+- caller/router
+- structured messages
+- mock or real tool/model interface
+- observable logs
+
+### `pacman`
+
+Legacy style anchors:
+
+- `cub3d`
+- `so_long`
+
+Predicted subject style:
+
+- playable project
+- movement and entity logic
+- maybe enemy AI or rule-based behaviors
+- readability matters more than graphical bravado
+
+Likely deliverables:
+
+- map
+- entities
+- scoring logic
+- visual runtime
+
+### `RAG against the machine`
+
+Legacy style anchor:
+
+- no exact old-track equivalent, but same capstone pressure
+
+Predicted subject style:
+
+- real retrieval pipeline
+- source indexing before generation
+- evaluation and citations
+- explicit anti-handwaving constraints
+
+Likely deliverables:
+
+- ingestion pipeline
+- retriever
+- answer generator with citations
+- evaluation report
+
+### `the answer protocol`
+
+Legacy style anchors:
+
+- `net_practice`
+- `ft_irc`
+- `webserv`
+
+Predicted subject style:
+
+- protocol and network semantics
+- structured exchanges
+- testing interoperability
+- less raw socket machismo, more contract discipline
+
+Likely deliverables:
+
+- protocol spec
+- server or broker
+- reference client
+- conformance tests
+
+### `agent smith`
+
+Legacy style anchors:
+
+- advanced orchestration capstones
+- part of the conceptual pressure once carried by later infra and large-system projects
+
+Predicted subject style:
+
+- multi-agent orchestration
+- tool use, context passing, memory and policy
+- explicit success metrics and evaluation scenarios
+
+Likely deliverables:
+
+- agent architecture
+- role policies
+- tool adapters
+- benchmark scenarios
+
+## Reading Rule
+
+These predictions should be used to:
+
+- prepare the curriculum structure
+- design learning rubrics
+- anticipate likely constraints
+
+They should not be presented as official 42 subject truth without a confidence
+label and source explanation.

--- a/docs/adr/0002-source-governance-and-rag-policy.md
+++ b/docs/adr/0002-source-governance-and-rag-policy.md
@@ -8,6 +8,8 @@
 A learning product for 42-related preparation will inevitably encounter:
 
 - official campus information
+- official normative documents such as The Norm
+- mirrored repositories that contain official subject PDFs or support files
 - community guides
 - testers
 - solution repositories
@@ -22,6 +24,7 @@ The product will enforce a tiered source policy.
 Allowed tiers:
 
 - `official_42`: ground truth
+- `official_document_mirrors`: ground truth when the mirrored document origin is verified
 - `community_docs`: explanation and mapping
 - `testers_and_tooling`: verification
 - `solution_metadata`: path mapping only
@@ -36,6 +39,7 @@ Positive:
 - preserves pedagogical integrity
 - makes RAG behavior auditable
 - clarifies what is authoritative versus interpretive
+- makes private or mirrored official document packs usable without pretending they are public official publication endpoints
 - allows community material without turning the app into a cheating tool
 
 Negative:

--- a/docs/adr/0008-official-reference-stack-and-quality-equivalence.md
+++ b/docs/adr/0008-official-reference-stack-and-quality-equivalence.md
@@ -1,0 +1,63 @@
+# ADR 0008: Official Reference Stack and Cross-Language Quality Equivalence
+
+- Status: accepted
+- Date: 2026-03-29
+
+## Context
+
+`42-training` now has access to stronger pedagogical references than the initial MVP:
+
+- The Norm v4.1 as the current official C standard
+- mirrored repositories containing current official subject PDFs and exercise packs
+- school feedback that real pre-submit practice often involves `norminette`, `francinette` and smaller local tester variants
+- an emerging Python and AI common-core lane that should not erase the rigor of the legacy C path
+
+The product therefore needs a stable decision on:
+
+- what counts as absolute pedagogical truth
+- what counts as verification tooling rather than truth
+- how to translate the spirit of 42 code rigor into Python and Bash without pretending those languages should follow C syntax rules
+
+## Decision
+
+The product will adopt the following reference model:
+
+- The Norm v4.1 is the absolute code-quality and pedagogical reference for C.
+- Public 42 pages and official normative documents remain the highest-authority sources.
+- Private or community-hosted mirrors of official documents are accepted as ground truth only when the mirrored origin is explicit and verified.
+- `norminette` is treated as the official automated checker for the objective subset of the Norm, not as a full replacement for evaluator review.
+- `francinette` and mini-moulinette or mini-norminette style tools are treated as verification harnesses, not as normative truth.
+- Python and Bash tracks must use coherent quality equivalents:
+  - Python: `ruff`, `mypy`, `pytest`, short explicit functions, typed boundaries, observable behavior
+  - Bash: `shellcheck`, `shfmt`, shell smoke tests, explicit quoting, fail-fast habits, readable command composition
+
+The application must expose this reference stack directly in its curriculum and UI so that pedagogy, source policy and quality expectations stay aligned.
+
+## Consequences
+
+Positive:
+
+- preserves the historical 42 C rigor as a first-class reference
+- makes the new Python lane compatible with the old standards in spirit rather than by superficial imitation
+- distinguishes official truth from mirrors, testers and community guidance
+- gives the UI and future RAG layers a stable model for confidence and tool recommendations
+
+Negative:
+
+- requires ongoing maintenance as the new curriculum becomes more public and less inferred
+- creates a broader reference surface than the initial MVP
+- some community tooling is archived or platform-fragile and must be presented with caveats
+
+## Rejected Alternatives
+
+### Treat all testers as authoritative
+
+Rejected because testers approximate evaluation behavior but do not define the pedagogical standard.
+
+### Reuse the C Norm verbatim for Python and Bash
+
+Rejected because equivalent rigor matters more than syntactic mimicry.
+
+### Ignore the emerging Python lane until the school publishes everything
+
+Rejected because the product goal is explicitly to prepare for both the legacy and emerging Common Core shapes while keeping confidence levels visible.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ This directory stores the key architecture decisions for `42-training`.
 - `0005-api-as-system-of-record.md`
 - `0006-multi-agent-role-model-and-orchestration.md`
 - `0007-postgresql-migration-strategy.md`
+- `0008-official-reference-stack-and-quality-equivalence.md`
 
 ## Purpose
 

--- a/packages/curriculum/data/42_lausanne_curriculum.json
+++ b/packages/curriculum/data/42_lausanne_curriculum.json
@@ -1,9 +1,10 @@
 {
   "metadata": {
     "campus": "42 Lausanne",
-    "updated_on": "2026-03-27",
-    "status": "mvp",
-    "positioning": "triple-track learning app for shell, C, Python and AI literacy"
+    "updated_on": "2026-03-29",
+    "status": "reference-refresh",
+    "positioning": "triple-track learning app for shell, legacy C rigor, emerging Python and AI literacy",
+    "reference_posture": "official public documents first, verified mirrors second, community tooling as verification only"
   },
   "source_policy": {
     "tiers": [
@@ -11,6 +12,11 @@
         "id": "official_42",
         "label": "Official 42 sources",
         "allowed_usage": "ground_truth"
+      },
+      {
+        "id": "official_document_mirrors",
+        "label": "Mirrors of official documents",
+        "allowed_usage": "ground_truth_when_origin_is_verified"
       },
       {
         "id": "community_docs",
@@ -32,6 +38,216 @@
         "label": "Direct solution content",
         "allowed_usage": "blocked_by_default"
       }
+    ],
+    "confidence_model": [
+      {
+        "level": "high",
+        "meaning": "Official public 42 page or official normative PDF."
+      },
+      {
+        "level": "medium",
+        "meaning": "Official document mirrored in a private reference repository or corroborated by staff discussion."
+      },
+      {
+        "level": "interpreted",
+        "meaning": "Curriculum hypothesis inferred from infographic, naming leaks or community mapping and kept explicit as interpretation."
+      }
+    ]
+  },
+  "reference_stack": {
+    "official_documents": [
+      {
+        "label": "42 Lausanne - pedagogie",
+        "url": "https://42lausanne.ch/pedagogie-42/",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "campus pedagogy and learning model"
+      },
+      {
+        "label": "42 Lausanne - IA",
+        "url": "https://42lausanne.ch/ia/",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "public signal that AI is now inside the Lausanne positioning"
+      },
+      {
+        "label": "The Norm v4.1 (English PDF)",
+        "url": "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "absolute code-quality and pedagogical reference for C projects"
+      },
+      {
+        "label": "42School/norminette",
+        "url": "https://github.com/42school/norminette",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "reference implementation of objective Norm checks"
+      }
+    ],
+    "official_document_mirrors": [
+      {
+        "label": "Ninjarsenic/42-Tronc_commun",
+        "url": "https://github.com/Ninjarsenic/42-Tronc_commun",
+        "tier": "official_document_mirrors",
+        "confidence": "medium",
+        "usage": "private mirror of current official Common Core subjects and support files",
+        "note": "Treat document content as authoritative only when the mirrored file origin is explicit."
+      },
+      {
+        "label": "Ninjarsenic/42-piscine",
+        "url": "https://github.com/Ninjarsenic/42-piscine",
+        "tier": "official_document_mirrors",
+        "confidence": "medium",
+        "usage": "private mirror of current official Piscine exercises and supporting assets",
+        "note": "Useful for shell and early C foundations, but still distinct from public official publication."
+      }
+    ],
+    "quality_stack": [
+      {
+        "id": "norm_v4_1",
+        "label": "The Norm v4.1",
+        "url": "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+        "language": "c",
+        "kind": "official_standard",
+        "authority": "absolute_reference",
+        "role": "Defines naming, formatting, function, header, macro and file constraints for Common Core C."
+      },
+      {
+        "id": "norminette",
+        "label": "norminette",
+        "url": "https://github.com/42school/norminette",
+        "language": "c",
+        "kind": "official_checker",
+        "authority": "official_tool",
+        "role": "Automates objective Norm checks; starred subjective rules still require human review."
+      },
+      {
+        "id": "francinette",
+        "label": "francinette",
+        "url": "https://github.com/xicodomingues/francinette",
+        "language": "c",
+        "kind": "community_local_moulinette",
+        "authority": "verification_only",
+        "role": "Runs norminette, make, project detection and project-specific tester suites locally.",
+        "note": "Archived and outdated upstream, but still useful to understand expected pre-submit checks."
+      },
+      {
+        "id": "mini_moulinette",
+        "label": "mini-moulinette / mini-norminette variants",
+        "url": "https://github.com/k11q/mini-moulinette",
+        "language": "c",
+        "kind": "community_micro_tester",
+        "authority": "verification_only",
+        "role": "Fast local assignment harness for Piscine-style exercises with bundled edge cases.",
+        "note": "Campus naming may vary; model this family as representative rather than canonical."
+      },
+      {
+        "id": "ruff",
+        "label": "ruff",
+        "url": "https://github.com/astral-sh/ruff",
+        "language": "python",
+        "kind": "lint_and_format",
+        "authority": "equivalent_quality_gate",
+        "role": "Closest Python equivalent to objective formatting plus obvious bad-pattern enforcement."
+      },
+      {
+        "id": "mypy",
+        "label": "mypy",
+        "url": "https://github.com/python/mypy",
+        "language": "python",
+        "kind": "type_checker",
+        "authority": "equivalent_quality_gate",
+        "role": "Keeps interfaces explicit and reduces hidden dynamic behavior in learning code."
+      },
+      {
+        "id": "pytest",
+        "label": "pytest",
+        "url": "https://pytest.org/",
+        "language": "python",
+        "kind": "test_runner",
+        "authority": "equivalent_quality_gate",
+        "role": "Makes understanding observable through explicit examples and edge-case checks."
+      },
+      {
+        "id": "shellcheck",
+        "label": "ShellCheck",
+        "url": "https://www.shellcheck.net/",
+        "language": "bash",
+        "kind": "lint",
+        "authority": "equivalent_quality_gate",
+        "role": "Catches quoting, globbing, subshell and portability mistakes in shell scripts."
+      },
+      {
+        "id": "shfmt",
+        "label": "shfmt",
+        "url": "https://github.com/mvdan/sh",
+        "language": "bash",
+        "kind": "formatter",
+        "authority": "equivalent_quality_gate",
+        "role": "Provides a stable shell formatting baseline analogous to Norm look-and-feel discipline."
+      },
+      {
+        "id": "bats",
+        "label": "bats",
+        "url": "https://github.com/bats-core/bats-core",
+        "language": "bash",
+        "kind": "test_runner",
+        "authority": "equivalent_quality_gate",
+        "role": "Makes shell behavior testable instead of relying only on manual terminal checks."
+      }
+    ],
+    "quality_equivalents": [
+      {
+        "language": "c",
+        "positioning": "Absolute reference track. Keep the historical 42 rigor intact.",
+        "quality_contract": "The Norm v4.1 is the default source of truth, norminette checks the objective subset, and project-specific testers plus evaluator review cover behavior and subjective quality.",
+        "automated_gates": [
+          "norminette",
+          "cc -Wall -Wextra -Werror",
+          "project testers",
+          "valgrind or leak checks when relevant"
+        ],
+        "human_review_focus": [
+          "clarity of decomposition",
+          "reasoning under constraints",
+          "defense readiness",
+          "starred Norm items not enforced by norminette"
+        ]
+      },
+      {
+        "language": "python",
+        "positioning": "Equivalent rigor without pretending Python should mimic C syntax.",
+        "quality_contract": "Prefer short explicit functions, predictable IO, typed boundaries, no hidden magic, and tests for happy path plus edge cases.",
+        "automated_gates": [
+          "ruff check",
+          "ruff format",
+          "mypy",
+          "pytest"
+        ],
+        "human_review_focus": [
+          "data-flow readability",
+          "controlled abstraction",
+          "algorithmic explanations",
+          "no blind framework dependence"
+        ]
+      },
+      {
+        "language": "bash",
+        "positioning": "Terminal-first discipline aligned with Piscine pressure and automation habits.",
+        "quality_contract": "Scripts must be explicit, quote correctly, fail loudly, stay small, and remain readable under shell constraints.",
+        "automated_gates": [
+          "shellcheck",
+          "shfmt",
+          "bats or smoke scripts"
+        ],
+        "human_review_focus": [
+          "command composition",
+          "quoting and expansion safety",
+          "error-path handling",
+          "debuggability in a terminal session"
+        ]
+      }
     ]
   },
   "tracks": [
@@ -46,93 +262,351 @@
           "title": "Navigation and files",
           "phase": "foundation",
           "skills": ["pwd", "ls", "cd", "mkdir", "touch", "cp", "mv", "rm"],
-          "deliverable": "Navigate, create, copy and clean files without hesitation."
+          "deliverable": "Navigate, create, copy and clean files without hesitation.",
+          "reference_note": "This app module aligns directly with the first official Shell Piscine subject available in the mirrored repository.",
+          "subject_refs": [
+            {
+              "label": "Shell00 subject PDF",
+              "document_title": "Piscine C Shell 00",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell00/fr.subject.pdf",
+              "mirror_path": "Shell00/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            }
+          ]
         },
         {
           "id": "shell-streams",
           "title": "Redirections and pipes",
           "phase": "foundation",
           "skills": ["stdin", "stdout", "stderr", "redirect", "append", "pipe", "grep"],
-          "deliverable": "Compose useful shell chains and inspect text quickly."
+          "deliverable": "Compose useful shell chains and inspect text quickly.",
+          "reference_note": "This app module is extracted from the broader Shell01 official subject.",
+          "subject_refs": [
+            {
+              "label": "Shell01 subject PDF",
+              "document_title": "Piscine C Shell 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell01/fr.subject%20(1).pdf",
+              "mirror_path": "Shell01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "shell-permissions",
           "title": "Permissions and execution",
           "phase": "foundation",
           "skills": ["chmod", "ownership", "executable bit", "PATH"],
-          "deliverable": "Understand why a script runs or fails."
+          "deliverable": "Understand why a script runs or fails.",
+          "reference_note": "Permissions and execution habits are modeled from the official Shell01 subject because the app splits the official subject into finer pedagogical modules.",
+          "subject_refs": [
+            {
+              "label": "Shell01 subject PDF",
+              "document_title": "Piscine C Shell 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell01/fr.subject%20(1).pdf",
+              "mirror_path": "Shell01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "shell-tooling",
           "title": "Linux work habits",
           "phase": "practice",
           "skills": ["find", "history", "man", "vim basics", "git basics"],
-          "deliverable": "Operate daily in Linux without depending on GUI reflexes."
+          "deliverable": "Operate daily in Linux without depending on GUI reflexes.",
+          "reference_note": "This module synthesizes habits spread across the official Shell00 and Shell01 subjects rather than corresponding to a single official PDF.",
+          "subject_refs": [
+            {
+              "label": "Shell00 subject PDF",
+              "document_title": "Piscine C Shell 00",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell00/fr.subject.pdf",
+              "mirror_path": "Shell00/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "Shell01 subject PDF",
+              "document_title": "Piscine C Shell 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell01/fr.subject%20(1).pdf",
+              "mirror_path": "Shell01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         }
       ]
     },
     {
       "id": "c",
       "title": "C / Core 42",
-      "summary": "Low-level rigor track aligned with the core 42 mindset.",
-      "why_it_matters": "Build algorithmic reasoning, memory discipline and debugging habits.",
+      "summary": "Low-level rigor track aligned with the historical and still essential 42 backbone.",
+      "why_it_matters": "Build algorithmic reasoning, memory discipline, debugging habits and defense-ready explanations.",
       "modules": [
         {
           "id": "c-basics",
           "title": "Syntax and control flow",
           "phase": "foundation",
           "skills": ["variables", "conditions", "loops", "functions", "headers"],
-          "deliverable": "Write small programs cleanly and compile with warnings enabled."
+          "deliverable": "Write small programs cleanly and compile with warnings enabled.",
+          "reference_note": "This app module condenses several official Piscine subjects that collectively build syntax, expressions, functions and control flow.",
+          "subject_refs": [
+            {
+              "label": "C00 subject PDF",
+              "document_title": "Piscine C C 00",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C00/fr.subject.pdf",
+              "mirror_path": "C00/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C03 subject PDF",
+              "document_title": "C Piscine C 03",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C03/en.subject.pdf",
+              "mirror_path": "C03/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C04 subject PDF",
+              "document_title": "Piscine C C 04",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C04/fr.subject.pdf",
+              "mirror_path": "C04/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C05 subject PDF",
+              "document_title": "Piscine C C 05",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C05/fr.subject%20(1).pdf",
+              "mirror_path": "C05/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C06 subject PDF",
+              "document_title": "Piscine C C 06",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C06/fr.subject.pdf",
+              "mirror_path": "C06/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "c-memory",
           "title": "Pointers and memory",
           "phase": "foundation",
           "skills": ["addresses", "pointers", "arrays", "strings", "malloc", "free"],
-          "deliverable": "Explain memory decisions and avoid basic leaks."
+          "deliverable": "Explain memory decisions and avoid basic leaks.",
+          "reference_note": "This app module spans the official pointer, string and allocation parts of the Piscine rather than one single subject.",
+          "subject_refs": [
+            {
+              "label": "C01 subject PDF",
+              "document_title": "Piscine C C 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C01/fr.subject%20(1).pdf",
+              "mirror_path": "C01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C02 subject PDF",
+              "document_title": "Piscine C C 02",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C02/fr.subject.pdf",
+              "mirror_path": "C02/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C07 subject PDF",
+              "document_title": "C Piscine C 07",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C07/en.subject.pdf",
+              "mirror_path": "C07/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "c-build-debug",
           "title": "Build, tests and debug",
           "phase": "practice",
           "skills": ["cc", "Wall", "Wextra", "Werror", "gdb", "valgrind"],
-          "deliverable": "Investigate failures instead of guessing."
+          "deliverable": "Investigate failures instead of guessing.",
+          "reference_note": "This module ties the official Norm to the first Common Core projects where build discipline, fd debugging and constrained APIs become concrete.",
+          "subject_refs": [
+            {
+              "label": "The Norm v4.1 PDF",
+              "document_title": "The Norm",
+              "url": "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+              "mirror_path": "42school/norminette/pdf/en.norm.pdf",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "Libft subject PDF",
+              "document_title": "Libft",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Libft/en.subject.pdf",
+              "mirror_path": "Libft/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "ft_printf subject PDF",
+              "document_title": "ft_printf",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject%20(1).pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "Get Next Line subject PDF",
+              "document_title": "Get Next Line",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject.pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "c-libft-pushswap-bridge",
           "title": "Library and algorithm bridge",
           "phase": "core",
           "skills": ["libft mindset", "API naming", "sorting logic", "complexity intuition"],
-          "deliverable": "Prepare for libft, printf, gnl and push_swap logic."
+          "deliverable": "Prepare for libft, printf, gnl and push_swap logic.",
+          "reference_note": "This module is intentionally bound to the exact first Common Core project subjects that bridge utility libraries, file descriptors and constrained sorting.",
+          "subject_refs": [
+            {
+              "label": "Libft subject PDF",
+              "document_title": "Libft",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Libft/en.subject.pdf",
+              "mirror_path": "Libft/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "ft_printf subject PDF",
+              "document_title": "ft_printf",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject%20(1).pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "Get Next Line subject PDF",
+              "document_title": "Get Next Line",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject.pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "Push_swap subject PDF",
+              "document_title": "Push_swap",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%202/Push_swap/en.subject%20(3).pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 2/Push_swap/en.subject (3).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            }
+          ]
         }
       ]
     },
     {
       "id": "python_ai",
       "title": "Python + AI",
-      "summary": "Python foundations plus the modern AI axis now present in 42 Lausanne.",
-      "why_it_matters": "Prepare for the new branch without weakening shell and C fundamentals.",
+      "summary": "Python foundations plus the modern AI axis now visible in 42 Lausanne.",
+      "why_it_matters": "Prepare for the emerging branch without weakening shell and C fundamentals.",
       "modules": [
         {
           "id": "python-basics",
           "title": "Python foundations",
           "phase": "foundation",
           "skills": ["variables", "conditions", "loops", "functions", "collections"],
-          "deliverable": "Write and explain small scripts confidently."
+          "deliverable": "Write and explain small scripts confidently.",
+          "reference_note": "No exact official Python subject PDF was found in the currently available official mirrors on 2026-03-29. This module is therefore anchored to the official Lausanne AI program page and to the interpreted new Common Core mapping.",
+          "subject_refs": [
+            {
+              "label": "42 Lausanne - IA",
+              "document_title": "42 Lausanne IA page",
+              "url": "https://42lausanne.ch/ia/",
+              "mirror_path": "42lausanne.ch/ia",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            }
+          ]
         },
         {
           "id": "python-oop-scripting",
           "title": "Objects and automation",
           "phase": "practice",
           "skills": ["classes", "methods", "files", "json", "argparse"],
-          "deliverable": "Build useful utilities and simple models."
+          "deliverable": "Build useful utilities and simple models.",
+          "reference_note": "No exact official Python OOP subject PDF is present in the current mirrored packs. This module stays tied to the official Lausanne AI axis while awaiting exact subject publication.",
+          "subject_refs": [
+            {
+              "label": "42 Lausanne - IA",
+              "document_title": "42 Lausanne IA page",
+              "url": "https://42lausanne.ch/ia/",
+              "mirror_path": "42lausanne.ch/ia",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            }
+          ]
         },
         {
           "id": "ai-rag-agents",
           "title": "AI, RAG and agent literacy",
           "phase": "advanced",
           "skills": ["prompt design", "retrieval", "evaluation", "agent workflow", "source policy"],
-          "deliverable": "Use AI as a disciplined tool without outsourcing understanding."
+          "deliverable": "Use AI as a disciplined tool without outsourcing understanding.",
+          "reference_note": "The official public anchor is the Lausanne AI page. Exact Common Core AI subject PDFs are not yet present in the currently available mirror pack, so the app keeps the downstream project names explicitly interpreted.",
+          "subject_refs": [
+            {
+              "label": "42 Lausanne - IA",
+              "document_title": "42 Lausanne IA page",
+              "url": "https://42lausanne.ch/ia/",
+              "mirror_path": "42lausanne.ch/ia",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            },
+            {
+              "label": "42 Lausanne - pedagogie",
+              "document_title": "42 Lausanne pedagogie page",
+              "url": "https://42lausanne.ch/pedagogie-42/",
+              "mirror_path": "42lausanne.ch/pedagogie-42",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            }
+          ]
         }
       ]
     }
@@ -178,12 +652,19 @@
         "webserv or irc",
         "inception",
         "transcendance"
+      ],
+      "preserved_dimensions": [
+        "terminal autonomy",
+        "memory rigor",
+        "algorithmic discipline",
+        "system and network intuition",
+        "oral defense readiness"
       ]
     },
     "new_common_core_interpretation": {
       "summary": "Algorithms earlier, Python earlier, AI inside the common core, still grounded in systems thinking.",
       "confidence": "medium",
-      "note": "Project names beyond official public category statements come from infographic interpretation and community mapping.",
+      "note": "Project names beyond official public category statements come from infographic interpretation, mirrored documents and school discussion.",
       "examples": [
         "libft",
         "push_swap",
@@ -202,6 +683,275 @@
         "the answer protocol",
         "agent smith",
         "transcendance"
+      ],
+      "milestones": [
+        {
+          "milestone": "M1",
+          "projects": ["libft", "push_swap", "printf", "get_next_line"],
+          "confidence": "medium"
+        },
+        {
+          "milestone": "M2",
+          "projects": ["piscine python", "a maze ing", "born2beroot"],
+          "confidence": "interpreted"
+        },
+        {
+          "milestone": "M3",
+          "projects": ["codexion", "fly in", "call me maybe"],
+          "confidence": "interpreted"
+        },
+        {
+          "milestone": "M4",
+          "projects": ["net_practice", "pacman", "RAG against the machine"],
+          "confidence": "interpreted"
+        },
+        {
+          "milestone": "M5+",
+          "projects": ["inception", "the answer protocol", "agent smith", "transcendance"],
+          "confidence": "interpreted"
+        }
+      ],
+      "style_analogies": [
+        {
+          "legacy_anchor": "C Piscine modules",
+          "new_project": "piscine python",
+          "rationale": "Same bootcamp role, but likely translated from low-level drills into Python fundamentals and OOP ramp-up."
+        },
+        {
+          "legacy_anchor": "so_long / fdf / fract'ol",
+          "new_project": "a maze ing",
+          "rationale": "Graphical or spatial reasoning project with a friendlier Python surface and stronger maze/game semantics."
+        },
+        {
+          "legacy_anchor": "philo",
+          "new_project": "codexion",
+          "rationale": "Concurrency slot remains present, likely reframed around Python execution models, coordination or agent scheduling."
+        },
+        {
+          "legacy_anchor": "push_swap",
+          "new_project": "fly in",
+          "rationale": "Algorithm slot persists and probably keeps the optimization mindset while changing the thematic wrapper."
+        },
+        {
+          "legacy_anchor": "pipex / minitalk",
+          "new_project": "call me maybe",
+          "rationale": "Communication and system-interaction style challenge may be reinterpreted as Python protocol, messaging or model-calling flows."
+        },
+        {
+          "legacy_anchor": "cub3d / mini_rt",
+          "new_project": "pacman",
+          "rationale": "A later graphical project remains, but the new name suggests game AI and grid behavior rather than pure rendering bravado."
+        },
+        {
+          "legacy_anchor": "net_practice / irc / webserv",
+          "new_project": "the answer protocol",
+          "rationale": "Network and protocol literacy appears preserved, possibly in a more application-protocol or agent-interaction framing."
+        },
+        {
+          "legacy_anchor": "advanced orchestration capstones",
+          "new_project": "agent smith",
+          "rationale": "The IA capstone slot likely expects multi-agent thinking, workflow control and autonomy under constraints."
+        }
+      ],
+      "predicted_project_models": [
+        {
+          "id": "piscine-python",
+          "title": "piscine python",
+          "milestone": "M2",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["C Piscine modules C00-C13", "Shell00", "Shell01"],
+          "predicted_subject_style": "Series of small exercises with escalating difficulty, explicit IO, deterministic outputs and strict basic language mastery.",
+          "predicted_constraints": [
+            "small standalone Python files",
+            "stdlib only or near-stdlib-only",
+            "explicit function decomposition",
+            "manual edge-case handling before abstraction"
+          ],
+          "predicted_deliverables": [
+            "ex00..exNN scripts",
+            "tiny reusable functions",
+            "simple CLI-oriented programs",
+            "light local tests or examples"
+          ],
+          "predicted_core_skills": ["python syntax", "functions", "strings", "lists", "dicts", "basic objects"]
+        },
+        {
+          "id": "a-maze-ing",
+          "title": "a maze ing",
+          "milestone": "M2",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["so_long", "fdf", "fract'ol"],
+          "predicted_subject_style": "Maze or grid-based graphical project where parsing, movement rules and algorithmic traversal matter as much as rendering.",
+          "predicted_constraints": [
+            "map parsing",
+            "event loop or turn loop",
+            "path validity checks",
+            "clear separation between model, rules and display"
+          ],
+          "predicted_deliverables": [
+            "maze loader",
+            "playable or solvable maze experience",
+            "pathfinding helper or validator",
+            "graphical or terminal visualizer"
+          ],
+          "predicted_core_skills": ["graphs", "pathfinding", "state machines", "Python graphics tooling", "clean module boundaries"]
+        },
+        {
+          "id": "codexion",
+          "title": "codexion",
+          "milestone": "M3",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["philo"],
+          "predicted_subject_style": "Concurrency project with Python-specific coordination tradeoffs rather than raw pthread mechanics.",
+          "predicted_constraints": [
+            "threading or multiprocessing",
+            "timeouts and lifecycle control",
+            "shared-state discipline",
+            "observable logs for debugging races"
+          ],
+          "predicted_deliverables": [
+            "task orchestrator",
+            "worker pool or actor model",
+            "concurrency-safe simulation",
+            "debuggable execution traces"
+          ],
+          "predicted_core_skills": ["threads", "processes", "queues", "locks", "resource contention", "reproducibility"]
+        },
+        {
+          "id": "fly-in",
+          "title": "fly in",
+          "milestone": "M3",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["push_swap"],
+          "predicted_subject_style": "Algorithm project scored on solution quality, where Python is allowed but the optimization pressure remains.",
+          "predicted_constraints": [
+            "strict scoring metric",
+            "limited action model",
+            "deterministic algorithm explanation",
+            "tradeoff analysis between correctness and efficiency"
+          ],
+          "predicted_deliverables": [
+            "solver",
+            "action trace",
+            "benchmark mode",
+            "explanation of chosen strategy"
+          ],
+          "predicted_core_skills": ["algorithms", "heuristics", "complexity", "search", "benchmarking"]
+        },
+        {
+          "id": "call-me-maybe",
+          "title": "call me maybe",
+          "milestone": "M3",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["pipex", "minitalk"],
+          "predicted_subject_style": "Communication-oriented Python exercise centered on message exchange, tool calling or controlled AI interaction.",
+          "predicted_constraints": [
+            "protocol contract",
+            "input validation",
+            "retry or failure handling",
+            "tight logging of calls and outputs"
+          ],
+          "predicted_deliverables": [
+            "message router or caller",
+            "structured payload format",
+            "mock or real model interaction",
+            "traceable conversation or execution log"
+          ],
+          "predicted_core_skills": ["serialization", "protocol design", "subprocess or API calls", "observability", "guardrails"]
+        },
+        {
+          "id": "pacman",
+          "title": "pacman",
+          "milestone": "M4",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["cub3d", "so_long"],
+          "predicted_subject_style": "Game-oriented graphical project where Python is used to manage entities, movement rules and maybe simple AI.",
+          "predicted_constraints": [
+            "real-time or tick-based updates",
+            "entity movement rules",
+            "collision checks",
+            "playable loop with readable architecture"
+          ],
+          "predicted_deliverables": [
+            "game map",
+            "player and enemy logic",
+            "score or objective system",
+            "visual runtime"
+          ],
+          "predicted_core_skills": ["game loops", "state updates", "event handling", "graphical assets", "light AI behavior"]
+        },
+        {
+          "id": "rag-against-the-machine",
+          "title": "RAG against the machine",
+          "milestone": "M4",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["research-heavy capstone extension"],
+          "predicted_subject_style": "RAG system project where learners must index sources, retrieve context and evaluate answer quality instead of just calling a model blindly.",
+          "predicted_constraints": [
+            "explicit corpus management",
+            "retrieval before generation",
+            "source attribution",
+            "evaluation set or benchmark"
+          ],
+          "predicted_deliverables": [
+            "ingestion pipeline",
+            "retriever",
+            "answer generator with citations",
+            "evaluation report"
+          ],
+          "predicted_core_skills": ["embeddings", "chunking", "ranking", "prompting", "evaluation", "source governance"]
+        },
+        {
+          "id": "the-answer-protocol",
+          "title": "the answer protocol",
+          "milestone": "M5+",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["net_practice", "ft_irc", "webserv"],
+          "predicted_subject_style": "Protocol design and networked communication project, likely focused on structured exchanges for modern systems or AI services.",
+          "predicted_constraints": [
+            "client/server contract",
+            "message framing",
+            "error codes or negotiation rules",
+            "interoperable test scenarios"
+          ],
+          "predicted_deliverables": [
+            "protocol spec",
+            "reference server or broker",
+            "test client",
+            "conformance tests"
+          ],
+          "predicted_core_skills": ["network IO", "protocol semantics", "serialization", "testing distributed behavior"]
+        },
+        {
+          "id": "agent-smith",
+          "title": "agent smith",
+          "milestone": "M5+",
+          "confidence": "interpreted",
+          "legacy_style_anchors": ["inception", "advanced orchestrated projects"],
+          "predicted_subject_style": "Autonomous multi-agent capstone where orchestration, tools, memory and safeguards matter more than raw model calls.",
+          "predicted_constraints": [
+            "multiple cooperating roles",
+            "tool use and context passing",
+            "policy constraints",
+            "observable success criteria"
+          ],
+          "predicted_deliverables": [
+            "agent architecture",
+            "role prompts or policies",
+            "tool adapters",
+            "evaluation scenario suite"
+          ],
+          "predicted_core_skills": ["orchestration", "multi-agent workflows", "tooling", "memory", "evaluation", "safety"]
+        }
+      ]
+    },
+    "synthesis": {
+      "summary": "The product keeps the old Common Core depth while modeling the emerging Python and AI lane as a coherent extension, not a replacement.",
+      "principles": [
+        "Preserve legacy C rigor even when the learner path is Python-first.",
+        "Treat the Norm as absolute for C and use principled equivalents for Python and Bash.",
+        "Expose confidence levels whenever the new curriculum naming is still interpreted rather than public and canonical.",
+        "Use official subject mirrors to enrich pedagogy without claiming they are public official publication endpoints."
       ]
     }
   },
@@ -217,19 +967,39 @@
       "tier": "official_42"
     },
     {
-      "label": "awesome-42",
-      "url": "https://github.com/leeoocca/awesome-42",
-      "tier": "community_docs"
+      "label": "The Norm v4.1 (English PDF)",
+      "url": "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+      "tier": "official_42"
+    },
+    {
+      "label": "Ninjarsenic/42-Tronc_commun",
+      "url": "https://github.com/Ninjarsenic/42-Tronc_commun",
+      "tier": "official_document_mirrors"
+    },
+    {
+      "label": "Ninjarsenic/42-piscine",
+      "url": "https://github.com/Ninjarsenic/42-piscine",
+      "tier": "official_document_mirrors"
     },
     {
       "label": "norminette",
       "url": "https://github.com/42school/norminette",
+      "tier": "official_42"
+    },
+    {
+      "label": "francinette",
+      "url": "https://github.com/xicodomingues/francinette",
       "tier": "testers_and_tooling"
     },
     {
-      "label": "libftTester",
-      "url": "https://github.com/Tripouille/libftTester",
+      "label": "mini-moulinette",
+      "url": "https://github.com/k11q/mini-moulinette",
       "tier": "testers_and_tooling"
+    },
+    {
+      "label": "awesome-42",
+      "url": "https://github.com/leeoocca/awesome-42",
+      "tier": "community_docs"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- integrate the official 42 reference stack into the curriculum, ADRs and homepage
- attach granular module-level subject refs to mirrored official PDFs where available
- add explicit interpreted predictions for the new Python and AI common-core projects based on the old-vs-new TC mapping

## Validation
- npm run build
- pytest (services/api)
- pytest (services/ai_gateway)