### PR TITLE
feat: add timed examiner flow (#129)

### DIFF
--- a/services/ai_gateway/app/defense.py
+++ b/services/ai_gateway/app/defense.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
 
 
 @dataclass
@@ -25,6 +30,8 @@ class DefenseQuestion:
     answered: bool = False
     score: float = 0.0
     feedback: str = ""
+    timed_out: bool = False
+    elapsed_seconds: float = 0.0
 
 
 @dataclass
@@ -34,6 +41,9 @@ class DefenseSession:
     module_id: str
     phase: str
     questions: list[DefenseQuestion] = field(default_factory=list)
+    question_time_limit_seconds: int = 60
+    started_at: datetime = field(default_factory=_utc_now)
+    current_question_started_at: datetime = field(default_factory=_utc_now)
     completed: bool = False
 
 
@@ -50,8 +60,10 @@ def create_session(
     module: dict[str, Any],
     phase: str,
     num_questions: int = 3,
+    question_time_limit_seconds: int = 60,
 ) -> DefenseSession:
     """Create a new defense session with generated questions."""
+    now = _utc_now()
     session_id = uuid.uuid4().hex[:12]
     questions = _generate_questions(track, module, phase, num_questions)
     session = DefenseSession(
@@ -60,6 +72,9 @@ def create_session(
         module_id=module["id"],
         phase=phase,
         questions=questions,
+        question_time_limit_seconds=question_time_limit_seconds,
+        started_at=now,
+        current_question_started_at=now,
     )
     _sessions[session_id] = session
     return session
@@ -121,11 +136,13 @@ def score_answer(question: DefenseQuestion, answer: str) -> tuple[float, str]:
 def compute_session_result(session: DefenseSession) -> dict[str, Any]:
     """Compute final defense result for a completed session."""
     answered = [q for q in session.questions if q.answered]
+    timed_out_questions = sum(1 for q in session.questions if q.timed_out)
     if not answered:
         return {
             "overall_score": 0.0,
             "passed": False,
             "summary": "No questions were answered.",
+            "timed_out_questions": timed_out_questions,
             "question_results": [],
         }
 
@@ -140,6 +157,8 @@ def compute_session_result(session: DefenseSession) -> dict[str, Any]:
             "score": q.score,
             "feedback": q.feedback,
             "answered": q.answered,
+            "timed_out": q.timed_out,
+            "elapsed_seconds": q.elapsed_seconds,
         }
         for q in session.questions
     ]
@@ -154,11 +173,81 @@ def compute_session_result(session: DefenseSession) -> dict[str, Any]:
     else:
         summary = f"Defense not passed ({overall:.0%}). Review the feedback for each question and revisit the module materials."
 
+    if timed_out_questions:
+        summary += f" {timed_out_questions} question(s) exceeded the timer."
+
     return {
         "overall_score": overall,
         "passed": passed,
         "summary": summary,
+        "timed_out_questions": timed_out_questions,
         "question_results": question_results,
+    }
+
+
+def get_current_question(session: DefenseSession) -> DefenseQuestion | None:
+    for question in session.questions:
+        if not question.answered:
+            return question
+    return None
+
+
+def get_current_question_deadline(session: DefenseSession) -> datetime | None:
+    if get_current_question(session) is None:
+        return None
+    return session.current_question_started_at + timedelta(seconds=session.question_time_limit_seconds)
+
+
+def submit_answer(session: DefenseSession, question_id: str, answer: str) -> dict[str, Any]:
+    if session.completed:
+        raise ValueError("Session already completed")
+
+    current_question = get_current_question(session)
+    if current_question is None:
+        session.completed = True
+        raise ValueError("Session already completed")
+
+    if question_id != current_question.id:
+        raise ValueError("Questions must be answered in order")
+
+    now = _utc_now()
+    elapsed_seconds = round((now - session.current_question_started_at).total_seconds(), 2)
+    deadline = get_current_question_deadline(session)
+    timed_out = deadline is not None and now > deadline
+
+    if timed_out:
+        score_val = 0.0
+        feedback = (
+            f"Time limit reached for '{current_question.skill}'. Try explaining the concept again from memory in one "
+            "clear paragraph."
+        )
+    else:
+        score_val, feedback = score_answer(current_question, answer)
+
+    current_question.score = score_val
+    current_question.feedback = feedback
+    current_question.answered = True
+    current_question.timed_out = timed_out
+    current_question.elapsed_seconds = elapsed_seconds
+
+    remaining = sum(1 for question in session.questions if not question.answered)
+    next_question = get_current_question(session)
+    next_question_deadline = None
+    if next_question is None:
+        session.completed = True
+    else:
+        session.current_question_started_at = now
+        next_question_deadline = get_current_question_deadline(session)
+
+    return {
+        "question_id": current_question.id,
+        "score": score_val,
+        "feedback": feedback,
+        "questions_remaining": remaining,
+        "timed_out": timed_out,
+        "elapsed_seconds": elapsed_seconds,
+        "next_question_id": next_question.id if next_question else None,
+        "next_question_deadline": next_question_deadline,
     }
 
 

--- a/services/ai_gateway/app/main.py
+++ b/services/ai_gateway/app/main.py
@@ -6,7 +6,14 @@ from typing import Literal
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
-from .defense import compute_session_result, create_session, get_session, score_answer
+from .defense import (
+    compute_session_result,
+    create_session,
+    get_current_question,
+    get_current_question_deadline,
+    get_session,
+    submit_answer,
+)
 from .intent import route_intent
 from .librarian import search_librarian
 from .llm_client import get_mentor_response
@@ -278,7 +285,13 @@ def defense_start(request: DefenseStartRequest) -> DefenseStartResponse:
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    session = create_session(track, module, request.phase, request.num_questions)
+    session = create_session(
+        track,
+        module,
+        request.phase,
+        request.num_questions,
+        request.question_time_limit_seconds,
+    )
 
     return DefenseStartResponse(
         status="ok",
@@ -290,10 +303,15 @@ def defense_start(request: DefenseStartRequest) -> DefenseStartResponse:
                 question_id=q.id,
                 text=q.text,
                 skill=q.skill,
+                time_limit_seconds=session.question_time_limit_seconds,
             )
             for q in session.questions
         ],
         total_questions=len(session.questions),
+        question_time_limit_seconds=session.question_time_limit_seconds,
+        active_question_id=session.questions[0].id if session.questions else None,
+        started_at=session.started_at,
+        current_question_deadline=get_current_question_deadline(session),
     )
 
 
@@ -308,24 +326,22 @@ def defense_answer(request: DefenseAnswerRequest) -> DefenseAnswerResponse:
     question = next((q for q in session.questions if q.id == request.question_id), None)
     if question is None:
         raise HTTPException(status_code=404, detail="Question not found")
-    if question.answered:
-        raise HTTPException(status_code=400, detail="Question already answered")
+    current_question = get_current_question(session)
+    if current_question is not None and request.question_id != current_question.id:
+        raise HTTPException(status_code=409, detail="Questions must be answered in order")
 
-    score_val, feedback = score_answer(question, request.answer)
-    question.score = score_val
-    question.feedback = feedback
-    question.answered = True
-
-    remaining = sum(1 for q in session.questions if not q.answered)
-    if remaining == 0:
-        session.completed = True
+    result = submit_answer(session, request.question_id, request.answer)
 
     return DefenseAnswerResponse(
         status="ok",
-        question_id=question.id,
-        score=score_val,
-        feedback=feedback,
-        questions_remaining=remaining,
+        question_id=result["question_id"],
+        score=result["score"],
+        feedback=result["feedback"],
+        questions_remaining=result["questions_remaining"],
+        timed_out=result["timed_out"],
+        elapsed_seconds=result["elapsed_seconds"],
+        next_question_id=result["next_question_id"],
+        next_question_deadline=result["next_question_deadline"],
     )
 
 
@@ -343,5 +359,6 @@ def defense_result(session_id: str) -> DefenseResultResponse:
         overall_score=result["overall_score"],
         passed=result["passed"],
         summary=result["summary"],
+        timed_out_questions=result["timed_out_questions"],
         question_results=[DefenseQuestionResult(**qr) for qr in result["question_results"]],
     )

--- a/services/ai_gateway/app/schemas.py
+++ b/services/ai_gateway/app/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -130,12 +131,14 @@ class DefenseStartRequest(BaseModel):
     module_id: str
     phase: Literal["foundation", "practice", "core", "advanced"] = "foundation"
     num_questions: int = Field(default=3, ge=1, le=10)
+    question_time_limit_seconds: int = Field(default=60, ge=10, le=600)
 
 
 class DefenseQuestionOut(BaseModel):
     question_id: str
     text: str
     skill: str
+    time_limit_seconds: int
 
 
 class DefenseStartResponse(BaseModel):
@@ -145,6 +148,10 @@ class DefenseStartResponse(BaseModel):
     module_id: str
     questions: list[DefenseQuestionOut]
     total_questions: int
+    question_time_limit_seconds: int
+    active_question_id: str | None
+    started_at: datetime
+    current_question_deadline: datetime | None
 
 
 class DefenseAnswerRequest(BaseModel):
@@ -159,6 +166,10 @@ class DefenseAnswerResponse(BaseModel):
     score: float
     feedback: str
     questions_remaining: int
+    timed_out: bool
+    elapsed_seconds: float
+    next_question_id: str | None = None
+    next_question_deadline: datetime | None = None
 
 
 class DefenseQuestionResult(BaseModel):
@@ -168,6 +179,8 @@ class DefenseQuestionResult(BaseModel):
     score: float
     feedback: str
     answered: bool
+    timed_out: bool = False
+    elapsed_seconds: float = 0.0
 
 
 class DefenseResultResponse(BaseModel):
@@ -176,4 +189,5 @@ class DefenseResultResponse(BaseModel):
     overall_score: float
     passed: bool
     summary: str
+    timed_out_questions: int
     question_results: list[DefenseQuestionResult]

--- a/services/ai_gateway/tests/test_defense.py
+++ b/services/ai_gateway/tests/test_defense.py
@@ -7,6 +7,9 @@ Key invariants:
 - The system never provides correct answers in feedback
 """
 
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -27,10 +30,20 @@ def _clean_sessions():
     clear_sessions()
 
 
-def _start_session(track_id: str = "shell", module_id: str = "shell-basics", num_questions: int = 3) -> dict:
+def _start_session(
+    track_id: str = "shell",
+    module_id: str = "shell-basics",
+    num_questions: int = 3,
+    question_time_limit_seconds: int = 60,
+) -> dict:
     response = client.post(
         START_ENDPOINT,
-        json={"track_id": track_id, "module_id": module_id, "num_questions": num_questions},
+        json={
+            "track_id": track_id,
+            "module_id": module_id,
+            "num_questions": num_questions,
+            "question_time_limit_seconds": question_time_limit_seconds,
+        },
     )
     assert response.status_code == 200
     return response.json()
@@ -47,6 +60,9 @@ def test_start_session_returns_questions() -> None:
     assert data["module_id"] == "shell-basics"
     assert len(data["questions"]) == 3
     assert data["total_questions"] == 3
+    assert data["question_time_limit_seconds"] == 60
+    assert data["active_question_id"] == data["questions"][0]["question_id"]
+    assert data["current_question_deadline"] is not None
 
 
 def test_start_session_questions_have_structure() -> None:
@@ -55,6 +71,7 @@ def test_start_session_questions_have_structure() -> None:
         assert "question_id" in q
         assert "text" in q
         assert "skill" in q
+        assert q["time_limit_seconds"] == 60
         assert len(q["text"]) > 10
 
 
@@ -124,6 +141,10 @@ def test_answer_question_scores_good_answer() -> None:
     assert data["score"] > 0.0
     assert data["feedback"]
     assert data["questions_remaining"] == 2
+    assert data["timed_out"] is False
+    assert data["elapsed_seconds"] >= 0.0
+    assert data["next_question_id"] == session["questions"][1]["question_id"]
+    assert data["next_question_deadline"] is not None
 
 
 def test_answer_question_scores_brief_answer_low() -> None:
@@ -171,7 +192,7 @@ def test_answer_already_answered_rejected() -> None:
     }
     client.post(ANSWER_ENDPOINT, json=payload)
     response = client.post(ANSWER_ENDPOINT, json=payload)
-    assert response.status_code == 400
+    assert response.status_code == 409
 
 
 def test_answer_invalid_session() -> None:
@@ -193,6 +214,20 @@ def test_answer_invalid_question() -> None:
         },
     )
     assert response.status_code == 404
+
+
+def test_answer_requires_current_question_first() -> None:
+    session = _start_session(num_questions=2)
+    second_question = session["questions"][1]
+    response = client.post(
+        ANSWER_ENDPOINT,
+        json={
+            "session_id": session["session_id"],
+            "question_id": second_question["question_id"],
+            "answer": "I want to skip ahead and answer this one first.",
+        },
+    )
+    assert response.status_code == 409
 
 
 def test_answer_decrements_remaining() -> None:
@@ -301,6 +336,54 @@ def test_completed_session_rejects_answers() -> None:
     assert response.status_code == 400
 
 
+def test_answer_times_out_when_question_deadline_passed() -> None:
+    start = datetime(2026, 3, 29, 12, 0, 0, tzinfo=UTC)
+    with patch("app.defense._utc_now", return_value=start):
+        session = _start_session(num_questions=1, question_time_limit_seconds=30)
+
+    question = session["questions"][0]
+    with patch("app.defense._utc_now", return_value=start + timedelta(seconds=45)):
+        response = client.post(
+            ANSWER_ENDPOINT,
+            json={
+                "session_id": session["session_id"],
+                "question_id": question["question_id"],
+                "answer": "pwd shows the current directory and helps me verify where I am in the filesystem.",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["timed_out"] is True
+    assert data["score"] == 0.0
+    assert data["elapsed_seconds"] == 45.0
+    assert data["next_question_id"] is None
+    assert data["next_question_deadline"] is None
+
+
+def test_result_counts_timed_out_questions() -> None:
+    start = datetime(2026, 3, 29, 12, 0, 0, tzinfo=UTC)
+    with patch("app.defense._utc_now", return_value=start):
+        session = _start_session(num_questions=1, question_time_limit_seconds=20)
+
+    question = session["questions"][0]
+    with patch("app.defense._utc_now", return_value=start + timedelta(seconds=25)):
+        client.post(
+            ANSWER_ENDPOINT,
+            json={
+                "session_id": session["session_id"],
+                "question_id": question["question_id"],
+                "answer": "ls lists files in a directory because it reads the directory entries.",
+            },
+        )
+
+    response = client.get(f"/api/v1/defense/{session['session_id']}/result")
+    data = response.json()
+    assert data["timed_out_questions"] == 1
+    assert data["question_results"][0]["timed_out"] is True
+    assert "timer" in data["summary"].lower()
+
+
 # === Unit tests for scoring ===
 
 
@@ -348,3 +431,5 @@ def test_result_question_results_structure() -> None:
     assert "score" in qr
     assert "feedback" in qr
     assert "answered" in qr
+    assert "timed_out" in qr
+    assert "elapsed_seconds" in qr


### PR DESCRIPTION
Closes #129.

## Summary
- build the Examiner flow on top of the defense endpoints with per-question timer metadata, ordered question progression, timeout handling, and scored answers
- expose timer state in the start/answer/result payloads so clients can run a chronometred verification flow
- include the intent-router dependency from #131 on this branch so Examiner remains routable through /api/v1/intent while that PR is pending

## Verification
- cd services/ai_gateway && pytest -q tests/test_defense.py
- cd services/ai_gateway && pytest -q