### PR TITLE
feat: emit pedagogical events from progression mutations (#156)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .analytics import build_analytics_dashboard, fetch_pedagogical_events
 from .auth import router as auth_router
 from .db import get_db_session
-from .events import _emit_event_async, emit_event  # noqa: F401
+from .events import _emit_event_async, emit_event
 from .models import DefenseSession as DefenseSessionModel
 from .models import ReviewAttempt as ReviewAttemptModel
 from .profiles import router as profiles_router
@@ -287,6 +287,13 @@ def module_start(module_id: str, payload: ModuleStartRequest | None = None) -> M
     now = datetime.now(UTC).isoformat()
     statuses[module_id] = {"status": "in_progress", "started_at": now}
     write_progression(progression_data)
+    emit_event(
+        "module_started",
+        learner_id=str(payload.learner_id) if payload is not None else "default",
+        track_id=str(track["id"]),
+        module_id=module_id,
+        payload={"status": "in_progress", "started_at": now},
+    )
 
     return ModuleProgressionResponse(
         module_id=module_id,
@@ -314,6 +321,13 @@ def module_complete(module_id: str, payload: ModuleCompleteRequest | None = None
     current["completed_at"] = now
     statuses[module_id] = current
     write_progression(progression_data)
+    emit_event(
+        "module_completed",
+        learner_id=str(payload.learner_id) if payload is not None else "default",
+        track_id=str(track["id"]),
+        module_id=module_id,
+        payload={"status": "completed", "completed_at": now},
+    )
 
     return ModuleProgressionResponse(
         module_id=module_id,
@@ -335,6 +349,13 @@ def module_skip(module_id: str, payload: ModuleSkipRequest | None = None) -> Mod
         entry["skip_reason"] = payload.reason
     statuses[module_id] = entry
     write_progression(progression_data)
+    emit_event(
+        "module_skipped",
+        learner_id=str(payload.learner_id) if payload is not None else "default",
+        track_id=str(track["id"]),
+        module_id=module_id,
+        payload=dict(entry),
+    )
 
     return ModuleProgressionResponse(
         module_id=module_id,
@@ -549,6 +570,22 @@ def submit_checkpoint(payload: CheckpointSubmission) -> CheckpointRecord:
     checkpoints = progression_data.setdefault("checkpoints", [])
     checkpoints.append(record.model_dump())
     write_progression(progression_data)
+    module_track_id = str(module.get("track_id", ""))
+    if not module_track_id:
+        module_context = _find_module(payload.module_id)
+        module_track_id = str(module_context[0]["id"])
+    emit_event(
+        "checkpoint_submitted",
+        learner_id="default",
+        track_id=module_track_id,
+        module_id=payload.module_id,
+        checkpoint_index=payload.checkpoint_index,
+        payload={
+            "type": payload.type,
+            "self_evaluation": payload.self_evaluation,
+            "submitted_at": now,
+        },
+    )
 
     return record
 

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -290,6 +290,7 @@ class CheckpointListResponse(BaseModel):
 PedagogicalEventType = Literal[
     "module_started",
     "module_completed",
+    "module_skipped",
     "checkpoint_submitted",
     "mentor_query",
     "defense_started",

--- a/services/api/tests/test_checkpoints.py
+++ b/services/api/tests/test_checkpoints.py
@@ -309,6 +309,31 @@ class TestSubmitCheckpoint:
         assert r.status_code == 200
         assert r.json()["type"] == "deliverable"
 
+    def test_submit_emits_pedagogical_event(self) -> None:
+        p_cur, p_load, p_write, _prog_data, _written = _patch_repo()
+        with p_cur, p_load, p_write, patch("app.main.emit_event") as mock_emit:
+            r = client.post(
+                "/api/v1/checkpoints/submit",
+                json={
+                    "module_id": "shell-basics",
+                    "checkpoint_index": 0,
+                    "type": "exit_criteria",
+                    "evidence": "pwd => /tmp",
+                    "self_evaluation": "pass",
+                },
+            )
+        assert r.status_code == 200
+        mock_emit.assert_called_once()
+        args, kwargs = mock_emit.call_args
+        assert args == ("checkpoint_submitted",)
+        assert kwargs["learner_id"] == "default"
+        assert kwargs["track_id"] == "shell"
+        assert kwargs["module_id"] == "shell-basics"
+        assert kwargs["checkpoint_index"] == 0
+        assert kwargs["payload"]["type"] == "exit_criteria"
+        assert kwargs["payload"]["self_evaluation"] == "pass"
+        assert "submitted_at" in kwargs["payload"]
+
 
 # ---------------------------------------------------------------------------
 # GET /api/v1/checkpoints/{module_id}

--- a/services/api/tests/test_module_progression.py
+++ b/services/api/tests/test_module_progression.py
@@ -151,6 +151,20 @@ class TestModuleStart:
             r = client.post("/api/v1/modules/nonexistent/start")
         assert r.status_code == 404
 
+    def test_start_emits_pedagogical_event(self) -> None:
+        p_cur, p_load, p_write, _prog, _written = _patch_repo()
+        with p_cur, p_load, p_write, patch("app.main.emit_event") as mock_emit:
+            r = client.post("/api/v1/modules/shell-basics/start", json={"learner_id": "learner-42"})
+        assert r.status_code == 200
+        mock_emit.assert_called_once()
+        args, kwargs = mock_emit.call_args
+        assert args == ("module_started",)
+        assert kwargs["learner_id"] == "learner-42"
+        assert kwargs["track_id"] == "shell"
+        assert kwargs["module_id"] == "shell-basics"
+        assert kwargs["payload"]["status"] == "in_progress"
+        assert "started_at" in kwargs["payload"]
+
 
 class TestModuleComplete:
     def test_complete_in_progress_module(self) -> None:
@@ -181,6 +195,23 @@ class TestModuleComplete:
             r = client.post("/api/v1/modules/shell-basics/complete")
         assert r.status_code == 409
 
+    def test_complete_emits_pedagogical_event(self) -> None:
+        prog = _make_progression(
+            module_status={"shell-basics": {"status": "in_progress", "started_at": "2026-01-01T00:00:00+00:00"}}
+        )
+        p_cur, p_load, p_write, _prog, _written = _patch_repo(prog)
+        with p_cur, p_load, p_write, patch("app.main.emit_event") as mock_emit:
+            r = client.post("/api/v1/modules/shell-basics/complete", json={"learner_id": "learner-42"})
+        assert r.status_code == 200
+        mock_emit.assert_called_once()
+        args, kwargs = mock_emit.call_args
+        assert args == ("module_completed",)
+        assert kwargs["learner_id"] == "learner-42"
+        assert kwargs["track_id"] == "shell"
+        assert kwargs["module_id"] == "shell-basics"
+        assert kwargs["payload"]["status"] == "completed"
+        assert "completed_at" in kwargs["payload"]
+
 
 class TestModuleSkip:
     def test_skip_module(self) -> None:
@@ -205,3 +236,20 @@ class TestModuleSkip:
         with p_cur, p_load, p_write:
             r = client.post("/api/v1/modules/nonexistent/skip")
         assert r.status_code == 404
+
+    def test_skip_emits_pedagogical_event(self) -> None:
+        p_cur, p_load, p_write, _prog, _written = _patch_repo()
+        with p_cur, p_load, p_write, patch("app.main.emit_event") as mock_emit:
+            r = client.post(
+                "/api/v1/modules/shell-basics/skip", json={"learner_id": "learner-42", "reason": "reviewed"}
+            )
+        assert r.status_code == 200
+        mock_emit.assert_called_once()
+        args, kwargs = mock_emit.call_args
+        assert args == ("module_skipped",)
+        assert kwargs["learner_id"] == "learner-42"
+        assert kwargs["track_id"] == "shell"
+        assert kwargs["module_id"] == "shell-basics"
+        assert kwargs["payload"]["status"] == "skipped"
+        assert kwargs["payload"]["skip_reason"] == "reviewed"
+        assert "skipped_at" in kwargs["payload"]


### PR DESCRIPTION
Closes #156.

## Summary
- emit pedagogical events from module start, complete and skip mutations
- emit checkpoint_submitted events from checkpoint submissions
- add backend tests covering the new event emission hooks

## Testing
- pytest -q services/api/tests/test_module_progression.py services/api/tests/test_checkpoints.py
- pytest -q services/api/tests
- cd services/api && python3 -m ruff check app tests
- cd services/api && python3 -m ruff format --check app tests