### PR TITLE
feat: add guided review and evidence pages (#155)

### DIFF
--- a/apps/web/app/components/NavHeader.tsx
+++ b/apps/web/app/components/NavHeader.tsx
@@ -6,6 +6,8 @@ const NAV_LINKS = [
   { href: "/", label: "Dashboard" },
   { href: "/progression", label: "Progression" },
   { href: "/defense", label: "Defense" },
+  { href: "/review", label: "Review" },
+  { href: "/evidence", label: "Evidence" },
   { href: "/profiles", label: "Profiles" },
   { href: "/analytics", label: "Analytics" },
   { href: "/login", label: "Login" },

--- a/apps/web/app/evidence/EvidenceClient.tsx
+++ b/apps/web/app/evidence/EvidenceClient.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { loadAssessmentFeed, type DefenseSessionRecord, type ReviewAttemptRecord } from "@/services/reviewEvidence";
+
+type ModuleOption = {
+  id: string;
+  title: string;
+  trackId: string;
+  trackTitle: string;
+};
+
+type Props = {
+  modules: ModuleOption[];
+};
+
+type ArtifactItem = {
+  id: string;
+  source: "review" | "defense";
+  moduleId: string;
+  title: string;
+  kind: string;
+  content: string;
+  actor: string;
+  createdAt: string;
+};
+
+function moduleLabel(moduleId: string, modules: ModuleOption[]) {
+  const module = modules.find((item) => item.id === moduleId);
+  return module ? `${module.trackTitle} — ${module.title}` : moduleId;
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function flattenReviewArtifacts(items: ReviewAttemptRecord[]): ArtifactItem[] {
+  return items.flatMap((item, index) =>
+    item.evidenceArtifacts.map((artifact, artifactIndex) => ({
+      id: `${item.id}-${artifactIndex}-${index}`,
+      source: "review" as const,
+      moduleId: item.moduleId,
+      title: artifact.label,
+      kind: artifact.kind,
+      content: artifact.content,
+      actor: item.reviewerId,
+      createdAt: item.createdAt,
+    }))
+  );
+}
+
+function flattenDefenseArtifacts(items: DefenseSessionRecord[]): ArtifactItem[] {
+  return items.flatMap((item, index) =>
+    item.evidenceArtifacts.map((artifact, artifactIndex) => ({
+      id: `${item.sessionId}-${artifactIndex}-${index}`,
+      source: "defense" as const,
+      moduleId: item.moduleId,
+      title: artifact.label,
+      kind: artifact.kind,
+      content: artifact.content,
+      actor: item.learnerId ?? "anonymous",
+      createdAt: item.createdAt,
+    }))
+  );
+}
+
+export default function EvidenceClient({ modules }: Props) {
+  const [reviewAttempts, setReviewAttempts] = useState<ReviewAttemptRecord[]>([]);
+  const [defenseSessions, setDefenseSessions] = useState<DefenseSessionRecord[]>([]);
+  const [selectedModule, setSelectedModule] = useState<string>("all");
+  const [loadingState, setLoadingState] = useState<"loading" | "ready" | "error">("loading");
+  const [mocked, setMocked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadFeed() {
+      try {
+        const data = await loadAssessmentFeed();
+        if (cancelled) {
+          return;
+        }
+        setReviewAttempts(data.reviewAttempts);
+        setDefenseSessions(data.defenseSessions);
+        setMocked(data.mocked);
+        setLoadingState("ready");
+      } catch {
+        if (!cancelled) {
+          setLoadingState("error");
+        }
+      }
+    }
+
+    void loadFeed();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const artifacts = useMemo(() => {
+    const combined = [...flattenReviewArtifacts(reviewAttempts), ...flattenDefenseArtifacts(defenseSessions)].sort((a, b) =>
+      b.createdAt.localeCompare(a.createdAt)
+    );
+
+    if (selectedModule === "all") {
+      return combined;
+    }
+
+    return combined.filter((item) => item.moduleId === selectedModule);
+  }, [defenseSessions, reviewAttempts, selectedModule]);
+
+  if (loadingState === "loading") {
+    return (
+      <section className="panel evidence-shell">
+        <h2>Loading evidence feed...</h2>
+      </section>
+    );
+  }
+
+  if (loadingState === "error") {
+    return (
+      <section className="panel evidence-shell">
+        <h2>Evidence feed unavailable</h2>
+        <p className="muted">The page could not load review or defense artifacts.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="evidence-shell">
+      <article className="panel evidence-summary">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Consolidated feed</p>
+            <h2>Artifact overview</h2>
+          </div>
+          <span className="pill">{mocked ? "Mocked fallback" : "API live"}</span>
+        </div>
+
+        <div className="hero-grid">
+          <div className="metric-card">
+            <span>Review attempts</span>
+            <strong>{reviewAttempts.length}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Defense sessions</span>
+            <strong>{defenseSessions.length}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Visible artifacts</span>
+            <strong>{artifacts.length}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Current filter</span>
+            <strong>{selectedModule === "all" ? "All modules" : moduleLabel(selectedModule, modules)}</strong>
+          </div>
+        </div>
+
+        <label className="defense-field">
+          <span>Filter by module</span>
+          <select value={selectedModule} onChange={(event) => setSelectedModule(event.target.value)}>
+            <option value="all">All modules</option>
+            {modules.map((module) => (
+              <option key={module.id} value={module.id}>
+                {module.trackTitle} — {module.title}
+              </option>
+            ))}
+          </select>
+        </label>
+      </article>
+
+      <article className="panel evidence-list-panel">
+        <p className="eyebrow">Artifacts</p>
+        <h2>Notes, outputs and defense traces</h2>
+
+        <div className="evidence-list">
+          {artifacts.length === 0 ? (
+            <article className="evidence-card">
+              <h3>No artifacts for this filter</h3>
+              <p className="muted">
+                Submit a guided review or finish a defense session with evidence to populate this view.
+              </p>
+            </article>
+          ) : (
+            artifacts.map((artifact) => (
+              <article key={artifact.id} className={`evidence-card evidence-card--${artifact.source}`}>
+                <div className="card-topline">
+                  <span>{artifact.source}</span>
+                  <span>{formatTimestamp(artifact.createdAt)}</span>
+                </div>
+                <h3>{artifact.title}</h3>
+                <p className="muted">{moduleLabel(artifact.moduleId, modules)}</p>
+                <div className="evidence-meta">
+                  <span>{artifact.kind}</span>
+                  <span>{artifact.actor}</span>
+                </div>
+                <pre className="evidence-content">{artifact.content}</pre>
+              </article>
+            ))
+          )}
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/apps/web/app/evidence/page.tsx
+++ b/apps/web/app/evidence/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+import { getDashboardData } from "@/lib/api";
+
+import EvidenceClient from "./EvidenceClient";
+
+export const metadata = {
+  title: "Evidence — 42 Training",
+  description: "Browse review and defense evidence artifacts",
+};
+
+export default async function EvidencePage() {
+  const data = await getDashboardData();
+  const modules = data.curriculum.tracks.flatMap((track) =>
+    track.modules.map((module) => ({
+      id: module.id,
+      title: module.title,
+      trackId: track.id,
+      trackTitle: track.title,
+    }))
+  );
+
+  return (
+    <main className="page-shell evidence-page">
+      <nav className="breadcrumb">
+        <Link href="/">Dashboard</Link>
+        <span className="breadcrumb-sep">/</span>
+        <span>Evidence</span>
+      </nav>
+
+      <section className="evidence-hero panel">
+        <p className="eyebrow">Evidence</p>
+        <h1>Keep the artifacts that prove how you reason, not just what you answer.</h1>
+        <p className="lead">
+          Reviews and oral defenses generate traces: notes, command outputs, summaries and reviewer prompts. This page
+          consolidates them in one place so you can revisit weak spots before the next project or evaluation.
+        </p>
+      </section>
+
+      <EvidenceClient modules={modules} />
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1565,3 +1565,126 @@ a {
   color: var(--c);
   font-size: 14px;
 }
+
+/* ------------------------------------------------------------------ */
+/*  Review / evidence pages                                            */
+/* ------------------------------------------------------------------ */
+
+.review-page,
+.evidence-page {
+  max-width: 1180px;
+}
+
+.review-hero h1,
+.evidence-hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  line-height: 1.1;
+  max-width: 16ch;
+}
+
+.review-shell,
+.evidence-shell,
+.review-form,
+.review-grid,
+.review-history-list,
+.review-guidance,
+.evidence-list,
+.evidence-summary,
+.evidence-list-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.review-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.review-lens-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.review-lens {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.62);
+  cursor: pointer;
+}
+
+.review-lens input {
+  margin: 0;
+}
+
+.review-lens--active {
+  border-color: rgba(216, 166, 87, 0.42);
+  background: rgba(216, 166, 87, 0.14);
+}
+
+.review-history-card,
+.evidence-card {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.review-history-meta,
+.evidence-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.evidence-list {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.evidence-card--review {
+  border-left: 4px solid var(--accent);
+}
+
+.evidence-card--defense {
+  border-left: 4px solid var(--shell);
+}
+
+.evidence-content {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(28, 26, 23, 0.05);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 899px) {
+  .review-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 900px) {
+  .review-shell {
+    grid-template-columns: 1.2fr 0.8fr;
+    align-items: start;
+  }
+
+  .evidence-shell {
+    grid-template-columns: 0.9fr 1.1fr;
+    align-items: start;
+  }
+}

--- a/apps/web/app/review/ReviewClient.tsx
+++ b/apps/web/app/review/ReviewClient.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  createReviewAttempt,
+  listReviewAttempts,
+  type EvidenceArtifact,
+  type ReviewAttemptRecord,
+} from "@/services/reviewEvidence";
+
+type ModuleOption = {
+  id: string;
+  title: string;
+  phase: string;
+  trackId: string;
+  trackTitle: string;
+};
+
+type Props = {
+  modules: ModuleOption[];
+};
+
+type FormState = {
+  learnerId: string;
+  reviewerId: string;
+  moduleId: string;
+  score: string;
+  feedback: string;
+  codeSnippet: string;
+  evidenceNotes: string;
+};
+
+type FormErrors = Partial<Record<keyof FormState, string>>;
+
+const REVIEW_LENSES = [
+  "Correctness and edge cases",
+  "Naming and readability",
+  "Memory discipline",
+  "Build or runtime failure points",
+  "Defense readiness",
+] as const;
+
+const INITIAL_FORM: FormState = {
+  learnerId: "default",
+  reviewerId: "peer-reviewer",
+  moduleId: "",
+  score: "",
+  feedback: "",
+  codeSnippet: "",
+  evidenceNotes: "",
+};
+
+function validateForm(values: FormState): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!values.reviewerId.trim()) {
+    errors.reviewerId = "Reviewer ID is required.";
+  }
+  if (!values.moduleId) {
+    errors.moduleId = "Select the reviewed module.";
+  }
+  if (values.codeSnippet.trim().length < 8) {
+    errors.codeSnippet = "Add a meaningful code or command snippet.";
+  }
+  if (values.feedback.trim().length < 12) {
+    errors.feedback = "Add review notes with a minimum level of detail.";
+  }
+  if (values.score && (Number.isNaN(Number(values.score)) || Number(values.score) < 0 || Number(values.score) > 100)) {
+    errors.score = "Score must stay between 0 and 100.";
+  }
+
+  return errors;
+}
+
+function moduleLabel(moduleId: string, modules: ModuleOption[]) {
+  const module = modules.find((item) => item.id === moduleId);
+  return module ? `${module.trackTitle} — ${module.title}` : moduleId;
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function buildArtifacts(notes: string, selectedLenses: string[]): EvidenceArtifact[] {
+  const lines = notes
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const noteArtifacts = lines.map((line, index) => ({
+    kind: "review-note",
+    label: `Review note ${index + 1}`,
+    content: line,
+  }));
+
+  if (selectedLenses.length === 0) {
+    return noteArtifacts;
+  }
+
+  return [
+    ...noteArtifacts,
+    {
+      kind: "review-focus",
+      label: "Guided review focus",
+      content: selectedLenses.join(" | "),
+    },
+  ];
+}
+
+export default function ReviewClient({ modules }: Props) {
+  const [form, setForm] = useState<FormState>({ ...INITIAL_FORM, moduleId: modules[0]?.id ?? "" });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [selectedLenses, setSelectedLenses] = useState<string[]>([REVIEW_LENSES[0], REVIEW_LENSES[4]]);
+  const [items, setItems] = useState<ReviewAttemptRecord[]>([]);
+  const [loadingState, setLoadingState] = useState<"loading" | "ready" | "error">("loading");
+  const [sourceMode, setSourceMode] = useState<"live" | "mocked">("live");
+  const [submitState, setSubmitState] = useState<"idle" | "submitting">("idle");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [feedbackTone, setFeedbackTone] = useState<"success" | "error">("success");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadItems() {
+      try {
+        const result = await listReviewAttempts();
+        if (cancelled) {
+          return;
+        }
+        setItems(result.items);
+        setSourceMode(result.mocked ? "mocked" : "live");
+        setLoadingState("ready");
+      } catch {
+        if (!cancelled) {
+          setLoadingState("error");
+        }
+      }
+    }
+
+    void loadItems();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reviewQuestions = useMemo(
+    () =>
+      selectedLenses.map((lens) => {
+        if (lens === "Correctness and edge cases") {
+          return "Which edge cases still fail or remain untested?";
+        }
+        if (lens === "Naming and readability") {
+          return "Which names or control-flow choices slow down understanding?";
+        }
+        if (lens === "Memory discipline") {
+          return "Where could allocation, ownership or cleanup still break?";
+        }
+        if (lens === "Build or runtime failure points") {
+          return "What would fail first at compile time or runtime and why?";
+        }
+        return "How would you defend these choices orally without showing the solution?";
+      }),
+    [selectedLenses]
+  );
+
+  function updateField(field: keyof FormState, value: string) {
+    setForm((current) => ({ ...current, [field]: value }));
+    setErrors((current) => ({ ...current, [field]: undefined }));
+    setFeedback(null);
+  }
+
+  function toggleLens(value: string) {
+    setSelectedLenses((current) =>
+      current.includes(value) ? current.filter((item) => item !== value) : [...current, value]
+    );
+    setFeedback(null);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const nextErrors = validateForm(form);
+    setErrors(nextErrors);
+    setFeedback(null);
+
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    setSubmitState("submitting");
+    try {
+      const result = await createReviewAttempt({
+        learnerId: form.learnerId.trim() || undefined,
+        reviewerId: form.reviewerId.trim(),
+        moduleId: form.moduleId,
+        codeSnippet: form.codeSnippet.trim(),
+        feedback: form.feedback.trim(),
+        questions: reviewQuestions,
+        score: form.score ? Number(form.score) : undefined,
+        evidenceArtifacts: buildArtifacts(form.evidenceNotes, selectedLenses),
+      });
+
+      setItems((current) => [result.item, ...current]);
+      setSourceMode(result.mocked ? "mocked" : "live");
+      setFeedbackTone("success");
+      setFeedback(`Review submitted for ${moduleLabel(form.moduleId, modules)}.`);
+      setForm((current) => ({
+        ...current,
+        score: "",
+        feedback: "",
+        codeSnippet: "",
+        evidenceNotes: "",
+      }));
+    } catch (error) {
+      setFeedbackTone("error");
+      setFeedback(error instanceof Error ? error.message : "Unable to submit the review.");
+    } finally {
+      setSubmitState("idle");
+    }
+  }
+
+  if (loadingState === "loading") {
+    return (
+      <section className="panel review-shell">
+        <h2>Loading review workspace...</h2>
+      </section>
+    );
+  }
+
+  if (loadingState === "error") {
+    return (
+      <section className="panel review-shell">
+        <h2>Review workspace unavailable</h2>
+        <p className="muted">The page could not load recent review attempts.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="review-shell">
+      <article className="panel review-form-panel">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Submission</p>
+            <h2>Submit a guided review</h2>
+          </div>
+          <span className="pill">{sourceMode === "live" ? "API live" : "Mocked fallback"}</span>
+        </div>
+
+        <form className="review-form" noValidate onSubmit={handleSubmit}>
+          <div className="review-grid">
+            <label className="defense-field">
+              <span>Module</span>
+              <select value={form.moduleId} onChange={(event) => updateField("moduleId", event.target.value)}>
+                {modules.map((module) => (
+                  <option key={module.id} value={module.id}>
+                    {module.trackTitle} — {module.title}
+                  </option>
+                ))}
+              </select>
+              {errors.moduleId && <small className="login-error">{errors.moduleId}</small>}
+            </label>
+
+            <label className="defense-field">
+              <span>Reviewer ID</span>
+              <input value={form.reviewerId} onChange={(event) => updateField("reviewerId", event.target.value)} />
+              {errors.reviewerId && <small className="login-error">{errors.reviewerId}</small>}
+            </label>
+
+            <label className="defense-field">
+              <span>Learner ID</span>
+              <input value={form.learnerId} onChange={(event) => updateField("learnerId", event.target.value)} />
+            </label>
+
+            <label className="defense-field">
+              <span>Score (optional)</span>
+              <input
+                type="number"
+                min="0"
+                max="100"
+                value={form.score}
+                onChange={(event) => updateField("score", event.target.value)}
+              />
+              {errors.score && <small className="login-error">{errors.score}</small>}
+            </label>
+          </div>
+
+          <div className="review-lens-list">
+            {REVIEW_LENSES.map((lens) => (
+              <label key={lens} className={`review-lens ${selectedLenses.includes(lens) ? "review-lens--active" : ""}`}>
+                <input
+                  type="checkbox"
+                  checked={selectedLenses.includes(lens)}
+                  onChange={() => toggleLens(lens)}
+                />
+                <span>{lens}</span>
+              </label>
+            ))}
+          </div>
+
+          <label className="defense-field">
+            <span>Code or command snippet</span>
+            <textarea
+              className="defense-textarea"
+              value={form.codeSnippet}
+              onChange={(event) => updateField("codeSnippet", event.target.value)}
+              placeholder="Paste the function, command sequence or excerpt you want reviewed."
+            />
+            {errors.codeSnippet && <small className="login-error">{errors.codeSnippet}</small>}
+          </label>
+
+          <label className="defense-field">
+            <span>Review notes</span>
+            <textarea
+              className="defense-textarea"
+              value={form.feedback}
+              onChange={(event) => updateField("feedback", event.target.value)}
+              placeholder="Describe what a peer should challenge, confirm or re-explain."
+            />
+            {errors.feedback && <small className="login-error">{errors.feedback}</small>}
+          </label>
+
+          <label className="defense-field">
+            <span>Evidence notes</span>
+            <textarea
+              className="defense-textarea"
+              value={form.evidenceNotes}
+              onChange={(event) => updateField("evidenceNotes", event.target.value)}
+              placeholder="One line per artifact: command output, self-note, checklist item, warning..."
+            />
+          </label>
+
+          <div className="review-guidance panel">
+            <p className="eyebrow">Generated reviewer prompts</p>
+            <div className="stack-list">
+              {reviewQuestions.map((question) => (
+                <span key={question} className="pill">
+                  {question}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <button type="submit" className="action-btn" disabled={submitState === "submitting"}>
+            {submitState === "submitting" ? "Submitting..." : "Submit review"}
+          </button>
+        </form>
+
+        {feedback && (
+          <div
+            className={`login-feedback ${
+              feedbackTone === "success" ? "login-feedback--success" : "login-feedback--error"
+            }`}
+          >
+            {feedback}
+          </div>
+        )}
+      </article>
+
+      <aside className="panel review-history-panel">
+        <p className="eyebrow">Recent attempts</p>
+        <h2>Review history</h2>
+        <div className="review-history-list">
+          {items.map((item) => (
+            <article key={item.id} className="review-history-card">
+              <div className="card-topline">
+                <span>{moduleLabel(item.moduleId, modules)}</span>
+                <span>{formatTimestamp(item.createdAt)}</span>
+              </div>
+              <strong>{item.reviewerId}</strong>
+              <p className="muted">{item.feedback}</p>
+              <div className="review-history-meta">
+                <span>{item.score !== null ? `${item.score}/100` : "No score"}</span>
+                <span>{item.evidenceArtifacts.length} artifacts</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </aside>
+    </section>
+  );
+}

--- a/apps/web/app/review/page.tsx
+++ b/apps/web/app/review/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+import { getDashboardData } from "@/lib/api";
+
+import ReviewClient from "./ReviewClient";
+
+export const metadata = {
+  title: "Guided Review — 42 Training",
+  description: "Submit code for guided peer-style review and track attached evidence",
+};
+
+export default async function ReviewPage() {
+  const data = await getDashboardData();
+  const modules = data.curriculum.tracks.flatMap((track) =>
+    track.modules.map((module) => ({
+      id: module.id,
+      title: module.title,
+      phase: module.phase,
+      trackId: track.id,
+      trackTitle: track.title,
+    }))
+  );
+
+  return (
+    <main className="page-shell review-page">
+      <nav className="breadcrumb">
+        <Link href="/">Dashboard</Link>
+        <span className="breadcrumb-sep">/</span>
+        <span>Review</span>
+      </nav>
+
+      <section className="review-hero panel">
+        <p className="eyebrow">Guided review</p>
+        <h1>Prepare a peer-style review before the real evaluation pressure hits.</h1>
+        <p className="lead">
+          Submit a code snippet, frame the review focus, attach evidence and keep a trace of the review questions you
+          want a peer to ask. The goal is not auto-grading. It is disciplined preparation for 42-style feedback.
+        </p>
+      </section>
+
+      <ReviewClient modules={modules} />
+    </main>
+  );
+}

--- a/apps/web/services/reviewEvidence.ts
+++ b/apps/web/services/reviewEvidence.ts
@@ -1,0 +1,288 @@
+export type EvidenceArtifact = {
+  kind: string;
+  label: string;
+  content: string;
+};
+
+export type ReviewAttemptRecord = {
+  id: string;
+  learnerId: string | null;
+  reviewerId: string;
+  moduleId: string;
+  codeSnippet: string;
+  feedback: string;
+  questions: string[];
+  score: number | null;
+  evidenceArtifacts: EvidenceArtifact[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DefenseSessionRecord = {
+  sessionId: string;
+  learnerId: string | null;
+  moduleId: string;
+  questions: string[];
+  answers: string[];
+  scores: number[];
+  status: string;
+  evidenceArtifacts: EvidenceArtifact[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ReviewAttemptCreatePayload = {
+  learnerId?: string;
+  reviewerId: string;
+  moduleId: string;
+  codeSnippet: string;
+  feedback: string;
+  questions: string[];
+  score?: number;
+  evidenceArtifacts: EvidenceArtifact[];
+};
+
+export type AssessmentFeed = {
+  reviewAttempts: ReviewAttemptRecord[];
+  defenseSessions: DefenseSessionRecord[];
+  mocked: boolean;
+};
+
+type ApiReviewAttemptRecord = {
+  id: string;
+  learner_id?: string | null;
+  reviewer_id: string;
+  module_id: string;
+  code_snippet: string;
+  feedback: string;
+  questions?: string[];
+  score?: number | null;
+  evidence_artifacts?: Array<Record<string, unknown>>;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type ApiDefenseSessionRecord = {
+  session_id: string;
+  learner_id?: string | null;
+  module_id: string;
+  questions?: string[];
+  answers?: string[];
+  scores?: number[];
+  status: string;
+  evidence_artifacts?: Array<Record<string, unknown>>;
+  created_at?: string;
+  updated_at?: string;
+};
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const REVIEW_STORAGE_KEY = "training-mock-review-attempts";
+const DEFENSE_STORAGE_KEY = "training-mock-defense-sessions";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function randomId(prefix: string) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeArtifact(input: Record<string, unknown>): EvidenceArtifact {
+  return {
+    kind: typeof input.kind === "string" ? input.kind : "note",
+    label: typeof input.label === "string" ? input.label : "Artifact",
+    content: typeof input.content === "string" ? input.content : "",
+  };
+}
+
+function mapReviewAttempt(record: ApiReviewAttemptRecord): ReviewAttemptRecord {
+  return {
+    id: record.id,
+    learnerId: record.learner_id ?? null,
+    reviewerId: record.reviewer_id,
+    moduleId: record.module_id,
+    codeSnippet: record.code_snippet,
+    feedback: record.feedback,
+    questions: record.questions ?? [],
+    score: record.score ?? null,
+    evidenceArtifacts: (record.evidence_artifacts ?? []).map(normalizeArtifact),
+    createdAt: record.created_at ?? nowIso(),
+    updatedAt: record.updated_at ?? nowIso(),
+  };
+}
+
+function mapDefenseSession(record: ApiDefenseSessionRecord): DefenseSessionRecord {
+  return {
+    sessionId: record.session_id,
+    learnerId: record.learner_id ?? null,
+    moduleId: record.module_id,
+    questions: record.questions ?? [],
+    answers: record.answers ?? [],
+    scores: record.scores ?? [],
+    status: record.status,
+    evidenceArtifacts: (record.evidence_artifacts ?? []).map(normalizeArtifact),
+    createdAt: record.created_at ?? nowIso(),
+    updatedAt: record.updated_at ?? nowIso(),
+  };
+}
+
+async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_URL}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Assessment API returned ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function seedReviewAttempts(): ReviewAttemptRecord[] {
+  const timestamp = nowIso();
+  return [
+    {
+      id: randomId("review"),
+      learnerId: "default",
+      reviewerId: "peer-shell",
+      moduleId: "shell-basics",
+      codeSnippet: "ls -la\nmkdir sandbox\ncd sandbox\n",
+      feedback: "Clear command sequence. Review file permissions and explain why each command is needed.",
+      questions: [
+        "How would you verify hidden files are present?",
+        "Which command would you use to inspect permissions before chmod?",
+      ],
+      score: 78,
+      evidenceArtifacts: [
+        { kind: "command-output", label: "Terminal output", content: "drwxr-xr-x sandbox\n-rw-r--r-- hello.txt" },
+        { kind: "self-note", label: "Learner note", content: "Confident on navigation, less sure on permissions." },
+      ],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  ];
+}
+
+function seedDefenseSessions(): DefenseSessionRecord[] {
+  const timestamp = nowIso();
+  return [
+    {
+      sessionId: randomId("defense"),
+      learnerId: "default",
+      moduleId: "c-memory",
+      questions: ["Explain the difference between stack allocation and heap allocation."],
+      answers: ["Stack is automatic and scoped, heap is manual and survives until free."],
+      scores: [82],
+      status: "passed",
+      evidenceArtifacts: [
+        { kind: "oral-summary", label: "Defense summary", content: "Solid explanation of malloc/free lifecycle." },
+      ],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  ];
+}
+
+function readStoredJson<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  const stored = window.localStorage.getItem(key);
+  if (!stored) {
+    window.localStorage.setItem(key, JSON.stringify(fallback));
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(stored) as T;
+  } catch {
+    window.localStorage.setItem(key, JSON.stringify(fallback));
+    return fallback;
+  }
+}
+
+function writeStoredJson<T>(key: string, value: T) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+function readMockReviewAttempts() {
+  return readStoredJson<ReviewAttemptRecord[]>(REVIEW_STORAGE_KEY, seedReviewAttempts());
+}
+
+function readMockDefenseSessions() {
+  return readStoredJson<DefenseSessionRecord[]>(DEFENSE_STORAGE_KEY, seedDefenseSessions());
+}
+
+export async function listReviewAttempts(): Promise<{ items: ReviewAttemptRecord[]; mocked: boolean }> {
+  try {
+    const data = await requestJson<ApiReviewAttemptRecord[]>("/api/v1/review-attempts");
+    return { items: data.map(mapReviewAttempt), mocked: false };
+  } catch {
+    return { items: readMockReviewAttempts(), mocked: true };
+  }
+}
+
+export async function createReviewAttempt(payload: ReviewAttemptCreatePayload): Promise<{ item: ReviewAttemptRecord; mocked: boolean }> {
+  try {
+    const data = await requestJson<ApiReviewAttemptRecord>("/api/v1/review-attempts", {
+      method: "POST",
+      body: JSON.stringify({
+        learner_id: payload.learnerId || null,
+        reviewer_id: payload.reviewerId,
+        module_id: payload.moduleId,
+        code_snippet: payload.codeSnippet,
+        feedback: payload.feedback,
+        questions: payload.questions,
+        score: payload.score ?? null,
+        evidence_artifacts: payload.evidenceArtifacts,
+      }),
+    });
+    return { item: mapReviewAttempt(data), mocked: false };
+  } catch {
+    const timestamp = nowIso();
+    const item: ReviewAttemptRecord = {
+      id: randomId("review"),
+      learnerId: payload.learnerId ?? null,
+      reviewerId: payload.reviewerId,
+      moduleId: payload.moduleId,
+      codeSnippet: payload.codeSnippet,
+      feedback: payload.feedback,
+      questions: payload.questions,
+      score: payload.score ?? null,
+      evidenceArtifacts: payload.evidenceArtifacts,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    const next = [item, ...readMockReviewAttempts()];
+    writeStoredJson(REVIEW_STORAGE_KEY, next);
+    return { item, mocked: true };
+  }
+}
+
+export async function listDefenseSessions(): Promise<{ items: DefenseSessionRecord[]; mocked: boolean }> {
+  try {
+    const data = await requestJson<ApiDefenseSessionRecord[]>("/api/v1/defense-sessions");
+    return { items: data.map(mapDefenseSession), mocked: false };
+  } catch {
+    return { items: readMockDefenseSessions(), mocked: true };
+  }
+}
+
+export async function loadAssessmentFeed(): Promise<AssessmentFeed> {
+  const [reviews, defenses] = await Promise.all([listReviewAttempts(), listDefenseSessions()]);
+  return {
+    reviewAttempts: reviews.items,
+    defenseSessions: defenses.items,
+    mocked: reviews.mocked || defenses.mocked,
+  };
+}


### PR DESCRIPTION
Closes #155.

## Summary
- add dedicated  and  pages aligned with the existing defense UI
- add a shared frontend service for review attempts and defense/evidence feeds, with mocked fallback when the API is unavailable
- extend navigation and global styling so the new guided-review workflow is discoverable and consistent

## Validation
- cd apps/web && npm run lint
- cd apps/web && npm run typecheck
- cd apps/web && env -u NODE_ENV npm run build