### PR TITLE
feat: prepare core SQLAlchemy models (#49)

### DIFF
--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import importlib
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+SQLALCHEMY_READY = False
+
+
+class _MappedPlaceholder:
+    def __class_getitem__(cls, _item: Any) -> Any:
+        return Any
+
+
+class _TypePlaceholder:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _FuncPlaceholder:
+    @staticmethod
+    def now() -> str:
+        return "CURRENT_TIMESTAMP"
+
+
+class _DeclarativeBasePlaceholder:
+    metadata: Any = None
+
+
+def _foreign_key_placeholder(*args: Any, **kwargs: Any) -> Any:
+    return None
+
+
+def _mapped_column_placeholder(*args: Any, **kwargs: Any) -> Any:
+    return None
+
+
+def _relationship_placeholder(*args: Any, **kwargs: Any) -> Any:
+    return None
+
+
+JSON: Any = _TypePlaceholder
+DateTime: Any = _TypePlaceholder
+Integer: Any = _TypePlaceholder
+String: Any = _TypePlaceholder
+Text: Any = _TypePlaceholder
+UniqueConstraint: Any = _TypePlaceholder
+ForeignKey: Any = _foreign_key_placeholder
+func: Any = _FuncPlaceholder()
+DeclarativeBase: Any = _DeclarativeBasePlaceholder
+Mapped: Any = _MappedPlaceholder
+mapped_column: Any = _mapped_column_placeholder
+relationship: Any = _relationship_placeholder
+
+try:
+    sqlalchemy = importlib.import_module("sqlalchemy")
+    sqlalchemy_orm = importlib.import_module("sqlalchemy.orm")
+
+    JSON = sqlalchemy.JSON
+    DateTime = sqlalchemy.DateTime
+    Integer = sqlalchemy.Integer
+    String = sqlalchemy.String
+    Text = sqlalchemy.Text
+    UniqueConstraint = sqlalchemy.UniqueConstraint
+    ForeignKey = sqlalchemy.ForeignKey
+    func = sqlalchemy.func
+    DeclarativeBase = sqlalchemy_orm.DeclarativeBase
+    Mapped = sqlalchemy_orm.Mapped
+    mapped_column = sqlalchemy_orm.mapped_column
+    relationship = sqlalchemy_orm.relationship
+    SQLALCHEMY_READY = True
+except ModuleNotFoundError:
+    pass
+
+
+class Base(DeclarativeBase):
+    """Temporary declarative base for issue #49.
+
+    This module is intentionally self-contained so issue #50 can wire the
+    SQLAlchemy engine, session and Alembic metadata later without having to
+    redesign the core table shapes first.
+    """
+
+
+def _uuid_str() -> str:
+    return str(uuid4())
+
+
+class LearnerProfile(Base):
+    __tablename__ = "learner_profile"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True, default=_uuid_str)
+    login: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    track: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    current_module: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    progressions: Mapped[list[Progression]] = relationship(back_populates="learner")
+    evidence_items: Mapped[list[Evidence]] = relationship(back_populates="learner")
+    reviews_authored: Mapped[list[Review]] = relationship(back_populates="reviewer", foreign_keys="Review.reviewer_id")
+    reviews_received: Mapped[list[Review]] = relationship(back_populates="learner", foreign_keys="Review.learner_id")
+
+
+class Progression(Base):
+    __tablename__ = "progression"
+    __table_args__ = (UniqueConstraint("learner_id", "module_id", name="uq_progression_learner_module"),)
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True, default=_uuid_str)
+    learner_id: Mapped[str] = mapped_column(String(64), ForeignKey("learner_profile.id"), nullable=False, index=True)
+    module_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    track_id: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    phase: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    skipped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    evidence_summary: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    learner: Mapped[LearnerProfile] = relationship(back_populates="progressions")
+    evidence_items: Mapped[list[Evidence]] = relationship(back_populates="progression")
+
+
+class Evidence(Base):
+    __tablename__ = "evidence"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True, default=_uuid_str)
+    learner_id: Mapped[str] = mapped_column(String(64), ForeignKey("learner_profile.id"), nullable=False, index=True)
+    progression_id: Mapped[str | None] = mapped_column(
+        String(64), ForeignKey("progression.id"), nullable=True, index=True
+    )
+    module_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    checkpoint_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    evidence_type: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    skill_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    checkpoint_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    self_evaluation: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    expected_content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    learner: Mapped[LearnerProfile] = relationship(back_populates="evidence_items")
+    progression: Mapped[Progression | None] = relationship(back_populates="evidence_items")
+
+
+class Review(Base):
+    __tablename__ = "review"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True, default=_uuid_str)
+    learner_id: Mapped[str | None] = mapped_column(
+        String(64), ForeignKey("learner_profile.id"), nullable=True, index=True
+    )
+    reviewer_id: Mapped[str] = mapped_column(String(64), ForeignKey("learner_profile.id"), nullable=False, index=True)
+    module_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    code_snippet: Mapped[str] = mapped_column(Text, nullable=False)
+    feedback: Mapped[str] = mapped_column(Text, nullable=False)
+    questions: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    learner: Mapped[LearnerProfile | None] = relationship(back_populates="reviews_received", foreign_keys=[learner_id])
+    reviewer: Mapped[LearnerProfile] = relationship(back_populates="reviews_authored", foreign_keys=[reviewer_id])

--- a/services/api/tests/test_models_draft.py
+++ b/services/api/tests/test_models_draft.py
@@ -1,0 +1,11 @@
+"""Draft tests for SQLAlchemy model preparation in issue #49."""
+
+from app.models import Base, Evidence, LearnerProfile, Progression, Review
+
+
+def test_core_model_classes_exist() -> None:
+    assert Base is not None
+    assert LearnerProfile.__tablename__ == "learner_profile"
+    assert Progression.__tablename__ == "progression"
+    assert Evidence.__tablename__ == "evidence"
+    assert Review.__tablename__ == "review"


### PR DESCRIPTION
## Summary
- add a preparatory services/api/app/models.py module with draft SQLAlchemy models for LearnerProfile, Progression, Evidence, and Review
- keep the module self-contained and import-safe before issue #50 wires the actual SQLAlchemy engine, session, and Alembic metadata
- add a minimal backend test to lock the draft model surface without coupling the current API runtime to SQLAlchemy yet

## Testing
- cd services/api && python3 -m pytest tests/test_schemas.py tests/test_models_draft.py -q
- cd services/api && python3 -m ruff check app tests
- cd services/api && python3 -m ruff format --check app tests
- cd services/api && python3 -m mypy app

## Notes
- This PR deliberately does not hook the models into the live API yet because that depends on issue #50 (SQLAlchemy/Alembic setup).