### PR TITLE
feat: create defense and review web interface (#130)

### DIFF
--- a/apps/web/app/components/NavHeader.tsx
+++ b/apps/web/app/components/NavHeader.tsx
@@ -5,6 +5,7 @@ import { getDashboardData } from "@/lib/api";
 const NAV_LINKS = [
   { href: "/", label: "Dashboard" },
   { href: "/progression", label: "Progression" },
+  { href: "/defense", label: "Defense" },
   { href: "/profiles", label: "Profiles" },
   { href: "/analytics", label: "Analytics" },
   { href: "/login", label: "Login" },

--- a/apps/web/app/defense/DefenseClient.tsx
+++ b/apps/web/app/defense/DefenseClient.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  Types matching the AI Gateway defense API                          */
+/* ------------------------------------------------------------------ */
+
+type DefenseQuestion = {
+  question_id: string;
+  text: string;
+  skill: string;
+  time_limit_seconds: number;
+};
+
+type DefenseStartResponse = {
+  status: string;
+  session_id: string;
+  track_id: string;
+  module_id: string;
+  questions: DefenseQuestion[];
+  total_questions: number;
+  question_time_limit_seconds: number;
+  active_question_id: string | null;
+  started_at: string;
+  current_question_deadline: string | null;
+};
+
+type DefenseAnswerResponse = {
+  status: string;
+  question_id: string;
+  score: number;
+  feedback: string;
+  questions_remaining: number;
+  timed_out: boolean;
+  elapsed_seconds: number;
+  next_question_id: string | null;
+  next_question_deadline: string | null;
+};
+
+type QuestionResult = {
+  question_id: string;
+  question: string;
+  skill: string;
+  score: number;
+  feedback: string;
+  answered: boolean;
+  timed_out: boolean;
+  elapsed_seconds: number;
+};
+
+type DefenseResultResponse = {
+  status: string;
+  session_id: string;
+  overall_score: number;
+  passed: boolean;
+  summary: string;
+  timed_out_questions: number;
+  question_results: QuestionResult[];
+};
+
+type Phase = "setup" | "active" | "results";
+
+/* ------------------------------------------------------------------ */
+/*  Module / track data passed from the server component               */
+/* ------------------------------------------------------------------ */
+
+type ModuleOption = {
+  id: string;
+  title: string;
+  phase: string;
+  trackId: string;
+  trackTitle: string;
+};
+
+type Props = {
+  modules: ModuleOption[];
+  apiUrl: string;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export default function DefenseClient({ modules, apiUrl }: Props) {
+  /* Setup state */
+  const [selectedModule, setSelectedModule] = useState(modules[0]?.id ?? "");
+  const [numQuestions, setNumQuestions] = useState(3);
+  const [timeLimit, setTimeLimit] = useState(60);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /* Session state */
+  const [phase, setPhase] = useState<Phase>("setup");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [questions, setQuestions] = useState<DefenseQuestion[]>([]);
+  const [activeQuestionIndex, setActiveQuestionIndex] = useState(0);
+  const [deadline, setDeadline] = useState<Date | null>(null);
+  const [secondsLeft, setSecondsLeft] = useState(0);
+
+  /* Answer state */
+  const [answer, setAnswer] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [lastFeedback, setLastFeedback] = useState<{
+    score: number;
+    feedback: string;
+    timed_out: boolean;
+  } | null>(null);
+
+  /* Results state */
+  const [results, setResults] = useState<DefenseResultResponse | null>(null);
+
+  /* Derived */
+  const currentModule = modules.find((m) => m.id === selectedModule);
+  const currentQuestion = questions[activeQuestionIndex] ?? null;
+
+  /* ---------------------------------------------------------------- */
+  /*  Timer                                                            */
+  /* ---------------------------------------------------------------- */
+
+  useEffect(() => {
+    if (phase !== "active" || !deadline) return;
+
+    const tick = () => {
+      const remaining = Math.max(
+        0,
+        Math.ceil((deadline.getTime() - Date.now()) / 1000)
+      );
+      setSecondsLeft(remaining);
+    };
+
+    tick();
+    const interval = setInterval(tick, 500);
+    return () => clearInterval(interval);
+  }, [phase, deadline]);
+
+  /* ---------------------------------------------------------------- */
+  /*  Start defense                                                    */
+  /* ---------------------------------------------------------------- */
+
+  async function handleStart() {
+    if (!selectedModule) return;
+    setLoading(true);
+    setError(null);
+
+    const trackId = currentModule?.trackId ?? "shell";
+    const modulePhase = currentModule?.phase ?? "foundation";
+
+    try {
+      const res = await fetch(`${apiUrl}/api/v1/defense/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          track_id: trackId,
+          module_id: selectedModule,
+          phase: modulePhase,
+          num_questions: numQuestions,
+          question_time_limit_seconds: timeLimit,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(body.detail ?? `API error ${res.status}`);
+      }
+
+      const data: DefenseStartResponse = await res.json();
+
+      setSessionId(data.session_id);
+      setQuestions(data.questions);
+      setActiveQuestionIndex(0);
+      setAnswer("");
+      setLastFeedback(null);
+      setResults(null);
+
+      if (data.current_question_deadline) {
+        setDeadline(new Date(data.current_question_deadline));
+      }
+
+      setPhase("active");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start defense");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Submit answer                                                    */
+  /* ---------------------------------------------------------------- */
+
+  async function handleSubmitAnswer() {
+    if (!sessionId || !currentQuestion || submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`${apiUrl}/api/v1/defense/answer`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: sessionId,
+          question_id: currentQuestion.question_id,
+          answer,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(body.detail ?? `API error ${res.status}`);
+      }
+
+      const data: DefenseAnswerResponse = await res.json();
+
+      setLastFeedback({
+        score: data.score,
+        feedback: data.feedback,
+        timed_out: data.timed_out,
+      });
+
+      if (data.questions_remaining === 0) {
+        /* Fetch final results */
+        await fetchResults();
+      } else {
+        /* Move to next question after a brief pause to show feedback */
+        setTimeout(() => {
+          setActiveQuestionIndex((i) => i + 1);
+          setAnswer("");
+          setLastFeedback(null);
+          if (data.next_question_deadline) {
+            setDeadline(new Date(data.next_question_deadline));
+          }
+        }, 2500);
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to submit answer"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Fetch results                                                    */
+  /* ---------------------------------------------------------------- */
+
+  const fetchResults = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      const res = await fetch(
+        `${apiUrl}/api/v1/defense/${sessionId}/result`
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch results: ${res.status}`);
+      }
+      const data: DefenseResultResponse = await res.json();
+      setResults(data);
+      setPhase("results");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch results"
+      );
+    }
+  }, [sessionId, apiUrl]);
+
+  /* ---------------------------------------------------------------- */
+  /*  Reset                                                            */
+  /* ---------------------------------------------------------------- */
+
+  function handleReset() {
+    setPhase("setup");
+    setSessionId(null);
+    setQuestions([]);
+    setActiveQuestionIndex(0);
+    setAnswer("");
+    setLastFeedback(null);
+    setResults(null);
+    setError(null);
+    setDeadline(null);
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Render: Setup                                                    */
+  /* ---------------------------------------------------------------- */
+
+  if (phase === "setup") {
+    return (
+      <section className="defense-setup panel">
+        <p className="eyebrow">Configuration</p>
+        <h2>Start a defense session</h2>
+        <p className="muted">
+          Select a module and configure the session parameters. You will be
+          asked timed questions about the module skills. Explain your
+          understanding clearly — no solutions are provided.
+        </p>
+
+        {error && <p className="defense-error">{error}</p>}
+
+        <div className="defense-form">
+          <label className="defense-field">
+            <span>Module</span>
+            <select
+              value={selectedModule}
+              onChange={(e) => setSelectedModule(e.target.value)}
+            >
+              {modules.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.trackTitle} — {m.title} ({m.phase})
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="defense-field-row">
+            <label className="defense-field">
+              <span>Questions</span>
+              <select
+                value={numQuestions}
+                onChange={(e) => setNumQuestions(Number(e.target.value))}
+              >
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="defense-field">
+              <span>Time per question</span>
+              <select
+                value={timeLimit}
+                onChange={(e) => setTimeLimit(Number(e.target.value))}
+              >
+                {[30, 45, 60, 90, 120, 180].map((s) => (
+                  <option key={s} value={s}>
+                    {s}s
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <button
+            className="action-btn"
+            onClick={handleStart}
+            disabled={loading || !selectedModule}
+          >
+            {loading ? "Starting..." : "Begin defense"}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Render: Active session                                           */
+  /* ---------------------------------------------------------------- */
+
+  if (phase === "active" && currentQuestion) {
+    const timerWarning = secondsLeft <= 15 && secondsLeft > 0;
+    const timerCritical = secondsLeft <= 5;
+
+    return (
+      <section className="defense-active">
+        {/* Progress bar */}
+        <div className="defense-progress panel">
+          <div className="defense-progress-header">
+            <span className="eyebrow">
+              Question {activeQuestionIndex + 1} of {questions.length}
+            </span>
+            <span
+              className={`defense-timer ${timerWarning ? "defense-timer--warning" : ""} ${timerCritical ? "defense-timer--critical" : ""}`}
+            >
+              {secondsLeft}s
+            </span>
+          </div>
+          <div className="progress-bar">
+            <div
+              className="progress-bar-fill"
+              style={{
+                width: `${((activeQuestionIndex + 1) / questions.length) * 100}%`,
+                backgroundColor: "var(--accent)",
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Question */}
+        <div className="defense-question panel">
+          <div className="defense-question-meta">
+            <span className="pill">{currentQuestion.skill}</span>
+          </div>
+          <p className="defense-question-text">{currentQuestion.text}</p>
+        </div>
+
+        {/* Feedback (shown briefly after answering) */}
+        {lastFeedback && (
+          <div
+            className={`defense-feedback panel ${lastFeedback.score >= 0.7 ? "defense-feedback--good" : lastFeedback.score >= 0.4 ? "defense-feedback--partial" : "defense-feedback--low"}`}
+          >
+            <div className="defense-feedback-header">
+              <strong>
+                Score: {Math.round(lastFeedback.score * 100)}%
+              </strong>
+              {lastFeedback.timed_out && (
+                <span className="pill pill--in_progress">Timed out</span>
+              )}
+            </div>
+            <p>{lastFeedback.feedback}</p>
+          </div>
+        )}
+
+        {/* Answer form */}
+        {!lastFeedback && (
+          <div className="defense-answer panel">
+            {error && <p className="defense-error">{error}</p>}
+            <label className="defense-field">
+              <span>Your explanation</span>
+              <textarea
+                className="defense-textarea"
+                rows={5}
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                placeholder="Explain your understanding of this concept in your own words..."
+                disabled={submitting}
+              />
+            </label>
+            <button
+              className="action-btn"
+              onClick={handleSubmitAnswer}
+              disabled={submitting || answer.trim().length === 0}
+            >
+              {submitting ? "Submitting..." : "Submit answer"}
+            </button>
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Render: Results                                                  */
+  /* ---------------------------------------------------------------- */
+
+  if (phase === "results" && results) {
+    return (
+      <section className="defense-results">
+        {/* Summary */}
+        <div
+          className={`defense-results-hero panel ${results.passed ? "defense-results-hero--passed" : "defense-results-hero--failed"}`}
+        >
+          <p className="eyebrow">Defense complete</p>
+          <h2>{results.passed ? "Passed" : "Not passed"}</h2>
+          <p className="defense-results-score">
+            {Math.round(results.overall_score * 100)}%
+          </p>
+          <p>{results.summary}</p>
+          {results.timed_out_questions > 0 && (
+            <p className="muted">
+              {results.timed_out_questions} question(s) timed out
+            </p>
+          )}
+        </div>
+
+        {/* Per-question results */}
+        <div className="defense-results-list">
+          {results.question_results.map((qr, i) => (
+            <div
+              key={qr.question_id}
+              className={`defense-result-card panel ${qr.score >= 0.7 ? "defense-result-card--good" : qr.score >= 0.4 ? "defense-result-card--partial" : "defense-result-card--low"}`}
+            >
+              <div className="defense-result-header">
+                <span className="eyebrow">Question {i + 1}</span>
+                <span className="pill">{qr.skill}</span>
+              </div>
+              <p className="defense-result-question">{qr.question}</p>
+              <div className="defense-result-meta">
+                <strong>{Math.round(qr.score * 100)}%</strong>
+                {qr.timed_out && (
+                  <span className="pill pill--in_progress">Timed out</span>
+                )}
+                {!qr.answered && (
+                  <span className="pill pill--todo">Not answered</span>
+                )}
+                <span className="muted">
+                  {qr.elapsed_seconds.toFixed(1)}s
+                </span>
+              </div>
+              <p className="defense-result-feedback">{qr.feedback}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="defense-actions">
+          <button className="action-btn" onClick={handleReset}>
+            New defense
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  /* Fallback: loading or error state */
+  return (
+    <section className="panel">
+      {error ? (
+        <>
+          <p className="defense-error">{error}</p>
+          <button className="action-btn" onClick={handleReset}>
+            Try again
+          </button>
+        </>
+      ) : (
+        <p className="muted">Loading...</p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/defense/page.tsx
+++ b/apps/web/app/defense/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+
+import { getDashboardData } from "@/lib/api";
+
+import DefenseClient from "./DefenseClient";
+
+export const metadata = {
+  title: "Defense — 42 Training",
+  description: "Oral defense and guided review for 42 Lausanne preparation",
+};
+
+export default async function DefensePage() {
+  const data = await getDashboardData();
+
+  /* Flatten all modules with their track context */
+  const modules = data.curriculum.tracks.flatMap((track) =>
+    track.modules.map((mod) => ({
+      id: mod.id,
+      title: mod.title,
+      phase: mod.phase,
+      trackId: track.id,
+      trackTitle: track.title,
+    }))
+  );
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+  return (
+    <main className="page-shell defense-page">
+      <nav className="breadcrumb">
+        <Link href="/">Dashboard</Link>
+        <span className="breadcrumb-sep">/</span>
+        <span>Defense</span>
+      </nav>
+
+      <section className="defense-hero panel">
+        <p className="eyebrow">Oral defense</p>
+        <h1>Defense and guided review</h1>
+        <p className="lead">
+          Test your understanding of module skills through timed questions.
+          Explain concepts in your own words — no solutions are provided. This
+          simulates the 42-style oral defense where you must demonstrate genuine
+          understanding.
+        </p>
+      </section>
+
+      <DefenseClient modules={modules} apiUrl={apiUrl} />
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1301,4 +1301,267 @@ a {
   .action-btn {
     min-height: unset;
   }
+
+  .defense-field-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .defense-results-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Defense page                                                       */
+/* ------------------------------------------------------------------ */
+
+.defense-page {
+  max-width: 900px;
+}
+
+.defense-hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  line-height: 1.1;
+}
+
+/* Setup form */
+
+.defense-setup {
+  display: grid;
+  gap: 16px;
+}
+
+.defense-form {
+  display: grid;
+  gap: 16px;
+  margin-top: 4px;
+}
+
+.defense-field {
+  display: grid;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.defense-field select,
+.defense-field input {
+  width: 100%;
+  min-height: 48px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(28, 26, 23, 0.14);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--ink);
+  font: inherit;
+}
+
+.defense-field select:focus,
+.defense-field input:focus {
+  outline: 2px solid rgba(28, 93, 99, 0.22);
+  outline-offset: 2px;
+  border-color: rgba(28, 93, 99, 0.35);
+}
+
+.defense-field-row {
+  display: grid;
+  gap: 16px;
+}
+
+/* Active session */
+
+.defense-active {
+  display: grid;
+  gap: 16px;
+}
+
+.defense-progress {
+  display: grid;
+  gap: 10px;
+}
+
+.defense-progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.defense-timer {
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--ink);
+  transition: color 0.2s;
+}
+
+.defense-timer--warning {
+  color: #7a5a16;
+}
+
+.defense-timer--critical {
+  color: var(--c);
+  animation: pulse 1s infinite;
+}
+
+.defense-question {
+  display: grid;
+  gap: 12px;
+}
+
+.defense-question-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.defense-question-text {
+  font-size: 1.1rem;
+  line-height: 1.5;
+}
+
+.defense-answer {
+  display: grid;
+  gap: 14px;
+}
+
+.defense-textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(28, 26, 23, 0.14);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--ink);
+  font: inherit;
+  font-size: 15px;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+.defense-textarea:focus {
+  outline: 2px solid rgba(28, 93, 99, 0.22);
+  outline-offset: 2px;
+  border-color: rgba(28, 93, 99, 0.35);
+}
+
+.defense-textarea::placeholder {
+  color: var(--muted);
+}
+
+/* Feedback flash */
+
+.defense-feedback {
+  display: grid;
+  gap: 8px;
+}
+
+.defense-feedback-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.defense-feedback--good {
+  border-left: 5px solid var(--python);
+}
+
+.defense-feedback--partial {
+  border-left: 5px solid var(--accent);
+}
+
+.defense-feedback--low {
+  border-left: 5px solid var(--c);
+}
+
+/* Results */
+
+.defense-results {
+  display: grid;
+  gap: 18px;
+}
+
+.defense-results-hero {
+  text-align: center;
+}
+
+.defense-results-hero--passed {
+  border-left: 6px solid var(--python);
+}
+
+.defense-results-hero--failed {
+  border-left: 6px solid var(--c);
+}
+
+.defense-results-score {
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 3rem;
+  font-weight: 700;
+  margin: 8px 0;
+  line-height: 1;
+}
+
+.defense-results-list {
+  display: grid;
+  gap: 14px;
+}
+
+.defense-result-card {
+  display: grid;
+  gap: 10px;
+}
+
+.defense-result-card--good {
+  border-left: 4px solid var(--python);
+}
+
+.defense-result-card--partial {
+  border-left: 4px solid var(--accent);
+}
+
+.defense-result-card--low {
+  border-left: 4px solid var(--c);
+}
+
+.defense-result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.defense-result-question {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.defense-result-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.defense-result-meta strong {
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 1.1rem;
+}
+
+.defense-result-feedback {
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.defense-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.defense-error {
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(178, 76, 43, 0.1);
+  border: 1px solid rgba(178, 76, 43, 0.2);
+  color: var(--c);
+  font-size: 14px;
 }


### PR DESCRIPTION
## Summary
- Add oral defense web UI at `/defense` with three phases: setup (module/config selection), active session (timed questions with countdown and answer submission), and results (per-question scored feedback with pass/fail summary)
- Wire up to existing `/api/v1/defense/*` API endpoints (start, answer, result)
- Add "Defense" link to the navigation header between Progression and Profiles

## Test plan
- [ ] Verify `/defense` page loads with module selection form
- [ ] Start a defense session and confirm timed questions appear
- [ ] Submit answers and verify feedback is displayed
- [ ] Complete all questions and confirm results summary shows pass/fail
- [ ] Check timer countdown and warning states (15s yellow, 5s red)
- [ ] Verify `npx tsc --noEmit` and `npm run lint` pass

Closes #130

Generated with [Claude Code](https://claude.com/claude-code)