### PR TITLE
fix: unify progression source of truth (#112)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
+from .progression_state import canonicalize_progression, get_completed_module_ids, get_module_statuses
 from .repository import load_curriculum, load_progression, write_progression
 from .schemas import (
     CheckpointListResponse,
@@ -111,12 +112,12 @@ def curriculum_track_detail(track_id: str) -> TrackDetail:
 
 @app.get("/api/v1/progression")
 def progression() -> ProgressionResponse:
-    return ProgressionResponse(**load_progression())
+    return ProgressionResponse(**canonicalize_progression(load_progression()))
 
 
 @app.post("/api/v1/progression")
 def update_progression(payload: ProgressUpdate) -> ProgressionResponse:
-    current = load_progression()
+    current = canonicalize_progression(load_progression())
     learning_plan = current.setdefault("learning_plan", {})
     progress = current.setdefault("progress", {})
 
@@ -137,7 +138,7 @@ def update_progression(payload: ProgressUpdate) -> ProgressionResponse:
     if "active_module" in updates:
         target_module = updates["active_module"]
         curriculum = load_curriculum()
-        completed = set(progress.get("completed_modules", []))
+        completed = get_completed_module_ids(current)
         errors = validate_module_activation(curriculum, current, target_module, completed)
         if errors:
             raise HTTPException(status_code=422, detail={"validation_errors": errors})
@@ -159,11 +160,6 @@ def _find_module(module_id: str) -> tuple[dict[str, object], dict[str, object]]:
     raise HTTPException(status_code=404, detail=f"Module '{module_id}' not found")
 
 
-def _get_module_statuses(progression: dict[str, object]) -> dict[str, dict[str, object]]:
-    """Return the module_status dict from progression, creating it if absent."""
-    return progression.setdefault("module_status", {})  # type: ignore[return-value]
-
-
 def _check_prerequisites(module_id: str, track: dict[str, object], progression: dict[str, object]) -> list[str]:
     """Return list of prerequisite module IDs that are not completed/skipped."""
     modules: list[dict[str, object]] = track.get("modules", [])  # type: ignore[assignment]
@@ -173,7 +169,7 @@ def _check_prerequisites(module_id: str, track: dict[str, object], progression: 
     idx = module_ids.index(module_id)
     if idx == 0:
         return []
-    statuses = _get_module_statuses(progression)
+    statuses = get_module_statuses(progression)
     missing: list[str] = []
     for prev_id in module_ids[:idx]:
         prev_status = statuses.get(prev_id, {})
@@ -189,8 +185,8 @@ def _check_prerequisites(module_id: str, track: dict[str, object], progression: 
 @app.get("/api/v1/modules/{module_id}/status")
 def module_status(module_id: str) -> ModuleStatusResponse:
     track, _module = _find_module(module_id)
-    progression_data = load_progression()
-    statuses = _get_module_statuses(progression_data)
+    progression_data = canonicalize_progression(load_progression())
+    statuses = get_module_statuses(progression_data)
     entry = statuses.get(module_id, {})
     if not isinstance(entry, dict):
         entry = {}
@@ -208,7 +204,7 @@ def module_status(module_id: str) -> ModuleStatusResponse:
 @app.post("/api/v1/modules/{module_id}/start")
 def module_start(module_id: str, payload: ModuleStartRequest | None = None) -> ModuleProgressionResponse:
     track, _module = _find_module(module_id)
-    progression_data = load_progression()
+    progression_data = canonicalize_progression(load_progression())
 
     missing = _check_prerequisites(module_id, track, progression_data)
     if missing:
@@ -221,7 +217,7 @@ def module_start(module_id: str, payload: ModuleStartRequest | None = None) -> M
             },
         )
 
-    statuses = _get_module_statuses(progression_data)
+    statuses = get_module_statuses(progression_data)
     current = statuses.get(module_id, {})
     if isinstance(current, dict) and current.get("status") == "in_progress":
         return ModuleProgressionResponse(
@@ -246,8 +242,8 @@ def module_start(module_id: str, payload: ModuleStartRequest | None = None) -> M
 @app.post("/api/v1/modules/{module_id}/complete")
 def module_complete(module_id: str, payload: ModuleCompleteRequest | None = None) -> ModuleProgressionResponse:
     track, _module = _find_module(module_id)
-    progression_data = load_progression()
-    statuses = _get_module_statuses(progression_data)
+    progression_data = canonicalize_progression(load_progression())
+    statuses = get_module_statuses(progression_data)
     current = statuses.get(module_id, {})
 
     if not isinstance(current, dict) or current.get("status") != "in_progress":
@@ -273,8 +269,8 @@ def module_complete(module_id: str, payload: ModuleCompleteRequest | None = None
 @app.post("/api/v1/modules/{module_id}/skip")
 def module_skip(module_id: str, payload: ModuleSkipRequest | None = None) -> ModuleProgressionResponse:
     track, _module = _find_module(module_id)
-    progression_data = load_progression()
-    statuses = _get_module_statuses(progression_data)
+    progression_data = canonicalize_progression(load_progression())
+    statuses = get_module_statuses(progression_data)
 
     now = datetime.now(UTC).isoformat()
     entry: dict[str, object] = {"status": "skipped", "skipped_at": now}
@@ -300,8 +296,8 @@ def validate_module(module_id: str) -> dict[str, object]:
     curriculum = load_curriculum()
     if find_module(curriculum, module_id) is None:
         raise HTTPException(status_code=404, detail=f"Module '{module_id}' not found")
-    progression_data = load_progression()
-    completed = set(progression_data.get("progress", {}).get("completed_modules", []))
+    progression_data = canonicalize_progression(load_progression())
+    completed = get_completed_module_ids(progression_data)
     errors = validate_module_activation(curriculum, progression_data, module_id, completed)
     return {
         "module_id": module_id,

--- a/services/api/app/progression_state.py
+++ b/services/api/app/progression_state.py
@@ -1,0 +1,58 @@
+"""Helpers to keep module progression in one canonical representation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DONE_MODULE_STATUSES = {"completed", "skipped"}
+
+
+def get_progress_block(progression: dict[str, Any]) -> dict[str, Any]:
+    """Return the mutable progress block, normalizing invalid values."""
+
+    progress = progression.setdefault("progress", {})
+    if not isinstance(progress, dict):
+        progress = {}
+        progression["progress"] = progress
+    return progress
+
+
+def get_module_statuses(progression: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return canonical module statuses, backfilling legacy completed_modules."""
+
+    statuses = progression.setdefault("module_status", {})
+    if not isinstance(statuses, dict):
+        statuses = {}
+        progression["module_status"] = statuses
+
+    legacy_completed = get_progress_block(progression).get("completed_modules", [])
+    if isinstance(legacy_completed, list):
+        for module_id in legacy_completed:
+            key = str(module_id)
+            if isinstance(statuses.get(key), dict):
+                continue
+            statuses[key] = {"status": "completed"}
+
+    return statuses  # type: ignore[return-value]
+
+
+def get_completed_module_ids(progression: dict[str, Any]) -> set[str]:
+    """Return modules considered done for gating rules.
+
+    A skipped module is considered done for prerequisite and phase checks.
+    """
+
+    statuses = get_module_statuses(progression)
+    return {
+        module_id
+        for module_id, entry in statuses.items()
+        if isinstance(entry, dict) and entry.get("status") in DONE_MODULE_STATUSES
+    }
+
+
+def canonicalize_progression(progression: dict[str, Any]) -> dict[str, Any]:
+    """Normalize progression so module_status is the only persisted module source."""
+
+    get_module_statuses(progression)
+    get_progress_block(progression).pop("completed_modules", None)
+    return progression

--- a/services/api/app/validation.py
+++ b/services/api/app/validation.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .progression_state import get_completed_module_ids
+
 # Ordered phases — a module's phase must not precede the latest completed phase
 # within the same track without all prior-phase modules being done.
 PHASE_ORDER: dict[str, int] = {
@@ -108,7 +110,7 @@ def validate_module_activation(
     An empty list means all validations pass.
     """
     if completed_modules is None:
-        completed_modules = set(progression.get("progress", {}).get("completed_modules", []))
+        completed_modules = get_completed_module_ids(progression)
 
     errors: list[dict[str, str]] = []
 

--- a/services/api/tests/test_module_progression.py
+++ b/services/api/tests/test_module_progression.py
@@ -133,6 +133,18 @@ class TestModuleStart:
         assert r.status_code == 200
         assert r.json()["status"] == "in_progress"
 
+    def test_start_after_legacy_completed_modules(self) -> None:
+        prog = {"learning_plan": {}, "progress": {"completed_modules": ["shell-basics"]}}
+        p_cur, p_load, p_write, _prog, written = _patch_repo(prog)
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/modules/shell-streams/start")
+        assert r.status_code == 200
+        assert r.json()["status"] == "in_progress"
+        assert len(written) == 1
+        assert "completed_modules" not in written[0]["progress"]
+        assert written[0]["module_status"]["shell-basics"]["status"] == "completed"
+        assert written[0]["module_status"]["shell-streams"]["status"] == "in_progress"
+
     def test_start_unknown_module(self) -> None:
         p_cur, p_load, p_write, _prog, _w = _patch_repo()
         with p_cur, p_load, p_write:

--- a/services/api/tests/test_validation.py
+++ b/services/api/tests/test_validation.py
@@ -119,9 +119,11 @@ _CURRICULUM = {
 
 
 def _prog(active_course: str = "shell", completed_modules: list[str] | None = None) -> dict[str, object]:
+    statuses = {module_id: {"status": "completed"} for module_id in (completed_modules or [])}
     return {
         "learning_plan": {"active_course": active_course},
-        "progress": {"completed_modules": completed_modules or []},
+        "progress": {},
+        "module_status": statuses,
     }
 
 
@@ -358,6 +360,17 @@ class TestValidateEndpoint:
         assert r.status_code == 200
         assert r.json()["valid"] is True
 
+    def test_validate_legacy_completed_modules_still_works(self) -> None:
+        legacy_progression = {
+            "learning_plan": {"active_course": "shell"},
+            "progress": {"completed_modules": ["shell-basics", "shell-streams", "shell-permissions"]},
+        }
+        p_cur, p_load, p_write, _p, _w = _patch_repo(legacy_progression)
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/modules/shell-tooling/validate")
+        assert r.status_code == 200
+        assert r.json()["valid"] is True
+
 
 class TestProgressionValidation:
     """POST /api/v1/progression with active_module triggers validation."""
@@ -419,3 +432,18 @@ class TestProgressionValidation:
         with p_cur, p_load, p_write:
             r = client.post("/api/v1/progression", json={"active_module": "c-basics"})
         assert r.status_code == 200
+
+    def test_legacy_completed_modules_are_canonicalized_on_write(self) -> None:
+        legacy_progression = {
+            "learning_plan": {"active_course": "shell"},
+            "progress": {"completed_modules": ["shell-basics", "shell-streams", "shell-permissions"]},
+        }
+        p_cur, p_load, p_write, _p, written = _patch_repo(legacy_progression)
+        with p_cur, p_load, p_write:
+            r = client.post("/api/v1/progression", json={"active_module": "shell-tooling"})
+        assert r.status_code == 200
+        assert len(written) == 1
+        assert "completed_modules" not in written[0]["progress"]
+        assert written[0]["module_status"]["shell-basics"]["status"] == "completed"
+        assert written[0]["module_status"]["shell-streams"]["status"] == "completed"
+        assert written[0]["module_status"]["shell-permissions"]["status"] == "completed"


### PR DESCRIPTION
Closes #112.

## Summary
- make module_status the single source of truth for module progression gating and persistence
- backfill legacy progress.completed_modules into module_status at read time without letting the legacy field remain persisted after writes
- add regression coverage for validation and module endpoints using both canonical and legacy progression payloads

## Scope check
- searched services/api and packages for module_status and completed_modules
- no occurrences were found under packages/

## Testing
- pytest -q services/api/tests/test_validation.py services/api/tests/test_module_progression.py services/api/tests/test_api.py
- pytest -q services/api/tests
- python3 -m ruff check services/api/app services/api/tests
- python3 -m ruff format --check services/api/app services/api/tests