### PR TITLE
feat: add mocked login UI page (#106)

### DIFF
--- a/apps/web/app/components/NavHeader.tsx
+++ b/apps/web/app/components/NavHeader.tsx
@@ -5,6 +5,7 @@ import { getDashboardData } from "@/lib/api";
 const NAV_LINKS = [
   { href: "/", label: "Dashboard" },
   { href: "/progression", label: "Progression" },
+  { href: "/login", label: "Login" },
 ] as const;
 
 export async function NavHeader() {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -783,6 +783,131 @@ a {
   font-size: 12px;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Login page                                                         */
+/* ------------------------------------------------------------------ */
+
+.login-page {
+  max-width: 1100px;
+}
+
+.login-shell {
+  display: grid;
+  gap: 20px;
+}
+
+.login-copy,
+.login-card {
+  display: grid;
+  gap: 18px;
+}
+
+.login-copy h1 {
+  max-width: 11ch;
+}
+
+.login-highlights {
+  display: grid;
+  gap: 12px;
+}
+
+.login-highlight {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.48);
+}
+
+.login-card-header {
+  display: grid;
+  gap: 4px;
+}
+
+.login-form {
+  display: grid;
+  gap: 16px;
+}
+
+.login-field {
+  display: grid;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.login-field input {
+  width: 100%;
+  min-height: 48px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(28, 26, 23, 0.14);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--ink);
+  font: inherit;
+}
+
+.login-field input::placeholder {
+  color: var(--muted);
+}
+
+.login-field input:focus {
+  outline: 2px solid rgba(28, 93, 99, 0.22);
+  outline-offset: 2px;
+  border-color: rgba(28, 93, 99, 0.35);
+}
+
+.login-field input[aria-invalid="true"] {
+  border-color: rgba(178, 76, 43, 0.5);
+}
+
+.login-error {
+  color: var(--c);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.login-actions {
+  display: grid;
+  gap: 12px;
+}
+
+.login-submit {
+  width: 100%;
+}
+
+.login-secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.56);
+  text-decoration: none;
+}
+
+.login-feedback {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  font-size: 14px;
+}
+
+.login-feedback--success {
+  background: rgba(53, 95, 59, 0.1);
+  border-color: rgba(53, 95, 59, 0.2);
+  color: var(--python);
+}
+
+.login-feedback--error {
+  background: rgba(178, 76, 43, 0.1);
+  border-color: rgba(178, 76, 43, 0.2);
+  color: var(--c);
+}
+
 /* ================================================================== */
 /*  Tablet breakpoint (>=600px)                                        */
 /* ================================================================== */
@@ -860,6 +985,11 @@ a {
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+  }
+
+  .login-actions {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
   }
 
   .progression-hero,
@@ -944,6 +1074,11 @@ a {
 
   .module-detail-body {
     grid-template-columns: 1.4fr 0.6fr;
+  }
+
+  .login-shell {
+    grid-template-columns: 1.05fr 0.95fr;
+    align-items: start;
   }
 
   .progression-hero,

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { loginWithPassword } from "@/services/auth";
+
+type FormState = {
+  email: string;
+  password: string;
+};
+
+type FormErrors = Partial<Record<keyof FormState, string>>;
+
+const INITIAL_STATE: FormState = {
+  email: "",
+  password: "",
+};
+
+function validateLoginForm(values: FormState): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!values.email.trim()) {
+    errors.email = "Email is required.";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) {
+    errors.email = "Enter a valid email address.";
+  }
+
+  if (!values.password) {
+    errors.password = "Password is required.";
+  } else if (values.password.length < 8) {
+    errors.password = "Password must contain at least 8 characters.";
+  }
+
+  return errors;
+}
+
+export default function LoginPage() {
+  const [form, setForm] = useState<FormState>(INITIAL_STATE);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [serverMessage, setServerMessage] = useState<string | null>(null);
+  const [submitState, setSubmitState] = useState<"idle" | "success" | "error">("idle");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function updateField(field: keyof FormState, value: string) {
+    setForm((current) => ({ ...current, [field]: value }));
+    setErrors((current) => ({ ...current, [field]: undefined }));
+    setServerMessage(null);
+    setSubmitState("idle");
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextErrors = validateLoginForm(form);
+    setErrors(nextErrors);
+    setServerMessage(null);
+
+    if (Object.keys(nextErrors).length > 0) {
+      setSubmitState("error");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await loginWithPassword(form);
+      setServerMessage(result.message);
+      setSubmitState(result.ok ? "success" : "error");
+    } catch {
+      setServerMessage("The mocked login flow failed unexpectedly.");
+      setSubmitState("error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="page-shell login-page">
+      <section className="login-shell">
+        <article className="login-copy panel">
+          <p className="eyebrow">Authentication</p>
+          <h1>Sign in with your learner account.</h1>
+          <p className="lead">
+            The backend authentication flow is still in progress. This page validates client-side inputs
+            and uses a mocked password login so the web flow can be integrated now.
+          </p>
+          <div className="login-highlights">
+            <div className="login-highlight">
+              <strong>Email + password</strong>
+              <span className="muted">No API key exposed in the browser.</span>
+            </div>
+            <div className="login-highlight">
+              <strong>Client validation</strong>
+              <span className="muted">Checks email format and a minimal password length.</span>
+            </div>
+            <div className="login-highlight">
+              <strong>Mocked backend call</strong>
+              <span className="muted">Ready to swap with the real API when auth endpoints exist.</span>
+            </div>
+          </div>
+          <p className="muted">
+            Demo note: use any valid email and a password of at least 8 characters. The address
+            <span className="prog-code"> blocked@42lausanne.ch </span>
+            returns a mocked failure state.
+          </p>
+        </article>
+
+        <section className="login-card panel" aria-labelledby="login-form-title">
+          <div className="login-card-header">
+            <p className="eyebrow">Web Login</p>
+            <h2 id="login-form-title">Access 42-training</h2>
+          </div>
+
+          <form className="login-form" noValidate onSubmit={handleSubmit}>
+            <label className="login-field">
+              <span>Email</span>
+              <input
+                type="email"
+                name="email"
+                autoComplete="email"
+                placeholder="learner@42lausanne.ch"
+                value={form.email}
+                onChange={(event) => updateField("email", event.target.value)}
+                aria-invalid={Boolean(errors.email)}
+                aria-describedby={errors.email ? "login-email-error" : undefined}
+              />
+              {errors.email && (
+                <small id="login-email-error" className="login-error">
+                  {errors.email}
+                </small>
+              )}
+            </label>
+
+            <label className="login-field">
+              <span>Password</span>
+              <input
+                type="password"
+                name="password"
+                autoComplete="current-password"
+                placeholder="Minimum 8 characters"
+                value={form.password}
+                onChange={(event) => updateField("password", event.target.value)}
+                aria-invalid={Boolean(errors.password)}
+                aria-describedby={errors.password ? "login-password-error" : undefined}
+              />
+              {errors.password && (
+                <small id="login-password-error" className="login-error">
+                  {errors.password}
+                </small>
+              )}
+            </label>
+
+            <div className="login-actions">
+              <button type="submit" className="action-btn login-submit" disabled={isSubmitting}>
+                {isSubmitting ? "Signing in..." : "Sign in"}
+              </button>
+              <Link href="/" className="login-secondary-link">
+                Back to dashboard
+              </Link>
+            </div>
+          </form>
+
+          {serverMessage && (
+            <div
+              className={`login-feedback ${
+                submitState === "success" ? "login-feedback--success" : "login-feedback--error"
+              }`}
+              aria-live="polite"
+            >
+              {serverMessage}
+            </div>
+          )}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/services/auth.ts
+++ b/apps/web/services/auth.ts
@@ -1,0 +1,32 @@
+export type LoginPayload = {
+  email: string;
+  password: string;
+};
+
+export type LoginResult = {
+  ok: boolean;
+  message: string;
+  mocked: true;
+};
+
+const MOCK_LATENCY_MS = 700;
+
+export async function loginWithPassword(payload: LoginPayload): Promise<LoginResult> {
+  await new Promise((resolve) => setTimeout(resolve, MOCK_LATENCY_MS));
+
+  const email = payload.email.trim().toLowerCase();
+
+  if (email === "blocked@42lausanne.ch") {
+    return {
+      ok: false,
+      message: "This demo account is blocked in the mocked auth service.",
+      mocked: true,
+    };
+  }
+
+  return {
+    ok: true,
+    message: `Signed in as ${email}. Backend auth is not wired yet, so this is a mocked response.`,
+    mocked: true,
+  };
+}


### PR DESCRIPTION
Closes #106.

## Summary
- add a new /login page with client-side email and password validation
- add a mocked auth service layer so the UI can submit without backend auth endpoints
- expose the page from the main navigation and style it to match the existing web app

## Validation
- cd apps/web && npm run lint
- cd apps/web && npm run typecheck
- cd apps/web && env -u NODE_ENV npm run build

## Notes
- the backend auth flow does not exist yet, so form submission is intentionally mocked
- the mock returns a failure for blocked@42lausanne.ch and success for other valid credentials