### PR TITLE
feat: bind JWT sessions to active learner profile (#127)

### DIFF
--- a/services/api/app/auth.py
+++ b/services/api/app/auth.py
@@ -81,14 +81,17 @@ def verify_password(password: str, password_hash: str) -> bool:
     return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))  # type: ignore[no-any-return]
 
 
-def create_access_token(user: UserAccount) -> str:
+def create_access_token(user: UserAccount, *, profile_id: str | None = None) -> str:
     now = datetime.now(UTC)
-    payload = {
+    active_pid = profile_id if profile_id is not None else user.active_profile_id
+    payload: dict[str, object] = {
         "sub": user.id,
         "email": user.email,
         "iat": now,
         "exp": now + timedelta(minutes=ACCESS_TOKEN_TTL_MINUTES),
     }
+    if active_pid is not None:
+        payload["profile_id"] = active_pid
     return jwt.encode(payload, get_jwt_secret(), algorithm=JWT_ALGORITHM)  # type: ignore[no-any-return]
 
 
@@ -120,9 +123,20 @@ def serialize_profiles(profiles: list[LearnerProfile]) -> list[AuthLearnerProfil
     ]
 
 
-def build_token_response(user: UserAccount) -> AuthTokenResponse:
+def get_jwt_active_profile(user: UserAccount) -> LearnerProfile | None:
+    """Return the profile bound to the current JWT, falling back to the DB active_profile."""
+    return getattr(user, "_jwt_active_profile", None) or user.active_profile
+
+
+def get_jwt_active_profile_id(user: UserAccount) -> str | None:
+    """Return the profile id bound to the current JWT, falling back to the DB active_profile_id."""
+    return getattr(user, "_jwt_active_profile_id", None) or user.active_profile_id  # type: ignore[no-any-return]
+
+
+def build_token_response(user: UserAccount, *, profile_id: str | None = None) -> AuthTokenResponse:
+    effective_profile_id = profile_id or user.active_profile_id
     return AuthTokenResponse(
-        access_token=create_access_token(user),
+        access_token=create_access_token(user, profile_id=effective_profile_id),
         expires_in=ACCESS_TOKEN_TTL_MINUTES * 60,
         user=serialize_user(user),
         learner_profile=serialize_learner_profile(user.active_profile),
@@ -173,6 +187,16 @@ async def get_current_user(
     if user is None:
         raise unauthorized()
 
+    # Resolve active profile from JWT claim so the session stays bound to the
+    # profile that was active when the token was issued.
+    jwt_profile_id = payload.get("profile_id")
+    if isinstance(jwt_profile_id, str) and jwt_profile_id:
+        profiles_by_id = {p.id: p for p in user.profiles}
+        jwt_profile = profiles_by_id.get(jwt_profile_id)
+        if jwt_profile is not None:
+            object.__setattr__(user, "_jwt_active_profile", jwt_profile)
+            object.__setattr__(user, "_jwt_active_profile_id", jwt_profile_id)
+
     return user
 
 
@@ -219,6 +243,38 @@ async def login(
 async def me(current_user: UserAccount = Depends(get_current_user)) -> AuthMeResponse:
     return AuthMeResponse(
         user=serialize_user(current_user),
-        learner_profile=serialize_learner_profile(current_user.active_profile),
+        learner_profile=serialize_learner_profile(get_jwt_active_profile(current_user)),
         profiles=serialize_profiles(current_user.profiles),
     )
+
+
+class SwitchProfileRequest(BaseModel):
+    profile_id: str = Field(min_length=1, max_length=64)
+
+
+@router.post("/switch-profile", response_model=AuthTokenResponse)
+async def switch_profile(
+    payload: SwitchProfileRequest,
+    current_user: UserAccount = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> AuthTokenResponse:
+    """Switch active profile and return a new JWT bound to that profile."""
+    profiles_by_id = {p.id: p for p in current_user.profiles}
+    target_profile = profiles_by_id.get(payload.profile_id)
+    if target_profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Profile not found")
+
+    current_user.active_profile_id = target_profile.id
+    await db.commit()
+
+    user = await load_user_with_profiles(db, user_id=current_user.id)
+    assert user is not None
+    return build_token_response(user, profile_id=target_profile.id)
+
+
+@router.post("/refresh", response_model=AuthTokenResponse)
+async def refresh(
+    current_user: UserAccount = Depends(get_current_user),
+) -> AuthTokenResponse:
+    """Return a fresh JWT preserving the current active profile."""
+    return build_token_response(current_user, profile_id=get_jwt_active_profile_id(current_user))

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -364,3 +364,139 @@ def test_profiles_switch_changes_active_profile_only_within_user_scope(
     )
 
     assert forbidden_response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# JWT profile-binding tests (issue #127)
+# ---------------------------------------------------------------------------
+
+
+def test_jwt_contains_active_profile_id_after_login(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    """Login JWT should embed the active_profile_id when one exists."""
+    client, session_factory = auth_client
+    reg = client.post("/api/v1/auth/register", json={"email": "jwt@example.com", "password": "supersecret"})
+    user_id = reg.json()["user"]["id"]
+
+    asyncio.run(
+        _create_profile_for_user(session_factory, user_id=user_id, login="jwt-shell", track="shell", activate=True)
+    )
+
+    login_resp = client.post("/api/v1/auth/login", json={"email": "jwt@example.com", "password": "supersecret"})
+    assert login_resp.status_code == 200
+    token_payload = jwt.decode(login_resp.json()["access_token"], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
+    assert "profile_id" in token_payload
+
+
+def test_jwt_omits_profile_id_when_none_active(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    """Register JWT (no profiles yet) should not contain profile_id."""
+    client, _session_factory = auth_client
+    reg = client.post("/api/v1/auth/register", json={"email": "noprofile@example.com", "password": "supersecret"})
+    token_payload = jwt.decode(reg.json()["access_token"], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
+    assert "profile_id" not in token_payload
+
+
+def test_auth_switch_profile_returns_new_jwt_with_profile_id(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    """POST /auth/switch-profile should return a new JWT bound to the target profile."""
+    client, session_factory = auth_client
+    reg = client.post("/api/v1/auth/register", json={"email": "switch@example.com", "password": "supersecret"})
+    token = reg.json()["access_token"]
+    user_id = reg.json()["user"]["id"]
+
+    asyncio.run(
+        _create_profile_for_user(session_factory, user_id=user_id, login="switch-shell", track="shell", activate=True)
+    )
+    c_profile = asyncio.run(_create_profile_for_user(session_factory, user_id=user_id, login="switch-c", track="c"))
+
+    resp = client.post(
+        "/api/v1/auth/switch-profile",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"profile_id": c_profile.id},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["user"]["id"] == user_id
+
+    new_payload = jwt.decode(data["access_token"], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
+    assert new_payload["profile_id"] == c_profile.id
+
+
+def test_auth_switch_profile_rejects_foreign_profile(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    """Switching to another user's profile should return 404."""
+    client, session_factory = auth_client
+    first = client.post("/api/v1/auth/register", json={"email": "a@example.com", "password": "supersecret"})
+    first_token = first.json()["access_token"]
+
+    second = client.post("/api/v1/auth/register", json={"email": "b@example.com", "password": "supersecret"})
+    second_user_id = second.json()["user"]["id"]
+    foreign = asyncio.run(
+        _create_profile_for_user(
+            session_factory, user_id=second_user_id, login="foreign-shell", track="shell", activate=True
+        )
+    )
+
+    resp = client.post(
+        "/api/v1/auth/switch-profile",
+        headers={"Authorization": f"Bearer {first_token}"},
+        json={"profile_id": foreign.id},
+    )
+    assert resp.status_code == 404
+
+
+def test_auth_refresh_preserves_profile_id(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    """POST /auth/refresh should return a new JWT keeping the same profile_id."""
+    client, session_factory = auth_client
+    reg = client.post("/api/v1/auth/register", json={"email": "refresh@example.com", "password": "supersecret"})
+    user_id = reg.json()["user"]["id"]
+
+    profile = asyncio.run(
+        _create_profile_for_user(session_factory, user_id=user_id, login="refresh-shell", track="shell", activate=True)
+    )
+
+    # Login to get a token with profile_id
+    login_resp = client.post("/api/v1/auth/login", json={"email": "refresh@example.com", "password": "supersecret"})
+    token = login_resp.json()["access_token"]
+
+    resp = client.post("/api/v1/auth/refresh", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+    new_payload = jwt.decode(resp.json()["access_token"], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
+    assert new_payload["profile_id"] == profile.id
+
+
+def test_me_reflects_jwt_bound_profile(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    """GET /auth/me should show the profile from the JWT, not necessarily the DB active one."""
+    client, session_factory = auth_client
+    reg = client.post("/api/v1/auth/register", json={"email": "me-jwt@example.com", "password": "supersecret"})
+    user_id = reg.json()["user"]["id"]
+
+    asyncio.run(
+        _create_profile_for_user(session_factory, user_id=user_id, login="me-shell", track="shell", activate=True)
+    )
+    c_profile = asyncio.run(_create_profile_for_user(session_factory, user_id=user_id, login="me-c", track="c"))
+
+    # Switch to C profile via auth endpoint (gets new JWT)
+    login_resp = client.post("/api/v1/auth/login", json={"email": "me-jwt@example.com", "password": "supersecret"})
+    token = login_resp.json()["access_token"]
+
+    switch_resp = client.post(
+        "/api/v1/auth/switch-profile",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"profile_id": c_profile.id},
+    )
+    new_token = switch_resp.json()["access_token"]
+
+    me_resp = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {new_token}"})
+    assert me_resp.status_code == 200
+    assert me_resp.json()["learner_profile"]["id"] == c_profile.id


### PR DESCRIPTION
## Summary
- Embeds `profile_id` in JWT payload when the user has an active learner profile
- `get_current_user()` now resolves the active profile from the JWT claim, so each session stays bound to the profile that was active when the token was issued
- Adds `POST /auth/switch-profile` endpoint that updates `active_profile_id` in DB and returns a fresh JWT bound to the new profile
- Adds `POST /auth/refresh` endpoint that issues a new JWT preserving the current profile binding
- `GET /auth/me` now reflects the JWT-bound profile rather than always reading from DB

Closes #127

## Test plan
- [x] `test_jwt_contains_active_profile_id_after_login` -- login JWT includes profile_id
- [x] `test_jwt_omits_profile_id_when_none_active` -- no profile_id when no active profile
- [x] `test_auth_switch_profile_returns_new_jwt_with_profile_id` -- switch returns new JWT
- [x] `test_auth_switch_profile_rejects_foreign_profile` -- cannot switch to another user's profile
- [x] `test_auth_refresh_preserves_profile_id` -- refresh keeps profile_id
- [x] `test_me_reflects_jwt_bound_profile` -- /me shows JWT-bound profile
- [x] All 11 pre-existing auth tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)