### PR TITLE
fix: align gateway event forwarding (#157)

### DIFF
--- a/services/ai_gateway/app/events.py
+++ b/services/ai_gateway/app/events.py
@@ -9,6 +9,7 @@ import httpx
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_BASE_URL = "http://localhost:8000"
+PEDAGOGICAL_EVENTS_PATH = "/api/v1/events"
 
 
 def emit_event(
@@ -25,7 +26,7 @@ def emit_event(
     api_base_url = os.getenv("AI_GATEWAY_API_BASE_URL", DEFAULT_API_BASE_URL).rstrip("/")
     try:
         response = httpx.post(
-            f"{api_base_url}/api/v1/internal/pedagogical-events",
+            f"{api_base_url}{PEDAGOGICAL_EVENTS_PATH}",
             json={
                 "event_type": event_type,
                 "learner_id": learner_id,

--- a/services/ai_gateway/tests/test_events.py
+++ b/services/ai_gateway/tests/test_events.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.events import emit_event
+
+
+def test_emit_event_forwards_to_public_api_events_endpoint() -> None:
+    fake_response = MagicMock()
+    fake_response.raise_for_status.return_value = None
+
+    with (
+        patch.dict("os.environ", {"AI_GATEWAY_API_BASE_URL": "http://api-service:8000"}, clear=False),
+        patch("app.events.httpx.post", return_value=fake_response) as mock_post,
+    ):
+        emit_event(
+            "mentor_query",
+            learner_id="learner-42",
+            track_id="shell",
+            module_id="shell-basics",
+            payload={"question": "How do I debug cp?"},
+        )
+
+    mock_post.assert_called_once_with(
+        "http://api-service:8000/api/v1/events",
+        json={
+            "event_type": "mentor_query",
+            "learner_id": "learner-42",
+            "track_id": "shell",
+            "module_id": "shell-basics",
+            "checkpoint_index": None,
+            "source_service": "ai_gateway",
+            "payload": {"question": "How do I debug cp?"},
+        },
+        timeout=0.5,
+    )
+
+
+def test_emit_event_swallows_forwarding_failures() -> None:
+    with patch("app.events.httpx.post", side_effect=RuntimeError("boom")):
+        emit_event("module_started", learner_id="learner-42")

--- a/services/api/tests/test_events_api.py
+++ b/services/api/tests/test_events_api.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_event_uses_public_api_events_endpoint_contract() -> None:
+    with patch("app.main._emit_event_async", new=AsyncMock(return_value="evt-123")) as mock_emit:
+        response = client.post(
+            "/api/v1/events",
+            json={
+                "event_type": "mentor_query",
+                "learner_id": "learner-42",
+                "track_id": "shell",
+                "module_id": "shell-basics",
+                "checkpoint_index": 0,
+                "source_service": "ai_gateway",
+                "payload": {"question": "How do I debug cp?"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "recorded", "event_id": "evt-123"}
+    mock_emit.assert_awaited_once_with(
+        "mentor_query",
+        learner_id="learner-42",
+        track_id="shell",
+        module_id="shell-basics",
+        checkpoint_index=0,
+        source_service="ai_gateway",
+        payload={"question": "How do I debug cp?"},
+    )


### PR DESCRIPTION
Closes #157.

## Summary
- align AI gateway event forwarding with the real backend ingestion endpoint at POST /api/v1/events
- add a gateway test that locks the forwarded URL and JSON payload
- add an API test that locks the public /api/v1/events contract and the call into _emit_event_async

## Verification
- cd services/ai_gateway && pytest -q tests/test_events.py
- cd services/api && pytest -q tests/test_events_api.py
- cd services/ai_gateway && pytest -q
- cd services/api && pytest -q