### PR TITLE
feat: operationalize librarian source index (#132)

### DIFF
--- a/services/ai_gateway/app/librarian.py
+++ b/services/ai_gateway/app/librarian.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .repository import load_curriculum
+from .retrieval import SourceProvider, SourceResult, StaticSourceProvider
+from .schemas import (
+    AuthorizedSource,
+    AuthorizedSourceResource,
+    LibrarianProvenance,
+    LibrarianRequest,
+    LibrarianResponse,
+    LibrarianResult,
+)
+
+# Tiers that are never exposed by the Librarian.
+BLOCKED_TIERS = {"blocked_solution_content"}
+
+# Foundation and practice phases also block solution metadata.
+PHASE_RESTRICTED_TIERS: dict[str, set[str]] = {
+    "foundation": {"solution_metadata"},
+    "practice": {"solution_metadata"},
+}
+
+
+def _curriculum_tier_ids(curriculum: dict[str, Any]) -> list[str]:
+    return [tier["id"] for tier in curriculum["source_policy"]["tiers"]]
+
+
+def allowed_tiers(curriculum: dict[str, Any], phase: str) -> list[str]:
+    excluded = BLOCKED_TIERS | PHASE_RESTRICTED_TIERS.get(phase, set())
+    return [tier_id for tier_id in _curriculum_tier_ids(curriculum) if tier_id not in excluded]
+
+
+def build_authorized_source_index(curriculum: dict[str, Any], phase: str) -> list[AuthorizedSource]:
+    allowed = set(allowed_tiers(curriculum, phase))
+    resources_by_tier: dict[str, list[AuthorizedSourceResource]] = {}
+
+    for resource in curriculum.get("recommended_resources", []):
+        tier = resource.get("tier")
+        if tier not in allowed:
+            continue
+        resources_by_tier.setdefault(tier, []).append(
+            AuthorizedSourceResource(
+                label=resource["label"],
+                url=resource.get("url"),
+            )
+        )
+
+    index: list[AuthorizedSource] = []
+    for tier in curriculum["source_policy"]["tiers"]:
+        tier_id = tier["id"]
+        if tier_id not in allowed:
+            continue
+        index.append(
+            AuthorizedSource(
+                tier=tier_id,
+                tier_label=tier["label"],
+                allowed_usage=tier["allowed_usage"],
+                confidence_level=tier["confidence_level"],
+                confidence_rationale=tier["confidence_rationale"],
+                resources=resources_by_tier.get(tier_id, []),
+            )
+        )
+
+    return index
+
+
+def _search_with_context(
+    provider: SourceProvider,
+    request: LibrarianRequest,
+    allowed: list[str],
+) -> list[SourceResult]:
+    raw_results = provider.search(
+        query=request.query,
+        tier_filter=allowed,
+        max_results=request.max_results,
+    )
+
+    search_query = request.query
+    if request.module_id:
+        search_query = f"{request.module_id} {search_query}"
+    elif request.track_id:
+        search_query = f"{request.track_id} {search_query}"
+
+    if search_query != request.query:
+        extra_results = provider.search(
+            query=search_query,
+            tier_filter=allowed,
+            max_results=request.max_results,
+        )
+        seen = {(result.content, result.tier, result.source_url) for result in raw_results}
+        for result in extra_results:
+            key = (result.content, result.tier, result.source_url)
+            if key in seen:
+                continue
+            raw_results.append(result)
+            seen.add(key)
+
+    raw_results.sort(key=lambda result: result.confidence, reverse=True)
+    return raw_results[: request.max_results]
+
+
+def _build_result_provenance(
+    result: SourceResult,
+    source_index: dict[str, AuthorizedSource],
+) -> LibrarianProvenance:
+    source = source_index[result.tier]
+    return LibrarianProvenance(
+        tier=result.tier,
+        tier_label=source.tier_label,
+        source_label=result.source_label or source.tier_label,
+        source_url=result.source_url,
+        allowed_usage=source.allowed_usage,
+        confidence_level=source.confidence_level,
+        confidence_rationale=source.confidence_rationale,
+    )
+
+
+def search_librarian(
+    request: LibrarianRequest,
+    provider: SourceProvider | None = None,
+) -> LibrarianResponse:
+    curriculum = load_curriculum()
+    provider = provider or StaticSourceProvider()
+
+    allowed = allowed_tiers(curriculum, request.phase)
+    authorized_sources = build_authorized_source_index(curriculum, request.phase)
+    source_index = {source.tier: source for source in authorized_sources}
+
+    raw_results = _search_with_context(provider, request, allowed)
+
+    results: list[LibrarianResult] = []
+    for raw_result in raw_results:
+        provenance = _build_result_provenance(raw_result, source_index)
+        results.append(
+            LibrarianResult(
+                content=raw_result.content,
+                source_url=raw_result.source_url,
+                tier=raw_result.tier,
+                tier_label=provenance.tier_label,
+                confidence=raw_result.confidence,
+                provenance=provenance,
+            )
+        )
+
+    blocked = sorted(BLOCKED_TIERS | PHASE_RESTRICTED_TIERS.get(request.phase, set()))
+
+    sources_used: list[LibrarianProvenance] = []
+    seen_sources: set[tuple[str, str, str | None]] = set()
+    for result in results:
+        key = (result.provenance.tier, result.provenance.source_label, result.provenance.source_url)
+        if key in seen_sources:
+            continue
+        sources_used.append(result.provenance)
+        seen_sources.add(key)
+
+    return LibrarianResponse(
+        status="ok",
+        query=request.query,
+        results=results,
+        tiers_used=sorted({result.tier for result in results}),
+        blocked_tiers=blocked,
+        authorized_sources=authorized_sources,
+        sources_used=sources_used,
+    )

--- a/services/ai_gateway/app/main.py
+++ b/services/ai_gateway/app/main.py
@@ -8,9 +8,9 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .defense import compute_session_result, create_session, get_session, score_answer
 from .intent import route_intent
+from .librarian import search_librarian
 from .llm_client import get_mentor_response
 from .repository import load_curriculum, load_progression
-from .retrieval import StaticSourceProvider
 from .reviewer import build_review
 from .schemas import (
     DefenseAnswerRequest,
@@ -24,7 +24,6 @@ from .schemas import (
     IntentResponse,
     LibrarianRequest,
     LibrarianResponse,
-    LibrarianResult,
     MentorRequest,
     MentorResponse,
     ReviewerRequest,
@@ -228,84 +227,9 @@ def mentor_respond(request: MentorRequest) -> MentorResponse:
     )
 
 
-# --- Tiers that are always blocked from Librarian results ---
-BLOCKED_TIERS = {"blocked_solution_content"}
-
-# Foundation and practice phases also block solution metadata
-PHASE_RESTRICTED_TIERS: dict[str, set[str]] = {
-    "foundation": {"solution_metadata"},
-    "practice": {"solution_metadata"},
-}
-
-
-def _allowed_tiers(phase: str) -> list[str]:
-    """Return tier ids the Librarian is allowed to serve for a given phase."""
-    curriculum = load_curriculum()
-    all_tiers = _curriculum_tier_ids(curriculum)
-    excluded = BLOCKED_TIERS | PHASE_RESTRICTED_TIERS.get(phase, set())
-    return [t for t in all_tiers if t not in excluded]
-
-
-def _tier_labels() -> dict[str, str]:
-    """Map tier id to human-readable label."""
-    curriculum = load_curriculum()
-    return {t["id"]: t["label"] for t in curriculum["source_policy"]["tiers"]}
-
-
 @app.post("/api/v1/librarian/search", response_model=LibrarianResponse)
 def librarian_search(request: LibrarianRequest) -> LibrarianResponse:
-    allowed = _allowed_tiers(request.phase)
-    labels = _tier_labels()
-    provider = StaticSourceProvider()
-
-    # Build search query — enrich with track/module context if provided
-    search_query = request.query
-    if request.module_id:
-        search_query = f"{request.module_id} {search_query}"
-    elif request.track_id:
-        search_query = f"{request.track_id} {search_query}"
-
-    raw_results = provider.search(
-        query=request.query,
-        tier_filter=allowed,
-        max_results=request.max_results,
-    )
-
-    # Also search with enriched query if it differs
-    if search_query != request.query:
-        extra = provider.search(
-            query=search_query,
-            tier_filter=allowed,
-            max_results=request.max_results,
-        )
-        seen = {(r.content, r.tier) for r in raw_results}
-        for r in extra:
-            if (r.content, r.tier) not in seen:
-                raw_results.append(r)
-                seen.add((r.content, r.tier))
-
-    # Re-sort and truncate
-    raw_results.sort(key=lambda r: r.confidence, reverse=True)
-    raw_results = raw_results[: request.max_results]
-
-    blocked = sorted(BLOCKED_TIERS | PHASE_RESTRICTED_TIERS.get(request.phase, set()))
-
-    return LibrarianResponse(
-        status="ok",
-        query=request.query,
-        results=[
-            LibrarianResult(
-                content=r.content,
-                source_url=r.source_url,
-                tier=r.tier,
-                tier_label=labels.get(r.tier, r.tier),
-                confidence=r.confidence,
-            )
-            for r in raw_results
-        ],
-        tiers_used=sorted({r.tier for r in raw_results}),
-        blocked_tiers=blocked,
-    )
+    return search_librarian(request)
 
 
 @app.post("/api/v1/reviewer/review", response_model=ReviewerResponse)

--- a/services/ai_gateway/app/retrieval.py
+++ b/services/ai_gateway/app/retrieval.py
@@ -17,6 +17,7 @@ class SourceResult(BaseModel):
     """A single result returned by a source provider."""
 
     content: str
+    source_label: str | None = None
     source_url: str | None = None
     tier: str = Field(description="Source tier id from the source policy (e.g. official_42, community_docs)")
     confidence: float = Field(ge=0.0, le=1.0, description="Relevance confidence between 0 and 1")
@@ -91,6 +92,7 @@ class StaticSourceProvider(SourceProvider):
             results.append(
                 SourceResult(
                     content=f"Track: {track['title']} — {track.get('summary', '')}",
+                    source_label="42 Lausanne curriculum data",
                     tier="official_42",
                     confidence=0.7,
                 )
@@ -105,6 +107,7 @@ class StaticSourceProvider(SourceProvider):
                 results.append(
                     SourceResult(
                         content=f"Module: {module['title']} (track: {track['id']}, phase: {module.get('phase', 'unknown')}) — Skills: {', '.join(module.get('skills', []))}",
+                        source_label="42 Lausanne curriculum data",
                         tier="official_42",
                         confidence=0.8,
                     )
@@ -116,6 +119,7 @@ class StaticSourceProvider(SourceProvider):
             results.append(
                 SourceResult(
                     content=f"Resource: {resource['label']}",
+                    source_label=resource["label"],
                     source_url=resource.get("url"),
                     tier=resource.get("tier", "community_docs"),
                     confidence=0.6,

--- a/services/ai_gateway/app/schemas.py
+++ b/services/ai_gateway/app/schemas.py
@@ -59,12 +59,37 @@ class LibrarianRequest(BaseModel):
     max_results: int = Field(default=5, ge=1, le=20)
 
 
+class AuthorizedSourceResource(BaseModel):
+    label: str
+    url: str | None = None
+
+
+class AuthorizedSource(BaseModel):
+    tier: str
+    tier_label: str
+    allowed_usage: str
+    confidence_level: str
+    confidence_rationale: str
+    resources: list[AuthorizedSourceResource]
+
+
+class LibrarianProvenance(BaseModel):
+    tier: str
+    tier_label: str
+    source_label: str
+    source_url: str | None = None
+    allowed_usage: str
+    confidence_level: str
+    confidence_rationale: str
+
+
 class LibrarianResult(BaseModel):
     content: str
     source_url: str | None = None
     tier: str
     tier_label: str
     confidence: float
+    provenance: LibrarianProvenance
 
 
 class LibrarianResponse(BaseModel):
@@ -73,6 +98,8 @@ class LibrarianResponse(BaseModel):
     results: list[LibrarianResult]
     tiers_used: list[str]
     blocked_tiers: list[str]
+    authorized_sources: list[AuthorizedSource]
+    sources_used: list[LibrarianProvenance]
 
 
 class ReviewerRequest(BaseModel):

--- a/services/ai_gateway/tests/test_librarian.py
+++ b/services/ai_gateway/tests/test_librarian.py
@@ -22,11 +22,14 @@ def test_librarian_basic_search() -> None:
 def test_librarian_results_have_expected_fields() -> None:
     response = client.post(ENDPOINT, json={"query": "shell"})
     data = response.json()
+    assert "authorized_sources" in data
+    assert "sources_used" in data
     for result in data["results"]:
         assert "content" in result
         assert "tier" in result
         assert "tier_label" in result
         assert "confidence" in result
+        assert "provenance" in result
         assert 0.0 <= result["confidence"] <= 1.0
 
 
@@ -37,6 +40,7 @@ def test_librarian_never_returns_blocked_tiers() -> None:
     for result in data["results"]:
         assert result["tier"] != "blocked_solution_content"
     assert "blocked_solution_content" in data["blocked_tiers"]
+    assert all(source["tier"] != "blocked_solution_content" for source in data["authorized_sources"])
 
 
 def test_librarian_foundation_blocks_solution_metadata() -> None:
@@ -46,6 +50,7 @@ def test_librarian_foundation_blocks_solution_metadata() -> None:
     for result in data["results"]:
         assert result["tier"] != "solution_metadata"
     assert "solution_metadata" in data["blocked_tiers"]
+    assert all(source["tier"] != "solution_metadata" for source in data["authorized_sources"])
 
 
 def test_librarian_advanced_allows_solution_metadata() -> None:
@@ -53,6 +58,7 @@ def test_librarian_advanced_allows_solution_metadata() -> None:
     response = client.post(ENDPOINT, json={"query": "shell", "phase": "advanced"})
     data = response.json()
     assert "solution_metadata" not in data["blocked_tiers"]
+    assert any(source["tier"] == "solution_metadata" for source in data["authorized_sources"])
 
 
 def test_librarian_with_track_context() -> None:
@@ -96,6 +102,7 @@ def test_librarian_tiers_used_reflects_results() -> None:
     data = response.json()
     result_tiers = {r["tier"] for r in data["results"]}
     assert result_tiers == set(data["tiers_used"])
+    assert {item["tier"] for item in data["sources_used"]} == result_tiers
 
 
 def test_librarian_query_too_short() -> None:
@@ -108,3 +115,33 @@ def test_librarian_resource_includes_url() -> None:
     response = client.post(ENDPOINT, json={"query": "norminette"})
     data = response.json()
     assert any(r["source_url"] is not None for r in data["results"])
+
+
+def test_librarian_result_includes_explicit_provenance() -> None:
+    response = client.post(ENDPOINT, json={"query": "norminette"})
+    data = response.json()
+    result = next(item for item in data["results"] if item["source_url"] is not None)
+    provenance = result["provenance"]
+    assert provenance["tier"] == result["tier"]
+    assert provenance["tier_label"] == result["tier_label"]
+    assert provenance["source_label"]
+    assert provenance["allowed_usage"]
+    assert provenance["confidence_level"]
+    assert provenance["confidence_rationale"]
+
+
+def test_librarian_authorized_sources_are_built_from_source_policy() -> None:
+    response = client.post(ENDPOINT, json={"query": "shell"})
+    data = response.json()
+    official = next(item for item in data["authorized_sources"] if item["tier"] == "official_42")
+    assert official["tier_label"] == "Official 42 sources"
+    assert official["allowed_usage"] == "ground_truth"
+    assert official["confidence_level"] == "high"
+
+
+def test_librarian_authorized_sources_include_recommended_resources() -> None:
+    response = client.post(ENDPOINT, json={"query": "shell"})
+    data = response.json()
+    testers = next(item for item in data["authorized_sources"] if item["tier"] == "testers_and_tooling")
+    labels = {resource["label"] for resource in testers["resources"]}
+    assert "norminette" in labels


### PR DESCRIPTION
Closes #132.

## Summary
- add a dedicated librarian service module for allowed-tier indexing and search orchestration
- build an authorized source index from curriculum source_policy tiers and recommended resources
- expose explicit provenance on librarian results and response-level sources used
- keep librarian filtering aligned with phase-based guardrails

## Validation
- pytest -q services/ai_gateway/tests
- python3 -m compileall services/ai_gateway/app