### PR TITLE
feat: bind jwt sessions to active profiles (#127)

### DIFF
--- a/services/api/app/auth.py
+++ b/services/api/app/auth.py
@@ -65,6 +65,10 @@ class AuthMeResponse(BaseModel):
     profiles: list[AuthLearnerProfileResponse] = Field(default_factory=list)
 
 
+class SwitchProfileRequest(BaseModel):
+    profile_id: str = Field(min_length=1, max_length=64)
+
+
 def get_jwt_secret() -> str:
     return os.getenv("JWT_SECRET", "dev-secret-change-me")
 
@@ -81,11 +85,34 @@ def verify_password(password: str, password_hash: str) -> bool:
     return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))  # type: ignore[no-any-return]
 
 
+def get_active_profile_id(user: UserAccount) -> str | None:
+    jwt_profile_id = getattr(user, "_jwt_active_profile_id", None)
+    if isinstance(jwt_profile_id, str) and jwt_profile_id:
+        return jwt_profile_id
+    return user.active_profile_id or user.learner_profile_id
+
+
+def get_active_profile(user: UserAccount) -> LearnerProfile | None:
+    jwt_profile = getattr(user, "_jwt_active_profile", None)
+    if isinstance(jwt_profile, LearnerProfile):
+        return jwt_profile
+
+    if user.active_profile is not None:
+        return user.active_profile
+
+    active_profile_id = user.active_profile_id or user.learner_profile_id
+    if active_profile_id is None:
+        return None
+
+    return next((profile for profile in user.profiles if profile.id == active_profile_id), None)
+
+
 def create_access_token(user: UserAccount) -> str:
     now = datetime.now(UTC)
     payload = {
         "sub": user.id,
         "email": user.email,
+        "profile_id": get_active_profile_id(user),
         "iat": now,
         "exp": now + timedelta(minutes=ACCESS_TOKEN_TTL_MINUTES),
     }
@@ -125,7 +152,7 @@ def build_token_response(user: UserAccount) -> AuthTokenResponse:
         access_token=create_access_token(user),
         expires_in=ACCESS_TOKEN_TTL_MINUTES * 60,
         user=serialize_user(user),
-        learner_profile=serialize_learner_profile(user.active_profile),
+        learner_profile=serialize_learner_profile(get_active_profile(user)),
         profiles=serialize_profiles(user.profiles),
     )
 
@@ -138,10 +165,24 @@ def unauthorized(detail: str = "Invalid authentication credentials") -> HTTPExce
     )
 
 
+def clear_jwt_profile_context(user: UserAccount) -> UserAccount:
+    user.__dict__.pop("_jwt_active_profile_id", None)
+    user.__dict__.pop("_jwt_active_profile", None)
+    return user
+
+
 async def load_user_with_profiles(
     db: AsyncSession, *, user_id: str | None = None, email: str | None = None
 ) -> UserAccount | None:
-    query = select(UserAccount).options(selectinload(UserAccount.active_profile), selectinload(UserAccount.profiles))
+    query = (
+        select(UserAccount)
+        .execution_options(populate_existing=True)
+        .options(
+            selectinload(UserAccount.active_profile),
+            selectinload(UserAccount.profiles),
+            selectinload(UserAccount.learner_profile),
+        )
+    )
     if user_id is not None:
         query = query.where(UserAccount.id == user_id)
     elif email is not None:
@@ -150,7 +191,10 @@ async def load_user_with_profiles(
         raise ValueError("load_user_with_profiles requires user_id or email")
 
     result = await db.execute(query)
-    return result.scalar_one_or_none()
+    user = result.scalar_one_or_none()
+    if user is None:
+        return None
+    return clear_jwt_profile_context(user)
 
 
 async def get_current_user(
@@ -166,13 +210,31 @@ async def get_current_user(
         raise unauthorized() from exc
 
     user_id = payload.get("sub")
+    profile_id = payload.get("profile_id")
     if not isinstance(user_id, str) or not user_id:
+        raise unauthorized()
+    if profile_id is not None and not isinstance(profile_id, str):
         raise unauthorized()
 
     user = await load_user_with_profiles(db, user_id=user_id)
     if user is None:
         raise unauthorized()
 
+    if profile_id is None:
+        return user
+
+    resolved_profile = next((profile for profile in user.profiles if profile.id == profile_id), None)
+    if resolved_profile is None and user.learner_profile_id == profile_id:
+        profile_result = await db.execute(select(LearnerProfile).where(LearnerProfile.id == profile_id))
+        resolved_profile = profile_result.scalar_one_or_none()
+
+    if resolved_profile is None or (
+        resolved_profile.user_account_id is not None and resolved_profile.user_account_id != user.id
+    ):
+        raise unauthorized("Active profile is not available for this user")
+
+    user._jwt_active_profile_id = resolved_profile.id  # type: ignore[attr-defined]
+    user._jwt_active_profile = resolved_profile  # type: ignore[attr-defined]
     return user
 
 
@@ -219,6 +281,32 @@ async def login(
 async def me(current_user: UserAccount = Depends(get_current_user)) -> AuthMeResponse:
     return AuthMeResponse(
         user=serialize_user(current_user),
-        learner_profile=serialize_learner_profile(current_user.active_profile),
+        learner_profile=serialize_learner_profile(get_active_profile(current_user)),
         profiles=serialize_profiles(current_user.profiles),
     )
+
+
+@router.post("/switch-profile", response_model=AuthTokenResponse)
+async def switch_profile(
+    payload: SwitchProfileRequest,
+    current_user: UserAccount = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> AuthTokenResponse:
+    current_user = await load_user_with_profiles(db, user_id=current_user.id)
+    assert current_user is not None
+
+    result = await db.execute(
+        select(LearnerProfile).where(
+            LearnerProfile.id == payload.profile_id, LearnerProfile.user_account_id == current_user.id
+        )
+    )
+    profile = result.scalar_one_or_none()
+    if profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Profile not found")
+
+    current_user.active_profile_id = profile.id
+    await db.commit()
+
+    refreshed_user = await load_user_with_profiles(db, user_id=current_user.id)
+    assert refreshed_user is not None
+    return build_token_response(refreshed_user)

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -14,8 +14,9 @@ from alembic.config import Config
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import selectinload
 
-from app.auth import JWT_ALGORITHM, get_jwt_secret
+from app.auth import JWT_ALGORITHM, create_access_token, get_jwt_secret
 from app.db import get_db_session
 from app.main import app
 from app.models import Base, LearnerProfile, UserAccount
@@ -60,6 +61,23 @@ async def _get_user_by_email(
         return result.scalar_one()
 
 
+async def _get_user_with_profiles(
+    session_factory: async_sessionmaker[AsyncSession],
+    email: str,
+) -> UserAccount:
+    async with session_factory() as session:
+        result = await session.execute(
+            select(UserAccount)
+            .options(
+                selectinload(UserAccount.active_profile),
+                selectinload(UserAccount.profiles),
+                selectinload(UserAccount.learner_profile),
+            )
+            .where(UserAccount.email == email)
+        )
+        return result.scalar_one()
+
+
 async def _create_profile_for_user(
     session_factory: async_sessionmaker[AsyncSession],
     *,
@@ -75,8 +93,8 @@ async def _create_profile_for_user(
             track=track,
             current_module=current_module,
             user_account_id=user_id,
+            runtime_state={},
             started_at=datetime.now(UTC),
-            updated_at=datetime.now(UTC),
         )
         session.add(profile)
         await session.flush()
@@ -111,6 +129,7 @@ def test_register_creates_user_with_bcrypt_hash(
     token_payload = jwt.decode(data["access_token"], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
     assert token_payload["email"] == "student@example.com"
     assert token_payload["sub"] == data["user"]["id"]
+    assert token_payload["profile_id"] is None
 
     user = asyncio.run(_get_user_by_email(session_factory, "student@example.com"))
     assert user.password_hash != "supersecret"
@@ -144,6 +163,32 @@ def test_login_returns_jwt_and_updates_last_login(
 
     user = asyncio.run(_get_user_by_email(session_factory, "student@example.com"))
     assert user.last_login_at is not None
+
+
+def test_login_token_includes_active_profile_id(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    client, session_factory = auth_client
+    register_response = client.post(
+        "/api/v1/auth/register", json={"email": "student@example.com", "password": "supersecret"}
+    )
+    user_id = register_response.json()["user"]["id"]
+    profile = asyncio.run(
+        _create_profile_for_user(
+            session_factory,
+            user_id=user_id,
+            login="student-shell",
+            track="shell",
+            current_module="shell-basics",
+            activate=True,
+        )
+    )
+
+    response = client.post("/api/v1/auth/login", json={"email": "student@example.com", "password": "supersecret"})
+
+    assert response.status_code == 200
+    token_payload = jwt.decode(response.json()["access_token"], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
+    assert token_payload["profile_id"] == profile.id
 
 
 def test_login_rejects_invalid_password(auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]]) -> None:
@@ -180,6 +225,47 @@ def test_me_returns_current_user_from_bearer_token(
     }
 
 
+def test_me_resolves_active_profile_from_jwt(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    client, session_factory = auth_client
+    register_response = client.post(
+        "/api/v1/auth/register", json={"email": "student@example.com", "password": "supersecret"}
+    )
+    user_id = register_response.json()["user"]["id"]
+    active_profile = asyncio.run(
+        _create_profile_for_user(
+            session_factory,
+            user_id=user_id,
+            login="student-shell",
+            track="shell",
+            current_module="shell-basics",
+            activate=True,
+        )
+    )
+    jwt_profile = asyncio.run(
+        _create_profile_for_user(
+            session_factory,
+            user_id=user_id,
+            login="student-c",
+            track="c",
+            current_module="c-basics",
+        )
+    )
+    user = asyncio.run(_get_user_with_profiles(session_factory, "student@example.com"))
+    user._jwt_active_profile_id = jwt_profile.id  # type: ignore[attr-defined]
+    user._jwt_active_profile = jwt_profile  # type: ignore[attr-defined]
+    token = create_access_token(user)
+
+    response = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json()["learner_profile"]["id"] == jwt_profile.id
+    assert response.json()["learner_profile"]["login"] == "student-c"
+    assert {item["track"] for item in response.json()["profiles"]} == {"shell", "c"}
+    assert response.json()["learner_profile"]["id"] != active_profile.id
+
+
 def test_me_requires_bearer_token(auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]]) -> None:
     client, _session_factory = auth_client
 
@@ -187,6 +273,98 @@ def test_me_requires_bearer_token(auth_client: tuple[TestClient, async_sessionma
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Invalid authentication credentials"
+
+
+def test_switch_profile_returns_new_token_and_updates_active_profile(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    client, session_factory = auth_client
+    register_response = client.post(
+        "/api/v1/auth/register", json={"email": "student@example.com", "password": "supersecret"}
+    )
+    user_id = register_response.json()["user"]["id"]
+    asyncio.run(
+        _create_profile_for_user(
+            session_factory,
+            user_id=user_id,
+            login="student-shell",
+            track="shell",
+            activate=True,
+        )
+    )
+    profile = asyncio.run(
+        _create_profile_for_user(
+            session_factory,
+            user_id=user_id,
+            login="student-c",
+            track="c",
+        )
+    )
+
+    login_response = client.post("/api/v1/auth/login", json={"email": "student@example.com", "password": "supersecret"})
+    token = login_response.json()["access_token"]
+
+    response = client.post(
+        "/api/v1/auth/switch-profile",
+        json={"profile_id": profile.id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["learner_profile"]["id"] == profile.id
+    assert {item["track"] for item in data["profiles"]} == {"shell", "c"}
+
+    token_payload = jwt.decode(data["access_token"], get_jwt_secret(), algorithms=[JWT_ALGORITHM])
+    assert token_payload["profile_id"] == profile.id
+
+    user = asyncio.run(_get_user_by_email(session_factory, "student@example.com"))
+    assert user.active_profile_id == profile.id
+
+
+def test_switch_profile_rejects_unavailable_profile(
+    auth_client: tuple[TestClient, async_sessionmaker[AsyncSession]],
+) -> None:
+    client, session_factory = auth_client
+    first_response = client.post(
+        "/api/v1/auth/register", json={"email": "student@example.com", "password": "supersecret"}
+    )
+    first_user_id = first_response.json()["user"]["id"]
+    asyncio.run(
+        _create_profile_for_user(
+            session_factory,
+            user_id=first_user_id,
+            login="student-shell",
+            track="shell",
+            activate=True,
+        )
+    )
+
+    second_response = client.post(
+        "/api/v1/auth/register", json={"email": "other@example.com", "password": "supersecret"}
+    )
+    second_user_id = second_response.json()["user"]["id"]
+    foreign_profile = asyncio.run(
+        _create_profile_for_user(
+            session_factory,
+            user_id=second_user_id,
+            login="other-c",
+            track="c",
+            activate=True,
+        )
+    )
+
+    login_response = client.post("/api/v1/auth/login", json={"email": "student@example.com", "password": "supersecret"})
+    token = login_response.json()["access_token"]
+
+    response = client.post(
+        "/api/v1/auth/switch-profile",
+        json={"profile_id": foreign_profile.id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Profile not found"
 
 
 def test_alembic_upgrade_head_creates_user_accounts_table(tmp_path: Path) -> None:
@@ -209,6 +387,7 @@ def test_alembic_upgrade_head_creates_user_accounts_table(tmp_path: Path) -> Non
         "password_hash",
         "status",
         "learner_profile_id",
+        "active_profile_id",
         "last_login_at",
         "created_at",
         "updated_at",


### PR DESCRIPTION
Closes #127.

## Summary
- add  to JWT payloads and resolve the active profile from the token in auth dependencies
- add  to update the active profile and return a fresh token
- add the missing  column on  in local develop as a prerequisite migration, backfilled from 
- extend auth tests around token payloads, profile resolution, endpoint behavior, and Alembic head

## Validation
- pytest -q services/api/tests/test_auth.py
- pytest -q services/api/tests