### PR TITLE
fix: resolve main promotion conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Documentation principale:
 - `docs/PRODUCT_METRICS.md` — KPIs produit et pedagogiques, SQL analytics et structure de dashboard
 - `docs/JSON_TO_PG_MIGRATION.md` — design du pipeline d'import `progression.json` vers PostgreSQL et strategie de transition
 - `docs/APPROCHE_ARCHITECTURE_EXHAUSTIVE.md`
+- `docs/42_REFERENCE_STACK.md`
+- `docs/NEW_TC_PROJECT_PREDICTIONS.md`
 - `ARCHITECTURE_TARGET.md`
 - `docs/DEVOPS_RBOK_ADAPTATION.md`
 - `docs/adr/README.md`
@@ -146,6 +148,8 @@ Core documentation:
 - `docs/PRODUCT_METRICS.md` — product and pedagogical KPIs, analytics SQL and dashboard structure
 - `docs/JSON_TO_PG_MIGRATION.md` — initial `progression.json` to PostgreSQL import design and transition strategy
 - `docs/APPROCHE_ARCHITECTURE_EXHAUSTIVE.md`
+- `docs/42_REFERENCE_STACK.md`
+- `docs/NEW_TC_PROJECT_PREDICTIONS.md`
 - `ARCHITECTURE_TARGET.md`
 - `docs/DEVOPS_RBOK_ADAPTATION.md`
 - `docs/adr/README.md`

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,6 +11,10 @@ export default async function HomePage() {
   const data = await getDashboardData();
   const { curriculum, progression } = data;
   const activeCourse = progression.learning_plan?.active_course ?? "shell";
+  const officialReferences = [
+    ...curriculum.reference_stack.official_documents,
+    ...curriculum.reference_stack.official_document_mirrors
+  ];
 
   return (
     <main className="page-shell">
@@ -32,8 +36,8 @@ export default async function HomePage() {
               <strong>{activeCourse}</strong>
             </div>
             <div className="metric-card">
-              <span>Pace mode</span>
-              <strong>{progression.learning_plan?.pace_mode ?? "self_paced"}</strong>
+              <span>Reference posture</span>
+              <strong>{curriculum.metadata.reference_posture ?? "official docs first"}</strong>
             </div>
             <div className="metric-card">
               <span>Next command</span>
@@ -81,6 +85,30 @@ export default async function HomePage() {
                         <Pill key={skill}>{skill}</Pill>
                       ))}
                     </div>
+                    {module.reference_note ? <p className="module-note">{module.reference_note}</p> : null}
+                    {(module.subject_refs ?? []).length > 0 ? (
+                      <div className="module-reference-list">
+                        {(module.subject_refs ?? []).map((reference) => (
+                          <a
+                            key={`${module.id}-${reference.label}`}
+                            className="module-reference-item"
+                            href={reference.url}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <div className="reference-topline">
+                              <strong>{reference.document_title}</strong>
+                              <span>{reference.coverage}</span>
+                            </div>
+                            <p>{reference.label}</p>
+                            <p className="muted">
+                              {reference.confidence} / {reference.tier}
+                            </p>
+                            {reference.mirror_path ? <p className="muted">{reference.mirror_path}</p> : null}
+                          </a>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
                 ))}
               </div>
@@ -115,6 +143,197 @@ export default async function HomePage() {
                 <strong>{tier.label}</strong>
                 <SourcePolicyBadge tier={tier.id} />
               </div>
+            ))}
+          </div>
+          <div className="confidence-list">
+            {(curriculum.source_policy.confidence_model ?? []).map((item) => (
+              <div key={item.level} className="confidence-item">
+                <strong>{item.level}</strong>
+                <p>{item.meaning}</p>
+              </div>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="section split">
+        <article className="panel">
+          <p className="eyebrow">Reference Stack</p>
+          <h2>Official documents and mirrors</h2>
+          <div className="reference-list">
+            {officialReferences.map((reference) => (
+              <a key={reference.label} className="reference-item" href={reference.url} target="_blank" rel="noreferrer">
+                <div className="reference-topline">
+                  <strong>{reference.label}</strong>
+                  <span>{reference.confidence ?? reference.tier}</span>
+                </div>
+                {reference.usage ? <p>{reference.usage}</p> : null}
+                {reference.note ? <p className="muted">{reference.note}</p> : null}
+              </a>
+            ))}
+          </div>
+        </article>
+        <article className="panel">
+          <p className="eyebrow">Quality Toolchain</p>
+          <h2>Available verification layers</h2>
+          <div className="tool-list">
+            {curriculum.reference_stack.quality_stack.map((tool) => (
+              <a key={tool.id} className="tool-item tool-link" href={tool.url} target="_blank" rel="noreferrer">
+                <div className="reference-topline">
+                  <strong>{tool.label}</strong>
+                  <span>{tool.language}</span>
+                </div>
+                <p>{tool.role}</p>
+                <p className="muted">
+                  {tool.authority} / {tool.kind}
+                </p>
+                {tool.note ? <p className="muted">{tool.note}</p> : null}
+              </a>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Quality Model</p>
+          <h2>Equivalent rigor by language</h2>
+        </div>
+        <div className="quality-grid">
+          {curriculum.reference_stack.quality_equivalents.map((item) => (
+            <article key={item.language} className="quality-card">
+              <div className="card-topline">
+                <span>{item.language}</span>
+                <span>quality contract</span>
+              </div>
+              <h3>{item.positioning}</h3>
+              <p>{item.quality_contract}</p>
+              <div className="quality-subsection">
+                <strong>Automated gates</strong>
+                <div className="stack-list">
+                  {item.automated_gates.map((gate) => (
+                    <Pill key={gate}>{gate}</Pill>
+                  ))}
+                </div>
+              </div>
+              <div className="quality-subsection">
+                <strong>Human review focus</strong>
+                <div className="stack-list">
+                  {item.human_review_focus.map((focus) => (
+                    <Pill key={focus}>{focus}</Pill>
+                  ))}
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Curriculum Mapping</p>
+          <h2>Legacy backbone, emerging Python lane</h2>
+        </div>
+        <article className="panel">
+          <p>{curriculum.curriculum_mapping.new_common_core_interpretation.summary}</p>
+          <p className="muted">
+            Confidence: {curriculum.curriculum_mapping.new_common_core_interpretation.confidence}.{" "}
+            {curriculum.curriculum_mapping.new_common_core_interpretation.note}
+          </p>
+          <div className="milestone-grid">
+            {(curriculum.curriculum_mapping.new_common_core_interpretation.milestones ?? []).map((item) => (
+              <div key={item.milestone} className="milestone-card">
+                <div className="reference-topline">
+                  <strong>{item.milestone}</strong>
+                  <span>{item.confidence}</span>
+                </div>
+                <div className="stack-list">
+                  {item.projects.map((project) => (
+                    <Pill key={project}>{project}</Pill>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="quality-subsection">
+            <strong>Preserved legacy dimensions</strong>
+            <div className="stack-list">
+              {(curriculum.curriculum_mapping.legacy_common_core.preserved_dimensions ?? []).map((item) => (
+                <Pill key={item}>{item}</Pill>
+              ))}
+            </div>
+          </div>
+          <div className="quality-subsection">
+            <strong>Synthesis</strong>
+            <div className="stack-list">
+              {(curriculum.curriculum_mapping.synthesis?.principles ?? []).map((item) => (
+                <Pill key={item}>{item}</Pill>
+              ))}
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="section">
+        <div className="section-heading">
+          <p className="eyebrow">Predictions</p>
+          <h2>Imagined subjects for the new Python and AI lane</h2>
+        </div>
+        <article className="panel">
+          <div className="analogy-list">
+            {(curriculum.curriculum_mapping.new_common_core_interpretation.style_analogies ?? []).map((item) => (
+              <div key={`${item.legacy_anchor}-${item.new_project}`} className="analogy-item">
+                <div className="reference-topline">
+                  <strong>{item.new_project}</strong>
+                  <span>{item.legacy_anchor}</span>
+                </div>
+                <p>{item.rationale}</p>
+              </div>
+            ))}
+          </div>
+          <div className="prediction-grid">
+            {(curriculum.curriculum_mapping.new_common_core_interpretation.predicted_project_models ?? []).map((item) => (
+              <article key={item.id} className="prediction-card">
+                <div className="reference-topline">
+                  <strong>{item.title}</strong>
+                  <span>
+                    {item.milestone} / {item.confidence}
+                  </span>
+                </div>
+                <p>{item.predicted_subject_style}</p>
+                <div className="quality-subsection">
+                  <strong>Legacy style anchors</strong>
+                  <div className="stack-list">
+                    {item.legacy_style_anchors.map((anchor) => (
+                      <Pill key={anchor}>{anchor}</Pill>
+                    ))}
+                  </div>
+                </div>
+                <div className="quality-subsection">
+                  <strong>Likely constraints</strong>
+                  <div className="stack-list">
+                    {item.predicted_constraints.map((constraint) => (
+                      <Pill key={constraint}>{constraint}</Pill>
+                    ))}
+                  </div>
+                </div>
+                <div className="quality-subsection">
+                  <strong>Likely deliverables</strong>
+                  <div className="stack-list">
+                    {item.predicted_deliverables.map((deliverable) => (
+                      <Pill key={deliverable}>{deliverable}</Pill>
+                    ))}
+                  </div>
+                </div>
+                <div className="quality-subsection">
+                  <strong>Target skills</strong>
+                  <div className="stack-list">
+                    {item.predicted_core_skills.map((skill) => (
+                      <Pill key={skill}>{skill}</Pill>
+                    ))}
+                  </div>
+                </div>
+              </article>
             ))}
           </div>
         </article>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -16,6 +16,8 @@ export type ModuleItem = {
   resources?: ModuleResource[];
   estimated_hours?: number;
   prerequisites?: string[];
+  reference_note?: string;
+  subject_refs?: SubjectRef[];
 };
 
 export type TrackItem = {
@@ -26,18 +28,94 @@ export type TrackItem = {
   modules: ModuleItem[];
 };
 
+export type ReferenceItem = {
+  label: string;
+  url: string;
+  tier: string;
+  confidence?: string;
+  usage?: string;
+  note?: string;
+};
+
+export type SubjectRef = {
+  label: string;
+  document_title: string;
+  url: string;
+  mirror_path?: string;
+  tier: string;
+  confidence: string;
+  coverage: string;
+  note?: string;
+};
+
+export type QualityTool = {
+  id: string;
+  label: string;
+  url: string;
+  language: string;
+  kind: string;
+  authority: string;
+  role: string;
+  note?: string;
+};
+
+export type QualityEquivalent = {
+  language: string;
+  positioning: string;
+  quality_contract: string;
+  automated_gates: string[];
+  human_review_focus: string[];
+};
+
 export type DashboardData = {
   curriculum: {
     metadata: {
       campus: string;
       updated_on: string;
+      status?: string;
+      reference_posture?: string;
     };
     source_policy: {
       tiers: Array<{ id: string; label: string; allowed_usage: string }>;
+      confidence_model?: Array<{ level: string; meaning: string }>;
+    };
+    reference_stack: {
+      official_documents: ReferenceItem[];
+      official_document_mirrors: ReferenceItem[];
+      quality_stack: QualityTool[];
+      quality_equivalents: QualityEquivalent[];
     };
     tracks: TrackItem[];
     bridges: Array<{ id: string; title: string; recommended_modules: string[] }>;
     recommended_resources?: Array<{ label: string; url: string; tier: string }>;
+    curriculum_mapping: {
+      legacy_common_core: {
+        summary: string;
+        preserved_dimensions?: string[];
+      };
+      new_common_core_interpretation: {
+        summary: string;
+        confidence: string;
+        note: string;
+        milestones?: Array<{ milestone: string; projects: string[]; confidence: string }>;
+        style_analogies?: Array<{ legacy_anchor: string; new_project: string; rationale: string }>;
+        predicted_project_models?: Array<{
+          id: string;
+          title: string;
+          milestone: string;
+          confidence: string;
+          legacy_style_anchors: string[];
+          predicted_subject_style: string;
+          predicted_constraints: string[];
+          predicted_deliverables: string[];
+          predicted_core_skills: string[];
+        }>;
+      };
+      synthesis?: {
+        summary: string;
+        principles: string[];
+      };
+    };
   };
   progression: {
     learning_plan?: {
@@ -87,7 +165,9 @@ const fallbackData: DashboardData = {
   curriculum: {
     metadata: {
       campus: "42 Lausanne",
-      updated_on: "2026-03-27",
+      updated_on: "2026-03-29",
+      status: "reference-refresh",
+      reference_posture: "official public documents first, verified mirrors second, community tooling as verification only",
     },
     source_policy: {
       tiers: [
@@ -97,6 +177,114 @@ const fallbackData: DashboardData = {
         { id: "solution_metadata", label: "Solution metadata", allowed_usage: "path_mapping_only" },
         { id: "blocked_solution_content", label: "Direct solution content", allowed_usage: "blocked_by_default" }
       ],
+      confidence_model: [
+        { level: "high", meaning: "Official public page or official normative PDF." },
+        { level: "medium", meaning: "Verified mirror or staff-corroborated signal." },
+        { level: "interpreted", meaning: "Inference kept explicit as interpretation." }
+      ],
+    },
+    reference_stack: {
+      official_documents: [
+        {
+          label: "42 Lausanne - pedagogie",
+          url: "https://42lausanne.ch/pedagogie-42/",
+          tier: "official_42",
+          confidence: "high",
+          usage: "campus pedagogy and learning model"
+        },
+        {
+          label: "42 Lausanne - IA",
+          url: "https://42lausanne.ch/ia/",
+          tier: "official_42",
+          confidence: "high",
+          usage: "public signal that AI is now inside the Lausanne positioning"
+        },
+        {
+          label: "The Norm v4.1 (English PDF)",
+          url: "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+          tier: "official_42",
+          confidence: "high",
+          usage: "absolute code-quality and pedagogical reference for C projects"
+        }
+      ],
+      official_document_mirrors: [
+        {
+          label: "Ninjarsenic/42-Tronc_commun",
+          url: "https://github.com/Ninjarsenic/42-Tronc_commun",
+          tier: "official_document_mirrors",
+          confidence: "medium",
+          note: "Private mirror of Common Core subjects."
+        },
+        {
+          label: "Ninjarsenic/42-piscine",
+          url: "https://github.com/Ninjarsenic/42-piscine",
+          tier: "official_document_mirrors",
+          confidence: "medium",
+          note: "Private mirror of official Piscine assets."
+        }
+      ],
+      quality_stack: [
+        {
+          id: "norminette",
+          label: "norminette",
+          url: "https://github.com/42school/norminette",
+          language: "c",
+          kind: "official_checker",
+          authority: "official_tool",
+          role: "Objective Norm checks."
+        },
+        {
+          id: "francinette",
+          label: "francinette",
+          url: "https://github.com/xicodomingues/francinette",
+          language: "c",
+          kind: "community_local_moulinette",
+          authority: "verification_only",
+          role: "Local make + norm + tester battery.",
+          note: "Archived upstream."
+        },
+        {
+          id: "ruff",
+          label: "ruff",
+          url: "https://github.com/astral-sh/ruff",
+          language: "python",
+          kind: "lint_and_format",
+          authority: "equivalent_quality_gate",
+          role: "Formatting and lint baseline for Python."
+        },
+        {
+          id: "shellcheck",
+          label: "ShellCheck",
+          url: "https://www.shellcheck.net/",
+          language: "bash",
+          kind: "lint",
+          authority: "equivalent_quality_gate",
+          role: "Quoting and portability guardrails for shell."
+        }
+      ],
+      quality_equivalents: [
+        {
+          language: "c",
+          positioning: "Absolute reference track.",
+          quality_contract: "The Norm plus norminette plus project-specific testers.",
+          automated_gates: ["norminette", "cc -Wall -Wextra -Werror", "tester suites"],
+          human_review_focus: ["clarity", "defense readiness", "subjective Norm items"]
+        },
+        {
+          language: "python",
+          positioning: "Equivalent rigor, not C mimicry.",
+          quality_contract: "Short explicit functions, typed boundaries, readable flow, test coverage.",
+          automated_gates: ["ruff check", "ruff format", "mypy", "pytest"],
+          human_review_focus: ["algorithmic explanation", "controlled abstraction", "debuggability"]
+        },
+        {
+          language: "bash",
+          positioning: "Terminal-first discipline.",
+          quality_contract: "Readable scripts, explicit quoting, small units, fail-fast habits.",
+          automated_gates: ["shellcheck", "shfmt", "smoke scripts"],
+          human_review_focus: ["pipeline clarity", "error handling", "debugging under shell constraints"]
+        }
+      ]
     },
     tracks: [
       {
@@ -105,8 +293,22 @@ const fallbackData: DashboardData = {
         summary: "Linux-first recovery track before Piscine pressure.",
         why_it_matters: "Rebuild confidence, command fluency and process awareness.",
         modules: [
-          { id: "shell-basics", title: "Navigation and files", phase: "foundation", skills: ["pwd", "ls", "cd", "cp"], deliverable: "Navigate and manipulate files with confidence." },
-          { id: "shell-streams", title: "Redirections and pipes", phase: "foundation", skills: ["stdin", "stdout", "pipe"], deliverable: "Chain commands effectively." }
+          {
+            id: "shell-basics",
+            title: "Navigation and files",
+            phase: "foundation",
+            skills: ["pwd", "ls", "cd", "cp"],
+            deliverable: "Navigate and manipulate files with confidence.",
+            reference_note: "Anchored to the exact Shell00 official subject mirror.",
+          },
+          {
+            id: "shell-streams",
+            title: "Redirections and pipes",
+            phase: "foundation",
+            skills: ["stdin", "stdout", "pipe"],
+            deliverable: "Chain commands effectively.",
+            reference_note: "Extracted from the broader Shell01 official subject."
+          }
         ],
       },
       {
@@ -133,7 +335,67 @@ const fallbackData: DashboardData = {
     bridges: [
       { id: "before_piscine", title: "Before the Piscine", recommended_modules: ["shell:shell-basics", "c:c-basics"] },
       { id: "before_new_common_core", title: "Before the new common core", recommended_modules: ["c:c-memory", "python_ai:ai-rag-agents"] }
-    ]
+    ],
+    recommended_resources: [
+      {
+        label: "42 Lausanne - pedagogie",
+        url: "https://42lausanne.ch/pedagogie-42/",
+        tier: "official_42"
+      },
+      {
+        label: "The Norm v4.1 (English PDF)",
+        url: "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+        tier: "official_42"
+      },
+      {
+        label: "Ninjarsenic/42-Tronc_commun",
+        url: "https://github.com/Ninjarsenic/42-Tronc_commun",
+        tier: "community_docs"
+      }
+    ],
+    curriculum_mapping: {
+      legacy_common_core: {
+        summary: "Historically C and Unix heavy, then concurrency, graphics, C++, network and devops.",
+        preserved_dimensions: ["terminal autonomy", "memory rigor", "oral defense readiness"]
+      },
+      new_common_core_interpretation: {
+        summary: "Algorithms earlier, Python earlier, AI inside the common core.",
+        confidence: "medium",
+        note: "Project naming is still partially interpreted from mirrored packs and infographic signals.",
+        milestones: [
+          { milestone: "M1", projects: ["libft", "push_swap", "printf", "get_next_line"], confidence: "medium" },
+          { milestone: "M2", projects: ["piscine python", "a maze ing", "born2beroot"], confidence: "interpreted" }
+        ],
+        style_analogies: [
+          {
+            legacy_anchor: "C Piscine modules",
+            new_project: "piscine python",
+            rationale: "Bootcamp role preserved, but translated to Python."
+          }
+        ],
+        predicted_project_models: [
+          {
+            id: "piscine-python",
+            title: "piscine python",
+            milestone: "M2",
+            confidence: "interpreted",
+            legacy_style_anchors: ["C Piscine modules C00-C13", "Shell00", "Shell01"],
+            predicted_subject_style: "Small escalating exercises with strict mastery of foundations.",
+            predicted_constraints: ["small scripts", "stdlib only", "explicit functions"],
+            predicted_deliverables: ["ex00..exNN scripts", "tiny CLIs", "simple tests"],
+            predicted_core_skills: ["syntax", "functions", "strings", "objects"]
+          }
+        ]
+      },
+      synthesis: {
+        summary: "Keep old Common Core rigor while preparing for the Python and AI branch.",
+        principles: [
+          "Preserve legacy C rigor.",
+          "Make Python and Bash quality expectations explicit.",
+          "Surface confidence levels for interpreted curriculum elements."
+        ]
+      }
+    }
   },
   progression: {
     learning_plan: {

--- a/docs/42_REFERENCE_STACK.md
+++ b/docs/42_REFERENCE_STACK.md
@@ -1,0 +1,167 @@
+# 42 Training Reference Stack
+
+## Purpose
+
+This document defines the pedagogical and code-quality reference hierarchy for
+`42-training`.
+
+The goal is not to collapse every source into one bucket. The goal is to keep a
+clear order of authority:
+
+1. official public 42 material
+2. verified mirrors of official documents
+3. tooling used to pre-check work
+4. community explanations and mappings
+
+This is especially important because the product now needs to support both:
+
+- the historical C-heavy Common Core
+- the emerging Python and AI lane seen in Lausanne signals and mirrored subject packs
+
+## Absolute References
+
+### Public official sources
+
+- 42 Lausanne pedagogy page
+- 42 Lausanne AI page
+- The Norm v4.1
+- the official `42school/norminette` repository
+
+These sources define the top-level truth model for pedagogy, code quality and
+language expectations where they are explicit.
+
+### Verified mirrors of official documents
+
+Two private reference repositories are now available locally for research:
+
+- `Ninjarsenic/42-piscine`
+- `Ninjarsenic/42-Tronc_commun`
+
+They should be treated as mirrors of official subject packs and support files,
+not as public official publication endpoints.
+
+Practical rule:
+
+- if the mirrored file is clearly an official PDF or support asset, it can be used
+  as ground truth
+- if origin is unclear, keep the source as `medium` confidence until corroborated
+
+## Quality Stack
+
+### C
+
+For C, the reference stack is strict and ordered:
+
+1. The Norm v4.1
+2. norminette
+3. project-specific testers
+4. evaluator review and oral defense
+
+Important nuance:
+
+- norminette checks many objective rules
+- it does not check every subjective or starred rule in the Norm
+- evaluator review still matters for clarity, decomposition and readability
+
+Key Norm constraints that matter product-wise:
+
+- short functions
+- limited parameters and local variables
+- predictable formatting
+- explicit declarations
+- constrained macros and headers
+- English-readable names
+- no hidden global-state shortcuts
+
+### francinette
+
+Francinette is not an official 42 tool and its upstream is archived, but it is
+still pedagogically useful because it models the broader pre-submit workflow.
+
+Reverse-engineered behavior:
+
+- detects the project from the folder and delivery artifacts
+- copies code to a temp workspace
+- runs `norminette`
+- runs `make`
+- dispatches to project-specific testers
+- supports strict modes for memory allocation checks in some projects
+
+This makes francinette useful as a verification harness, not as a source of
+truth.
+
+### mini-moulinette / mini-norminette variants
+
+The exact campus naming is not fully canonical in public sources, but the tool
+family is real and matches the role described by school discussion:
+
+- very fast local pre-submit checks
+- bundled exercise-level test cases
+- score-like feedback that approximates a local moulinette
+
+Use these tools as quick verification aids, never as the pedagogical authority.
+
+## Python and Bash Equivalence
+
+Python and Bash should not imitate the C Norm at the syntax level. They should
+match it in spirit:
+
+- explicitness
+- small understandable units
+- limited hidden behavior
+- readable naming
+- observable test coverage
+- easy debugging
+
+### Python equivalent
+
+Recommended baseline:
+
+- `ruff check`
+- `ruff format`
+- `mypy`
+- `pytest`
+
+What this replaces conceptually:
+
+- Norm formatting discipline -> formatter and lint baseline
+- limited implicit behavior -> typed boundaries and simpler functions
+- evaluator readability pressure -> explicit data flow and testable behavior
+
+### Bash equivalent
+
+Recommended baseline:
+
+- `shellcheck`
+- `shfmt`
+- smoke scripts or `bats`
+
+What this replaces conceptually:
+
+- Norm formatting discipline -> `shfmt`
+- constrained syntax and clarity -> ShellCheck plus quoting discipline
+- reviewer pressure -> readable pipelines, explicit error handling and debuggable scripts
+
+## Curriculum Interpretation Policy
+
+The new Common Core naming visible in the infographic and mirrored documents must
+stay explicitly labeled as interpreted whenever public official publication is
+still incomplete.
+
+Rules:
+
+- keep legacy C/Common Core projects as first-class references
+- expose emerging Python and AI milestones with confidence labels
+- never present inferred project names as fully canonical without saying so
+
+## Product Impact
+
+The application should surface:
+
+- official references
+- mirror references with confidence levels
+- the quality stack per language
+- the distinction between truth, verification and interpretation
+
+This lets the learner train for the old and new tracks at the same time without
+losing the original 42 rigor.

--- a/docs/NEW_TC_PROJECT_PREDICTIONS.md
+++ b/docs/NEW_TC_PROJECT_PREDICTIONS.md
@@ -1,0 +1,230 @@
+# New Common Core Project Predictions
+
+## Status
+
+This document is explicitly interpretive.
+
+It uses three inputs:
+
+- the old versus new Common Core infographic shared in the thread
+- the historical 42 C project sequence
+- the official public Lausanne signals about AI and the currently available mirror packs
+
+It does **not** claim that the predicted subjects below are canon.
+
+## Method
+
+The working hypothesis is that the new Python and AI projects preserve the 42
+pedagogical style of the old C track:
+
+- constrained briefs
+- project-based progression
+- rising system and algorithm difficulty
+- peer evaluation pressure
+- oral defense expectations
+
+What changes is the thematic wrapper and the dominant language.
+
+## Predicted Mappings
+
+### `piscine python`
+
+Legacy style anchor:
+
+- C Piscine modules `C00` to `C13`
+
+Predicted subject style:
+
+- many small Python exercises
+- strict basics before abstraction
+- visible command-line behavior
+- progressive move from syntax to data structures to small OOP units
+
+Likely deliverables:
+
+- `ex00..exNN` scripts
+- tiny CLIs
+- elementary utility functions
+- local test examples
+
+Likely constraints:
+
+- stdlib-first
+- no framework magic
+- clear function boundaries
+- strong edge-case pressure
+
+### `a maze ing`
+
+Legacy style anchors:
+
+- `so_long`
+- `fdf`
+- `fract'ol`
+
+Predicted subject style:
+
+- maze or grid problem
+- parsing + movement + validation
+- light graphics or visual feedback
+- algorithmic traversal, not just rendering
+
+Likely deliverables:
+
+- map parser
+- maze visualizer
+- solver or validator
+- game loop or turn loop
+
+### `codexion`
+
+Legacy style anchor:
+
+- `philo`
+
+Predicted subject style:
+
+- concurrency under Python constraints
+- scheduling, coordination, workers, locks or queues
+- emphasis on observability and race debugging
+
+Likely deliverables:
+
+- multi-worker engine
+- task orchestration layer
+- reproducible logs
+- timeout and shutdown handling
+
+### `fly in`
+
+Legacy style anchor:
+
+- `push_swap`
+
+Predicted subject style:
+
+- scored algorithm challenge
+- optimization under an action model
+- explanation of strategy matters
+
+Likely deliverables:
+
+- solver
+- trace of actions
+- benchmark or scorer
+- comparison of strategies
+
+### `call me maybe`
+
+Legacy style anchors:
+
+- `pipex`
+- `minitalk`
+
+Predicted subject style:
+
+- communication-oriented Python project
+- protocol or payload discipline
+- possible model-calling or function-calling semantics
+- strong focus on failure handling and tracing
+
+Likely deliverables:
+
+- caller/router
+- structured messages
+- mock or real tool/model interface
+- observable logs
+
+### `pacman`
+
+Legacy style anchors:
+
+- `cub3d`
+- `so_long`
+
+Predicted subject style:
+
+- playable project
+- movement and entity logic
+- maybe enemy AI or rule-based behaviors
+- readability matters more than graphical bravado
+
+Likely deliverables:
+
+- map
+- entities
+- scoring logic
+- visual runtime
+
+### `RAG against the machine`
+
+Legacy style anchor:
+
+- no exact old-track equivalent, but same capstone pressure
+
+Predicted subject style:
+
+- real retrieval pipeline
+- source indexing before generation
+- evaluation and citations
+- explicit anti-handwaving constraints
+
+Likely deliverables:
+
+- ingestion pipeline
+- retriever
+- answer generator with citations
+- evaluation report
+
+### `the answer protocol`
+
+Legacy style anchors:
+
+- `net_practice`
+- `ft_irc`
+- `webserv`
+
+Predicted subject style:
+
+- protocol and network semantics
+- structured exchanges
+- testing interoperability
+- less raw socket machismo, more contract discipline
+
+Likely deliverables:
+
+- protocol spec
+- server or broker
+- reference client
+- conformance tests
+
+### `agent smith`
+
+Legacy style anchors:
+
+- advanced orchestration capstones
+- part of the conceptual pressure once carried by later infra and large-system projects
+
+Predicted subject style:
+
+- multi-agent orchestration
+- tool use, context passing, memory and policy
+- explicit success metrics and evaluation scenarios
+
+Likely deliverables:
+
+- agent architecture
+- role policies
+- tool adapters
+- benchmark scenarios
+
+## Reading Rule
+
+These predictions should be used to:
+
+- prepare the curriculum structure
+- design learning rubrics
+- anticipate likely constraints
+
+They should not be presented as official 42 subject truth without a confidence
+label and source explanation.

--- a/docs/adr/0002-source-governance-and-rag-policy.md
+++ b/docs/adr/0002-source-governance-and-rag-policy.md
@@ -8,6 +8,8 @@
 A learning product for 42-related preparation will inevitably encounter:
 
 - official campus information
+- official normative documents such as The Norm
+- mirrored repositories that contain official subject PDFs or support files
 - community guides
 - testers
 - solution repositories
@@ -22,6 +24,7 @@ The product will enforce a tiered source policy.
 Allowed tiers:
 
 - `official_42`: ground truth
+- `official_document_mirrors`: ground truth when the mirrored document origin is verified
 - `community_docs`: explanation and mapping
 - `testers_and_tooling`: verification
 - `solution_metadata`: path mapping only
@@ -36,6 +39,7 @@ Positive:
 - preserves pedagogical integrity
 - makes RAG behavior auditable
 - clarifies what is authoritative versus interpretive
+- makes private or mirrored official document packs usable without pretending they are public official publication endpoints
 - allows community material without turning the app into a cheating tool
 
 Negative:

--- a/docs/adr/0008-official-reference-stack-and-quality-equivalence.md
+++ b/docs/adr/0008-official-reference-stack-and-quality-equivalence.md
@@ -1,0 +1,63 @@
+# ADR 0008: Official Reference Stack and Cross-Language Quality Equivalence
+
+- Status: accepted
+- Date: 2026-03-29
+
+## Context
+
+`42-training` now has access to stronger pedagogical references than the initial MVP:
+
+- The Norm v4.1 as the current official C standard
+- mirrored repositories containing current official subject PDFs and exercise packs
+- school feedback that real pre-submit practice often involves `norminette`, `francinette` and smaller local tester variants
+- an emerging Python and AI common-core lane that should not erase the rigor of the legacy C path
+
+The product therefore needs a stable decision on:
+
+- what counts as absolute pedagogical truth
+- what counts as verification tooling rather than truth
+- how to translate the spirit of 42 code rigor into Python and Bash without pretending those languages should follow C syntax rules
+
+## Decision
+
+The product will adopt the following reference model:
+
+- The Norm v4.1 is the absolute code-quality and pedagogical reference for C.
+- Public 42 pages and official normative documents remain the highest-authority sources.
+- Private or community-hosted mirrors of official documents are accepted as ground truth only when the mirrored origin is explicit and verified.
+- `norminette` is treated as the official automated checker for the objective subset of the Norm, not as a full replacement for evaluator review.
+- `francinette` and mini-moulinette or mini-norminette style tools are treated as verification harnesses, not as normative truth.
+- Python and Bash tracks must use coherent quality equivalents:
+  - Python: `ruff`, `mypy`, `pytest`, short explicit functions, typed boundaries, observable behavior
+  - Bash: `shellcheck`, `shfmt`, shell smoke tests, explicit quoting, fail-fast habits, readable command composition
+
+The application must expose this reference stack directly in its curriculum and UI so that pedagogy, source policy and quality expectations stay aligned.
+
+## Consequences
+
+Positive:
+
+- preserves the historical 42 C rigor as a first-class reference
+- makes the new Python lane compatible with the old standards in spirit rather than by superficial imitation
+- distinguishes official truth from mirrors, testers and community guidance
+- gives the UI and future RAG layers a stable model for confidence and tool recommendations
+
+Negative:
+
+- requires ongoing maintenance as the new curriculum becomes more public and less inferred
+- creates a broader reference surface than the initial MVP
+- some community tooling is archived or platform-fragile and must be presented with caveats
+
+## Rejected Alternatives
+
+### Treat all testers as authoritative
+
+Rejected because testers approximate evaluation behavior but do not define the pedagogical standard.
+
+### Reuse the C Norm verbatim for Python and Bash
+
+Rejected because equivalent rigor matters more than syntactic mimicry.
+
+### Ignore the emerging Python lane until the school publishes everything
+
+Rejected because the product goal is explicitly to prepare for both the legacy and emerging Common Core shapes while keeping confidence levels visible.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ This directory stores the key architecture decisions for `42-training`.
 - `0005-api-as-system-of-record.md`
 - `0006-multi-agent-role-model-and-orchestration.md`
 - `0007-postgresql-migration-strategy.md`
+- `0008-official-reference-stack-and-quality-equivalence.md`
 
 ## Purpose
 

--- a/packages/curriculum/data/42_lausanne_curriculum.json
+++ b/packages/curriculum/data/42_lausanne_curriculum.json
@@ -5,7 +5,8 @@
     "status": "mvp",
     "positioning": "triple-track learning app for shell, C, Python and AI literacy",
     "schema_version": "0.2.0",
-    "entity_note": "skills, checkpoints, resources and evidence_types are seeded for shell-basics as exemplar. Other modules will be populated incrementally."
+    "entity_note": "skills, checkpoints, resources and evidence_types are seeded for shell-basics as exemplar. Other modules will be populated incrementally.",
+    "reference_posture": "official public documents first, verified mirrors second, community tooling as verification only"
   },
   "source_policy": {
     "tiers": [
@@ -101,7 +102,21 @@
       "medium": "Community-vetted, generally reliable. Cross-check when precision matters.",
       "low": "Useful as metadata only. Do not treat as authoritative content.",
       "inferred": "Not verified against any source. Must be flagged explicitly to the learner."
-    }
+    },
+    "confidence_model": [
+      {
+        "level": "high",
+        "meaning": "Official public 42 page or official normative PDF."
+      },
+      {
+        "level": "medium",
+        "meaning": "Official document mirrored in a private reference repository or corroborated by staff discussion."
+      },
+      {
+        "level": "interpreted",
+        "meaning": "Curriculum hypothesis inferred from infographic, naming leaks or community mapping and kept explicit as interpretation."
+      }
+    ]
   },
   "tracks": [
     {
@@ -115,10 +130,25 @@
           "title": "Navigation and files",
           "phase": "foundation",
           "prerequisites": [],
-          "skills": ["pwd", "ls", "cd", "mkdir", "touch", "cp", "mv", "rm"],
+          "skills": [
+            "pwd",
+            "ls",
+            "cd",
+            "mkdir",
+            "touch",
+            "cp",
+            "mv",
+            "rm"
+          ],
           "skill_ids": [
-            "shell-pwd", "shell-ls", "shell-cd", "shell-mkdir",
-            "shell-touch", "shell-cp", "shell-mv", "shell-rm"
+            "shell-pwd",
+            "shell-ls",
+            "shell-cd",
+            "shell-mkdir",
+            "shell-touch",
+            "shell-cp",
+            "shell-mv",
+            "shell-rm"
           ],
           "deliverable": "Navigate, create, copy and clean files without hesitation.",
           "objectives": [
@@ -133,13 +163,34 @@
             "Explain the difference between cp and mv in own words"
           ],
           "exit_checklist": [
-            { "item": "Navigate to /tmp, /var/log and home using only cd and pwd", "type": "exercise" },
-            { "item": "Create a directory tree: project/src, project/docs, project/tests", "type": "exercise" },
-            { "item": "Copy a file from src/ to docs/ and verify with ls", "type": "exercise" },
-            { "item": "Move a file from docs/ to tests/ and confirm the original is gone", "type": "exercise" },
-            { "item": "Remove the entire project/ tree with rm -r", "type": "exercise" },
-            { "item": "Explain in own words: what does cp do that mv does not?", "type": "explanation" },
-            { "item": "Navigate a directory tree blindfolded (no ls, only cd and pwd)", "type": "challenge" }
+            {
+              "item": "Navigate to /tmp, /var/log and home using only cd and pwd",
+              "type": "exercise"
+            },
+            {
+              "item": "Create a directory tree: project/src, project/docs, project/tests",
+              "type": "exercise"
+            },
+            {
+              "item": "Copy a file from src/ to docs/ and verify with ls",
+              "type": "exercise"
+            },
+            {
+              "item": "Move a file from docs/ to tests/ and confirm the original is gone",
+              "type": "exercise"
+            },
+            {
+              "item": "Remove the entire project/ tree with rm -r",
+              "type": "exercise"
+            },
+            {
+              "item": "Explain in own words: what does cp do that mv does not?",
+              "type": "explanation"
+            },
+            {
+              "item": "Navigate a directory tree blindfolded (no ls, only cd and pwd)",
+              "type": "challenge"
+            }
           ],
           "resources": [
             {
@@ -155,17 +206,44 @@
               "why": "Step-by-step introduction to filesystem navigation on Linux"
             }
           ],
-          "estimated_hours": 4
+          "estimated_hours": 4,
+          "reference_note": "This app module aligns directly with the first official Shell Piscine subject available in the mirrored repository.",
+          "subject_refs": [
+            {
+              "label": "Shell00 subject PDF",
+              "document_title": "Piscine C Shell 00",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell00/fr.subject.pdf",
+              "mirror_path": "Shell00/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            }
+          ]
         },
         {
           "id": "shell-streams",
           "title": "Redirections and pipes",
           "phase": "foundation",
-          "prerequisites": ["shell-basics"],
-          "skills": ["stdin", "stdout", "stderr", "redirect", "append", "pipe", "grep"],
+          "prerequisites": [
+            "shell-basics"
+          ],
+          "skills": [
+            "stdin",
+            "stdout",
+            "stderr",
+            "redirect",
+            "append",
+            "pipe",
+            "grep"
+          ],
           "skill_ids": [
-            "shell-stdin", "shell-stdout", "shell-stderr", "shell-redirect",
-            "shell-append", "shell-pipe", "shell-grep"
+            "shell-stdin",
+            "shell-stdout",
+            "shell-stderr",
+            "shell-redirect",
+            "shell-append",
+            "shell-pipe",
+            "shell-grep"
           ],
           "deliverable": "Compose useful shell chains and inspect text quickly.",
           "objectives": [
@@ -180,12 +258,30 @@
             "Explain what happens when you pipe into grep vs redirect into grep"
           ],
           "exit_checklist": [
-            { "item": "Write output of ls -la to a file using >", "type": "exercise" },
-            { "item": "Append date output to the same file using >>", "type": "exercise" },
-            { "item": "Run a command that produces stderr and redirect only stderr to error.log", "type": "exercise" },
-            { "item": "Build a pipeline: cat file | grep pattern | wc -l", "type": "exercise" },
-            { "item": "Build a 3-stage pipeline that filters, sorts and counts unique lines", "type": "challenge" },
-            { "item": "Explain the difference between echo hello | grep h and grep h < file", "type": "explanation" }
+            {
+              "item": "Write output of ls -la to a file using >",
+              "type": "exercise"
+            },
+            {
+              "item": "Append date output to the same file using >>",
+              "type": "exercise"
+            },
+            {
+              "item": "Run a command that produces stderr and redirect only stderr to error.log",
+              "type": "exercise"
+            },
+            {
+              "item": "Build a pipeline: cat file | grep pattern | wc -l",
+              "type": "exercise"
+            },
+            {
+              "item": "Build a 3-stage pipeline that filters, sorts and counts unique lines",
+              "type": "challenge"
+            },
+            {
+              "item": "Explain the difference between echo hello | grep h and grep h < file",
+              "type": "explanation"
+            }
           ],
           "resources": [
             {
@@ -201,16 +297,38 @@
               "why": "Authoritative reference for redirect syntax and behavior"
             }
           ],
-          "estimated_hours": 5
+          "estimated_hours": 5,
+          "reference_note": "This app module is extracted from the broader Shell01 official subject.",
+          "subject_refs": [
+            {
+              "label": "Shell01 subject PDF",
+              "document_title": "Piscine C Shell 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell01/fr.subject%20(1).pdf",
+              "mirror_path": "Shell01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "shell-permissions",
           "title": "Permissions and execution",
           "phase": "foundation",
-          "prerequisites": ["shell-basics"],
-          "skills": ["chmod", "ownership", "executable bit", "PATH"],
+          "prerequisites": [
+            "shell-basics"
+          ],
+          "skills": [
+            "chmod",
+            "ownership",
+            "executable bit",
+            "PATH"
+          ],
           "skill_ids": [
-            "shell-chmod", "shell-ownership", "shell-executable-bit", "shell-path"
+            "shell-chmod",
+            "shell-ownership",
+            "shell-executable-bit",
+            "shell-path"
           ],
           "deliverable": "Understand why a script runs or fails.",
           "objectives": [
@@ -225,12 +343,30 @@
             "Explain why a file with 644 cannot be executed"
           ],
           "exit_checklist": [
-            { "item": "Create a script, try to run it, observe permission denied", "type": "exercise" },
-            { "item": "Use chmod +x to make it executable and run it", "type": "exercise" },
-            { "item": "Set permissions to 755 using octal notation and verify with ls -l", "type": "exercise" },
-            { "item": "Add the script directory to PATH and run it by name alone", "type": "exercise" },
-            { "item": "Explain why 644 means read+write for owner but no execute for anyone", "type": "explanation" },
-            { "item": "Diagnose a permission denied error on a file you did not create", "type": "challenge" }
+            {
+              "item": "Create a script, try to run it, observe permission denied",
+              "type": "exercise"
+            },
+            {
+              "item": "Use chmod +x to make it executable and run it",
+              "type": "exercise"
+            },
+            {
+              "item": "Set permissions to 755 using octal notation and verify with ls -l",
+              "type": "exercise"
+            },
+            {
+              "item": "Add the script directory to PATH and run it by name alone",
+              "type": "exercise"
+            },
+            {
+              "item": "Explain why 644 means read+write for owner but no execute for anyone",
+              "type": "explanation"
+            },
+            {
+              "item": "Diagnose a permission denied error on a file you did not create",
+              "type": "challenge"
+            }
           ],
           "resources": [
             {
@@ -246,16 +382,41 @@
               "why": "Clear reference for Unix permission model with practical examples"
             }
           ],
-          "estimated_hours": 3
+          "estimated_hours": 3,
+          "reference_note": "Permissions and execution habits are modeled from the official Shell01 subject because the app splits the official subject into finer pedagogical modules.",
+          "subject_refs": [
+            {
+              "label": "Shell01 subject PDF",
+              "document_title": "Piscine C Shell 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell01/fr.subject%20(1).pdf",
+              "mirror_path": "Shell01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "shell-tooling",
           "title": "Linux work habits",
           "phase": "practice",
-          "prerequisites": ["shell-streams", "shell-permissions"],
-          "skills": ["find", "history", "man", "vim basics", "git basics"],
+          "prerequisites": [
+            "shell-streams",
+            "shell-permissions"
+          ],
+          "skills": [
+            "find",
+            "history",
+            "man",
+            "vim basics",
+            "git basics"
+          ],
           "skill_ids": [
-            "shell-find", "shell-history", "shell-man", "shell-vim-basics", "shell-git-basics"
+            "shell-find",
+            "shell-history",
+            "shell-man",
+            "shell-vim-basics",
+            "shell-git-basics"
           ],
           "deliverable": "Operate daily in Linux without depending on GUI reflexes.",
           "objectives": [
@@ -270,14 +431,38 @@
             "Create a git repository and make 3 meaningful commits"
           ],
           "exit_checklist": [
-            { "item": "Use find to locate all .c files in a project tree", "type": "exercise" },
-            { "item": "Use find with -mtime to filter files modified in the last 24 hours", "type": "exercise" },
-            { "item": "Look up the flags of chmod using only man chmod", "type": "exercise" },
-            { "item": "Open a file in vim, insert text, save and quit", "type": "exercise" },
-            { "item": "Search for a word in vim using /pattern", "type": "exercise" },
-            { "item": "Run git init, create 3 files, commit each with a meaningful message", "type": "exercise" },
-            { "item": "Use git log to review your commit history", "type": "exercise" },
-            { "item": "Answer a man page question without any web search", "type": "challenge" }
+            {
+              "item": "Use find to locate all .c files in a project tree",
+              "type": "exercise"
+            },
+            {
+              "item": "Use find with -mtime to filter files modified in the last 24 hours",
+              "type": "exercise"
+            },
+            {
+              "item": "Look up the flags of chmod using only man chmod",
+              "type": "exercise"
+            },
+            {
+              "item": "Open a file in vim, insert text, save and quit",
+              "type": "exercise"
+            },
+            {
+              "item": "Search for a word in vim using /pattern",
+              "type": "exercise"
+            },
+            {
+              "item": "Run git init, create 3 files, commit each with a meaningful message",
+              "type": "exercise"
+            },
+            {
+              "item": "Use git log to review your commit history",
+              "type": "exercise"
+            },
+            {
+              "item": "Answer a man page question without any web search",
+              "type": "challenge"
+            }
           ],
           "resources": [
             {
@@ -299,7 +484,28 @@
               "why": "Hands-on vim practice without setup"
             }
           ],
-          "estimated_hours": 6
+          "estimated_hours": 6,
+          "reference_note": "This module synthesizes habits spread across the official Shell00 and Shell01 subjects rather than corresponding to a single official PDF.",
+          "subject_refs": [
+            {
+              "label": "Shell00 subject PDF",
+              "document_title": "Piscine C Shell 00",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell00/fr.subject.pdf",
+              "mirror_path": "Shell00/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "Shell01 subject PDF",
+              "document_title": "Piscine C Shell 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/Shell01/fr.subject%20(1).pdf",
+              "mirror_path": "Shell01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         }
       ]
     },
@@ -313,10 +519,22 @@
           "id": "c-basics",
           "title": "Syntax and control flow",
           "phase": "foundation",
-          "prerequisites": ["shell-basics"],
-          "skills": ["variables", "conditions", "loops", "functions", "headers"],
+          "prerequisites": [
+            "shell-basics"
+          ],
+          "skills": [
+            "variables",
+            "conditions",
+            "loops",
+            "functions",
+            "headers"
+          ],
           "skill_ids": [
-            "c-variables", "c-conditions", "c-loops", "c-functions", "c-headers"
+            "c-variables",
+            "c-conditions",
+            "c-loops",
+            "c-functions",
+            "c-headers"
           ],
           "deliverable": "Write small programs cleanly and compile with warnings enabled.",
           "objectives": [
@@ -332,14 +550,38 @@
             "Split a program across multiple files with a shared header"
           ],
           "exit_checklist": [
-            { "item": "Declare int, char, float variables and print them with printf", "type": "exercise" },
-            { "item": "Write an if/else block that handles at least 3 cases", "type": "exercise" },
-            { "item": "Write a while loop that counts from 1 to 100", "type": "exercise" },
-            { "item": "Write a for loop that iterates over a string character by character", "type": "exercise" },
-            { "item": "Create a function with a prototype in a .h file", "type": "exercise" },
-            { "item": "Compile with cc -Wall -Wextra -Werror and fix all warnings", "type": "exercise" },
-            { "item": "Split a program into main.c, utils.c and utils.h", "type": "challenge" },
-            { "item": "Run norminette on your code and fix all style errors", "type": "exercise" }
+            {
+              "item": "Declare int, char, float variables and print them with printf",
+              "type": "exercise"
+            },
+            {
+              "item": "Write an if/else block that handles at least 3 cases",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a while loop that counts from 1 to 100",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a for loop that iterates over a string character by character",
+              "type": "exercise"
+            },
+            {
+              "item": "Create a function with a prototype in a .h file",
+              "type": "exercise"
+            },
+            {
+              "item": "Compile with cc -Wall -Wextra -Werror and fix all warnings",
+              "type": "exercise"
+            },
+            {
+              "item": "Split a program into main.c, utils.c and utils.h",
+              "type": "challenge"
+            },
+            {
+              "item": "Run norminette on your code and fix all style errors",
+              "type": "exercise"
+            }
           ],
           "resources": [
             {
@@ -361,16 +603,78 @@
               "why": "Comprehensive free C guide with practical examples"
             }
           ],
-          "estimated_hours": 8
+          "estimated_hours": 8,
+          "reference_note": "This app module condenses several official Piscine subjects that collectively build syntax, expressions, functions and control flow.",
+          "subject_refs": [
+            {
+              "label": "C00 subject PDF",
+              "document_title": "Piscine C C 00",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C00/fr.subject.pdf",
+              "mirror_path": "C00/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C03 subject PDF",
+              "document_title": "C Piscine C 03",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C03/en.subject.pdf",
+              "mirror_path": "C03/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C04 subject PDF",
+              "document_title": "Piscine C C 04",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C04/fr.subject.pdf",
+              "mirror_path": "C04/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C05 subject PDF",
+              "document_title": "Piscine C C 05",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C05/fr.subject%20(1).pdf",
+              "mirror_path": "C05/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C06 subject PDF",
+              "document_title": "Piscine C C 06",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C06/fr.subject.pdf",
+              "mirror_path": "C06/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "c-memory",
           "title": "Pointers and memory",
           "phase": "foundation",
-          "prerequisites": ["c-basics"],
-          "skills": ["addresses", "pointers", "arrays", "strings", "malloc", "free"],
+          "prerequisites": [
+            "c-basics"
+          ],
+          "skills": [
+            "addresses",
+            "pointers",
+            "arrays",
+            "strings",
+            "malloc",
+            "free"
+          ],
           "skill_ids": [
-            "c-addresses", "c-pointers", "c-arrays", "c-strings", "c-malloc", "c-free"
+            "c-addresses",
+            "c-pointers",
+            "c-arrays",
+            "c-strings",
+            "c-malloc",
+            "c-free"
           ],
           "deliverable": "Explain memory decisions and avoid basic leaks.",
           "objectives": [
@@ -386,14 +690,38 @@
             "Run valgrind on own code and fix all reported leaks"
           ],
           "exit_checklist": [
-            { "item": "Declare a pointer, assign it to a variable address, dereference it", "type": "exercise" },
-            { "item": "Pass an int by pointer to a function and modify it", "type": "exercise" },
-            { "item": "Iterate over a char array using pointer arithmetic", "type": "exercise" },
-            { "item": "Allocate an int array with malloc, fill it, then free it", "type": "exercise" },
-            { "item": "Write a function that returns a malloc'd string and free it in main", "type": "exercise" },
-            { "item": "Draw a memory diagram showing stack frame and heap allocation", "type": "explanation" },
-            { "item": "Run valgrind --leak-check=full on your program and fix all leaks", "type": "exercise" },
-            { "item": "Explain what a dangling pointer is and how to avoid one", "type": "explanation" }
+            {
+              "item": "Declare a pointer, assign it to a variable address, dereference it",
+              "type": "exercise"
+            },
+            {
+              "item": "Pass an int by pointer to a function and modify it",
+              "type": "exercise"
+            },
+            {
+              "item": "Iterate over a char array using pointer arithmetic",
+              "type": "exercise"
+            },
+            {
+              "item": "Allocate an int array with malloc, fill it, then free it",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a function that returns a malloc'd string and free it in main",
+              "type": "exercise"
+            },
+            {
+              "item": "Draw a memory diagram showing stack frame and heap allocation",
+              "type": "explanation"
+            },
+            {
+              "item": "Run valgrind --leak-check=full on your program and fix all leaks",
+              "type": "exercise"
+            },
+            {
+              "item": "Explain what a dangling pointer is and how to avoid one",
+              "type": "explanation"
+            }
           ],
           "resources": [
             {
@@ -415,16 +743,61 @@
               "why": "Essential tool for detecting memory leaks in C programs"
             }
           ],
-          "estimated_hours": 10
+          "estimated_hours": 10,
+          "reference_note": "This app module spans the official pointer, string and allocation parts of the Piscine rather than one single subject.",
+          "subject_refs": [
+            {
+              "label": "C01 subject PDF",
+              "document_title": "Piscine C C 01",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C01/fr.subject%20(1).pdf",
+              "mirror_path": "C01/fr.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C02 subject PDF",
+              "document_title": "Piscine C C 02",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C02/fr.subject.pdf",
+              "mirror_path": "C02/fr.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "C07 subject PDF",
+              "document_title": "C Piscine C 07",
+              "url": "https://github.com/Ninjarsenic/42-piscine/blob/main/C07/en.subject.pdf",
+              "mirror_path": "C07/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "c-build-debug",
           "title": "Build, tests and debug",
           "phase": "practice",
-          "prerequisites": ["c-basics", "shell-streams"],
-          "skills": ["cc", "Wall", "Wextra", "Werror", "gdb", "valgrind"],
+          "prerequisites": [
+            "c-basics",
+            "shell-streams"
+          ],
+          "skills": [
+            "cc",
+            "Wall",
+            "Wextra",
+            "Werror",
+            "gdb",
+            "valgrind"
+          ],
           "skill_ids": [
-            "c-cc", "c-wall", "c-wextra", "c-werror", "c-gdb", "c-valgrind"
+            "c-cc",
+            "c-wall",
+            "c-wextra",
+            "c-werror",
+            "c-gdb",
+            "c-valgrind"
           ],
           "deliverable": "Investigate failures instead of guessing.",
           "objectives": [
@@ -440,14 +813,38 @@
             "Produce a valgrind-clean run on a project with dynamic allocation"
           ],
           "exit_checklist": [
-            { "item": "Compile a program with cc -Wall -Wextra -Werror -g", "type": "exercise" },
-            { "item": "Read a compiler error message and fix the issue without guessing", "type": "exercise" },
-            { "item": "Write a Makefile with all, clean, fclean and re targets", "type": "exercise" },
-            { "item": "Run make re and verify the binary is rebuilt from scratch", "type": "exercise" },
-            { "item": "Set a breakpoint in gdb, run to it, inspect a variable", "type": "exercise" },
-            { "item": "Use gdb to find the exact line causing a segfault", "type": "challenge" },
-            { "item": "Run valgrind on a program with malloc and achieve zero errors", "type": "exercise" },
-            { "item": "Describe your debugging workflow: what do you try first, second, third?", "type": "explanation" }
+            {
+              "item": "Compile a program with cc -Wall -Wextra -Werror -g",
+              "type": "exercise"
+            },
+            {
+              "item": "Read a compiler error message and fix the issue without guessing",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a Makefile with all, clean, fclean and re targets",
+              "type": "exercise"
+            },
+            {
+              "item": "Run make re and verify the binary is rebuilt from scratch",
+              "type": "exercise"
+            },
+            {
+              "item": "Set a breakpoint in gdb, run to it, inspect a variable",
+              "type": "exercise"
+            },
+            {
+              "item": "Use gdb to find the exact line causing a segfault",
+              "type": "challenge"
+            },
+            {
+              "item": "Run valgrind on a program with malloc and achieve zero errors",
+              "type": "exercise"
+            },
+            {
+              "item": "Describe your debugging workflow: what do you try first, second, third?",
+              "type": "explanation"
+            }
           ],
           "resources": [
             {
@@ -475,16 +872,66 @@
               "why": "Memory error detection reference"
             }
           ],
-          "estimated_hours": 8
+          "estimated_hours": 8,
+          "reference_note": "This module ties the official Norm to the first Common Core projects where build discipline, fd debugging and constrained APIs become concrete.",
+          "subject_refs": [
+            {
+              "label": "The Norm v4.1 PDF",
+              "document_title": "The Norm",
+              "url": "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+              "mirror_path": "42school/norminette/pdf/en.norm.pdf",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "Libft subject PDF",
+              "document_title": "Libft",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Libft/en.subject.pdf",
+              "mirror_path": "Libft/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "ft_printf subject PDF",
+              "document_title": "ft_printf",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject%20(1).pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            },
+            {
+              "label": "Get Next Line subject PDF",
+              "document_title": "Get Next Line",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject.pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "partial_subject_mapping"
+            }
+          ]
         },
         {
           "id": "c-libft-pushswap-bridge",
           "title": "Library and algorithm bridge",
           "phase": "core",
-          "prerequisites": ["c-memory", "c-build-debug"],
-          "skills": ["libft mindset", "API naming", "sorting logic", "complexity intuition"],
+          "prerequisites": [
+            "c-memory",
+            "c-build-debug"
+          ],
+          "skills": [
+            "libft mindset",
+            "API naming",
+            "sorting logic",
+            "complexity intuition"
+          ],
           "skill_ids": [
-            "c-libft-mindset", "c-api-naming", "c-sorting-logic", "c-complexity-intuition"
+            "c-libft-mindset",
+            "c-api-naming",
+            "c-sorting-logic",
+            "c-complexity-intuition"
           ],
           "deliverable": "Prepare for libft, printf, gnl and push_swap logic.",
           "objectives": [
@@ -499,15 +946,42 @@
             "Write a test harness that validates function behavior against edge cases"
           ],
           "exit_checklist": [
-            { "item": "Implement ft_strlen with the same prototype as strlen", "type": "exercise" },
-            { "item": "Implement ft_strcpy, ft_strdup and ft_substr", "type": "exercise" },
-            { "item": "Implement ft_atoi handling signs and whitespace", "type": "exercise" },
-            { "item": "Ensure all functions follow a consistent naming convention", "type": "exercise" },
-            { "item": "Write a main.c that tests each function with normal and edge inputs", "type": "exercise" },
-            { "item": "Implement bubble sort and explain why it is O(n^2)", "type": "exercise" },
-            { "item": "Implement a second sort (insertion or selection) and compare", "type": "exercise" },
-            { "item": "Run norminette and valgrind on all functions and fix all issues", "type": "exercise" },
-            { "item": "Explain when O(n log n) matters vs O(n^2) with a concrete example", "type": "explanation" }
+            {
+              "item": "Implement ft_strlen with the same prototype as strlen",
+              "type": "exercise"
+            },
+            {
+              "item": "Implement ft_strcpy, ft_strdup and ft_substr",
+              "type": "exercise"
+            },
+            {
+              "item": "Implement ft_atoi handling signs and whitespace",
+              "type": "exercise"
+            },
+            {
+              "item": "Ensure all functions follow a consistent naming convention",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a main.c that tests each function with normal and edge inputs",
+              "type": "exercise"
+            },
+            {
+              "item": "Implement bubble sort and explain why it is O(n^2)",
+              "type": "exercise"
+            },
+            {
+              "item": "Implement a second sort (insertion or selection) and compare",
+              "type": "exercise"
+            },
+            {
+              "item": "Run norminette and valgrind on all functions and fix all issues",
+              "type": "exercise"
+            },
+            {
+              "item": "Explain when O(n log n) matters vs O(n^2) with a concrete example",
+              "type": "explanation"
+            }
           ],
           "resources": [
             {
@@ -535,7 +1009,46 @@
               "why": "Curated index of 42 project guides, testers and community resources"
             }
           ],
-          "estimated_hours": 12
+          "estimated_hours": 12,
+          "reference_note": "This module is intentionally bound to the exact first Common Core project subjects that bridge utility libraries, file descriptors and constrained sorting.",
+          "subject_refs": [
+            {
+              "label": "Libft subject PDF",
+              "document_title": "Libft",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Libft/en.subject.pdf",
+              "mirror_path": "Libft/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "ft_printf subject PDF",
+              "document_title": "ft_printf",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject%20(1).pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject (1).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "Get Next Line subject PDF",
+              "document_title": "Get Next Line",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%201/en.subject.pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 1/en.subject.pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            },
+            {
+              "label": "Push_swap subject PDF",
+              "document_title": "Push_swap",
+              "url": "https://github.com/Ninjarsenic/42-Tronc_commun/blob/main/Zpdf_cursus_c/Cercle%202/Push_swap/en.subject%20(3).pdf",
+              "mirror_path": "Zpdf_cursus_c/Cercle 2/Push_swap/en.subject (3).pdf",
+              "tier": "official_document_mirrors",
+              "confidence": "medium",
+              "coverage": "exact_subject"
+            }
+          ]
         }
       ]
     },
@@ -549,10 +1062,22 @@
           "id": "python-basics",
           "title": "Python foundations",
           "phase": "foundation",
-          "prerequisites": ["shell-basics"],
-          "skills": ["variables", "conditions", "loops", "functions", "collections"],
+          "prerequisites": [
+            "shell-basics"
+          ],
+          "skills": [
+            "variables",
+            "conditions",
+            "loops",
+            "functions",
+            "collections"
+          ],
           "skill_ids": [
-            "py-variables", "py-conditions", "py-loops", "py-functions", "py-collections"
+            "py-variables",
+            "py-conditions",
+            "py-loops",
+            "py-functions",
+            "py-collections"
           ],
           "deliverable": "Write and explain small scripts confidently.",
           "objectives": [
@@ -568,14 +1093,38 @@
             "Solve a small algorithmic problem using only standard library"
           ],
           "exit_checklist": [
-            { "item": "Declare variables of type int, str, float, bool and print them", "type": "exercise" },
-            { "item": "Write an if/elif/else block with at least 3 branches", "type": "exercise" },
-            { "item": "Write a for loop that iterates over a list and a dictionary", "type": "exercise" },
-            { "item": "Write a function that takes a list and returns a filtered version", "type": "exercise" },
-            { "item": "Use a list comprehension to transform a list of strings", "type": "exercise" },
-            { "item": "Write a script that reads a text file and counts word frequencies", "type": "exercise" },
-            { "item": "Explain when to use a list vs a tuple vs a dictionary", "type": "explanation" },
-            { "item": "Solve FizzBuzz using only the standard library", "type": "challenge" }
+            {
+              "item": "Declare variables of type int, str, float, bool and print them",
+              "type": "exercise"
+            },
+            {
+              "item": "Write an if/elif/else block with at least 3 branches",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a for loop that iterates over a list and a dictionary",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a function that takes a list and returns a filtered version",
+              "type": "exercise"
+            },
+            {
+              "item": "Use a list comprehension to transform a list of strings",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a script that reads a text file and counts word frequencies",
+              "type": "exercise"
+            },
+            {
+              "item": "Explain when to use a list vs a tuple vs a dictionary",
+              "type": "explanation"
+            },
+            {
+              "item": "Solve FizzBuzz using only the standard library",
+              "type": "challenge"
+            }
           ],
           "resources": [
             {
@@ -591,16 +1140,40 @@
               "why": "The canonical Python tutorial from the language maintainers"
             }
           ],
-          "estimated_hours": 8
+          "estimated_hours": 8,
+          "reference_note": "No exact official Python subject PDF was found in the currently available official mirrors on 2026-03-29. This module is therefore anchored to the official Lausanne AI program page and to the interpreted new Common Core mapping.",
+          "subject_refs": [
+            {
+              "label": "42 Lausanne - IA",
+              "document_title": "42 Lausanne IA page",
+              "url": "https://42lausanne.ch/ia/",
+              "mirror_path": "42lausanne.ch/ia",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            }
+          ]
         },
         {
           "id": "python-oop-scripting",
           "title": "Objects and automation",
           "phase": "practice",
-          "prerequisites": ["python-basics"],
-          "skills": ["classes", "methods", "files", "json", "argparse"],
+          "prerequisites": [
+            "python-basics"
+          ],
+          "skills": [
+            "classes",
+            "methods",
+            "files",
+            "json",
+            "argparse"
+          ],
           "skill_ids": [
-            "py-classes", "py-methods", "py-files", "py-json", "py-argparse"
+            "py-classes",
+            "py-methods",
+            "py-files",
+            "py-json",
+            "py-argparse"
           ],
           "deliverable": "Build useful utilities and simple models.",
           "objectives": [
@@ -616,13 +1189,34 @@
             "Write a script that handles missing files and bad input gracefully"
           ],
           "exit_checklist": [
-            { "item": "Define a class with __init__, at least 2 attributes and a method", "type": "exercise" },
-            { "item": "Create a subclass that overrides one method", "type": "exercise" },
-            { "item": "Read a JSON file with json.load and access nested fields", "type": "exercise" },
-            { "item": "Write a dictionary to a JSON file with json.dump and indent=2", "type": "exercise" },
-            { "item": "Parse CLI arguments with argparse (at least 1 positional, 1 optional)", "type": "exercise" },
-            { "item": "Handle FileNotFoundError and json.JSONDecodeError with try/except", "type": "exercise" },
-            { "item": "Build a CLI tool that reads JSON, transforms it and writes output", "type": "challenge" }
+            {
+              "item": "Define a class with __init__, at least 2 attributes and a method",
+              "type": "exercise"
+            },
+            {
+              "item": "Create a subclass that overrides one method",
+              "type": "exercise"
+            },
+            {
+              "item": "Read a JSON file with json.load and access nested fields",
+              "type": "exercise"
+            },
+            {
+              "item": "Write a dictionary to a JSON file with json.dump and indent=2",
+              "type": "exercise"
+            },
+            {
+              "item": "Parse CLI arguments with argparse (at least 1 positional, 1 optional)",
+              "type": "exercise"
+            },
+            {
+              "item": "Handle FileNotFoundError and json.JSONDecodeError with try/except",
+              "type": "exercise"
+            },
+            {
+              "item": "Build a CLI tool that reads JSON, transforms it and writes output",
+              "type": "challenge"
+            }
           ],
           "resources": [
             {
@@ -638,16 +1232,40 @@
               "why": "Official reference for Python class syntax and OOP patterns"
             }
           ],
-          "estimated_hours": 10
+          "estimated_hours": 10,
+          "reference_note": "No exact official Python OOP subject PDF is present in the current mirrored packs. This module stays tied to the official Lausanne AI axis while awaiting exact subject publication.",
+          "subject_refs": [
+            {
+              "label": "42 Lausanne - IA",
+              "document_title": "42 Lausanne IA page",
+              "url": "https://42lausanne.ch/ia/",
+              "mirror_path": "42lausanne.ch/ia",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            }
+          ]
         },
         {
           "id": "ai-rag-agents",
           "title": "AI, RAG and agent literacy",
           "phase": "advanced",
-          "prerequisites": ["python-oop-scripting"],
-          "skills": ["prompt design", "retrieval", "evaluation", "agent workflow", "source policy"],
+          "prerequisites": [
+            "python-oop-scripting"
+          ],
+          "skills": [
+            "prompt design",
+            "retrieval",
+            "evaluation",
+            "agent workflow",
+            "source policy"
+          ],
           "skill_ids": [
-            "ai-prompt-design", "ai-retrieval", "ai-evaluation", "ai-agent-workflow", "ai-source-policy"
+            "ai-prompt-design",
+            "ai-retrieval",
+            "ai-evaluation",
+            "ai-agent-workflow",
+            "ai-source-policy"
           ],
           "deliverable": "Use AI as a disciplined tool without outsourcing understanding.",
           "objectives": [
@@ -663,14 +1281,38 @@
             "Explain the source-governance tiers and why they matter for learning integrity"
           ],
           "exit_checklist": [
-            { "item": "Explain what RAG is and why retrieval matters for accuracy", "type": "explanation" },
-            { "item": "Write a prompt that constrains the LLM to answer from provided context only", "type": "exercise" },
-            { "item": "Build a minimal retrieve-then-generate pipeline (even with mock data)", "type": "exercise" },
-            { "item": "Evaluate 5 AI responses: mark each as accurate, partial or hallucinated", "type": "exercise" },
-            { "item": "Identify which source tier each response draws from (official, community, inferred)", "type": "exercise" },
-            { "item": "Explain the 5 source-governance tiers and give one example per tier", "type": "explanation" },
-            { "item": "Describe one scenario where AI assistance becomes AI dependency", "type": "explanation" },
-            { "item": "Build a pipeline that refuses to answer when no source is available", "type": "challenge" }
+            {
+              "item": "Explain what RAG is and why retrieval matters for accuracy",
+              "type": "explanation"
+            },
+            {
+              "item": "Write a prompt that constrains the LLM to answer from provided context only",
+              "type": "exercise"
+            },
+            {
+              "item": "Build a minimal retrieve-then-generate pipeline (even with mock data)",
+              "type": "exercise"
+            },
+            {
+              "item": "Evaluate 5 AI responses: mark each as accurate, partial or hallucinated",
+              "type": "exercise"
+            },
+            {
+              "item": "Identify which source tier each response draws from (official, community, inferred)",
+              "type": "exercise"
+            },
+            {
+              "item": "Explain the 5 source-governance tiers and give one example per tier",
+              "type": "explanation"
+            },
+            {
+              "item": "Describe one scenario where AI assistance becomes AI dependency",
+              "type": "explanation"
+            },
+            {
+              "item": "Build a pipeline that refuses to answer when no source is available",
+              "type": "challenge"
+            }
           ],
           "resources": [
             {
@@ -692,7 +1334,28 @@
               "why": "Community reference for AI-related 42 projects and resources"
             }
           ],
-          "estimated_hours": 15
+          "estimated_hours": 15,
+          "reference_note": "The official public anchor is the Lausanne AI page. Exact Common Core AI subject PDFs are not yet present in the currently available mirror pack, so the app keeps the downstream project names explicitly interpreted.",
+          "subject_refs": [
+            {
+              "label": "42 Lausanne - IA",
+              "document_title": "42 Lausanne IA page",
+              "url": "https://42lausanne.ch/ia/",
+              "mirror_path": "42lausanne.ch/ia",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            },
+            {
+              "label": "42 Lausanne - pedagogie",
+              "document_title": "42 Lausanne pedagogie page",
+              "url": "https://42lausanne.ch/pedagogie-42/",
+              "mirror_path": "42lausanne.ch/pedagogie-42",
+              "tier": "official_42",
+              "confidence": "high",
+              "coverage": "official_program_signal"
+            }
+          ]
         }
       ]
     }
@@ -714,7 +1377,9 @@
       "module_id": "shell-basics",
       "description": "List directory contents to see what files exist.",
       "phase": "foundation",
-      "prerequisites": ["shell-pwd"]
+      "prerequisites": [
+        "shell-pwd"
+      ]
     },
     {
       "id": "shell-cd",
@@ -723,7 +1388,9 @@
       "module_id": "shell-basics",
       "description": "Change directory to move through the filesystem.",
       "phase": "foundation",
-      "prerequisites": ["shell-pwd"]
+      "prerequisites": [
+        "shell-pwd"
+      ]
     },
     {
       "id": "shell-mkdir",
@@ -732,7 +1399,9 @@
       "module_id": "shell-basics",
       "description": "Create directories to organize files.",
       "phase": "foundation",
-      "prerequisites": ["shell-cd"]
+      "prerequisites": [
+        "shell-cd"
+      ]
     },
     {
       "id": "shell-touch",
@@ -741,7 +1410,9 @@
       "module_id": "shell-basics",
       "description": "Create empty files or update timestamps.",
       "phase": "foundation",
-      "prerequisites": ["shell-cd"]
+      "prerequisites": [
+        "shell-cd"
+      ]
     },
     {
       "id": "shell-cp",
@@ -750,7 +1421,9 @@
       "module_id": "shell-basics",
       "description": "Copy files and directories.",
       "phase": "foundation",
-      "prerequisites": ["shell-ls"]
+      "prerequisites": [
+        "shell-ls"
+      ]
     },
     {
       "id": "shell-mv",
@@ -759,7 +1432,9 @@
       "module_id": "shell-basics",
       "description": "Move or rename files and directories.",
       "phase": "foundation",
-      "prerequisites": ["shell-ls"]
+      "prerequisites": [
+        "shell-ls"
+      ]
     },
     {
       "id": "shell-rm",
@@ -768,7 +1443,10 @@
       "module_id": "shell-basics",
       "description": "Remove files and directories. Understand irreversibility.",
       "phase": "foundation",
-      "prerequisites": ["shell-ls", "shell-cp"]
+      "prerequisites": [
+        "shell-ls",
+        "shell-cp"
+      ]
     }
   ],
   "checkpoints": [
@@ -776,7 +1454,11 @@
       "id": "cp-shell-navigate",
       "label": "Navigate a directory tree",
       "type": "exercise",
-      "validates_skills": ["shell-pwd", "shell-ls", "shell-cd"],
+      "validates_skills": [
+        "shell-pwd",
+        "shell-ls",
+        "shell-cd"
+      ],
       "module_id": "shell-basics",
       "prompt": "Starting from your home directory, navigate to /tmp, list its contents, then return home. Show each command and its output.",
       "success_criteria": "Learner uses pwd, cd, and ls correctly and can explain where they are at each step."
@@ -785,7 +1467,12 @@
       "id": "cp-shell-create-organize",
       "label": "Create and organize a project structure",
       "type": "exercise",
-      "validates_skills": ["shell-mkdir", "shell-touch", "shell-cp", "shell-mv"],
+      "validates_skills": [
+        "shell-mkdir",
+        "shell-touch",
+        "shell-cp",
+        "shell-mv"
+      ],
       "module_id": "shell-basics",
       "prompt": "Create a directory called 'myproject' with subdirectories 'src' and 'docs'. Create a file in src, copy it to docs, then rename it.",
       "success_criteria": "Correct directory structure exists and learner can verify it with ls -R."
@@ -794,7 +1481,9 @@
       "id": "cp-shell-cleanup",
       "label": "Clean up files safely",
       "type": "self_check",
-      "validates_skills": ["shell-rm"],
+      "validates_skills": [
+        "shell-rm"
+      ],
       "module_id": "shell-basics",
       "prompt": "Remove the test structure you created. Before each rm, explain what will be deleted and why it is safe to do so.",
       "success_criteria": "Learner demonstrates awareness of what rm does and checks before deleting."
@@ -806,7 +1495,11 @@
       "label": "42 Lausanne - pedagogie",
       "url": "https://42lausanne.ch/pedagogie-42/",
       "tier": "official_42",
-      "skill_ids": ["shell-pwd", "shell-ls", "shell-cd"],
+      "skill_ids": [
+        "shell-pwd",
+        "shell-ls",
+        "shell-cd"
+      ],
       "format": "article",
       "language": "fr"
     },
@@ -816,8 +1509,14 @@
       "url": "https://man7.org/linux/man-pages/",
       "tier": "community_docs",
       "skill_ids": [
-        "shell-pwd", "shell-ls", "shell-cd", "shell-mkdir",
-        "shell-touch", "shell-cp", "shell-mv", "shell-rm"
+        "shell-pwd",
+        "shell-ls",
+        "shell-cd",
+        "shell-mkdir",
+        "shell-touch",
+        "shell-cp",
+        "shell-mv",
+        "shell-rm"
       ],
       "format": "man_page",
       "language": "en"
@@ -827,7 +1526,10 @@
       "label": "awesome-42",
       "url": "https://github.com/leeoocca/awesome-42",
       "tier": "community_docs",
-      "skill_ids": ["shell-pwd", "shell-ls"],
+      "skill_ids": [
+        "shell-pwd",
+        "shell-ls"
+      ],
       "format": "repository",
       "language": "en"
     }
@@ -957,5 +1659,201 @@
       "url": "https://github.com/Tripouille/libftTester",
       "tier": "testers_and_tooling"
     }
-  ]
+  ],
+  "reference_stack": {
+    "official_documents": [
+      {
+        "label": "42 Lausanne - pedagogie",
+        "url": "https://42lausanne.ch/pedagogie-42/",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "campus pedagogy and learning model"
+      },
+      {
+        "label": "42 Lausanne - IA",
+        "url": "https://42lausanne.ch/ia/",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "public signal that AI is now inside the Lausanne positioning"
+      },
+      {
+        "label": "The Norm v4.1 (English PDF)",
+        "url": "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "absolute code-quality and pedagogical reference for C projects"
+      },
+      {
+        "label": "42School/norminette",
+        "url": "https://github.com/42school/norminette",
+        "tier": "official_42",
+        "confidence": "high",
+        "usage": "reference implementation of objective Norm checks"
+      }
+    ],
+    "official_document_mirrors": [
+      {
+        "label": "Ninjarsenic/42-Tronc_commun",
+        "url": "https://github.com/Ninjarsenic/42-Tronc_commun",
+        "tier": "official_document_mirrors",
+        "confidence": "medium",
+        "usage": "private mirror of current official Common Core subjects and support files",
+        "note": "Treat document content as authoritative only when the mirrored file origin is explicit."
+      },
+      {
+        "label": "Ninjarsenic/42-piscine",
+        "url": "https://github.com/Ninjarsenic/42-piscine",
+        "tier": "official_document_mirrors",
+        "confidence": "medium",
+        "usage": "private mirror of current official Piscine exercises and supporting assets",
+        "note": "Useful for shell and early C foundations, but still distinct from public official publication."
+      }
+    ],
+    "quality_stack": [
+      {
+        "id": "norm_v4_1",
+        "label": "The Norm v4.1",
+        "url": "https://github.com/42School/norminette/blob/master/pdf/en.norm.pdf",
+        "language": "c",
+        "kind": "official_standard",
+        "authority": "absolute_reference",
+        "role": "Defines naming, formatting, function, header, macro and file constraints for Common Core C."
+      },
+      {
+        "id": "norminette",
+        "label": "norminette",
+        "url": "https://github.com/42school/norminette",
+        "language": "c",
+        "kind": "official_checker",
+        "authority": "official_tool",
+        "role": "Automates objective Norm checks; starred subjective rules still require human review."
+      },
+      {
+        "id": "francinette",
+        "label": "francinette",
+        "url": "https://github.com/xicodomingues/francinette",
+        "language": "c",
+        "kind": "community_local_moulinette",
+        "authority": "verification_only",
+        "role": "Runs norminette, make, project detection and project-specific tester suites locally.",
+        "note": "Archived and outdated upstream, but still useful to understand expected pre-submit checks."
+      },
+      {
+        "id": "mini_moulinette",
+        "label": "mini-moulinette / mini-norminette variants",
+        "url": "https://github.com/k11q/mini-moulinette",
+        "language": "c",
+        "kind": "community_micro_tester",
+        "authority": "verification_only",
+        "role": "Fast local assignment harness for Piscine-style exercises with bundled edge cases.",
+        "note": "Campus naming may vary; model this family as representative rather than canonical."
+      },
+      {
+        "id": "ruff",
+        "label": "ruff",
+        "url": "https://github.com/astral-sh/ruff",
+        "language": "python",
+        "kind": "lint_and_format",
+        "authority": "equivalent_quality_gate",
+        "role": "Closest Python equivalent to objective formatting plus obvious bad-pattern enforcement."
+      },
+      {
+        "id": "mypy",
+        "label": "mypy",
+        "url": "https://github.com/python/mypy",
+        "language": "python",
+        "kind": "type_checker",
+        "authority": "equivalent_quality_gate",
+        "role": "Keeps interfaces explicit and reduces hidden dynamic behavior in learning code."
+      },
+      {
+        "id": "pytest",
+        "label": "pytest",
+        "url": "https://pytest.org/",
+        "language": "python",
+        "kind": "test_runner",
+        "authority": "equivalent_quality_gate",
+        "role": "Makes understanding observable through explicit examples and edge-case checks."
+      },
+      {
+        "id": "shellcheck",
+        "label": "ShellCheck",
+        "url": "https://www.shellcheck.net/",
+        "language": "bash",
+        "kind": "lint",
+        "authority": "equivalent_quality_gate",
+        "role": "Catches quoting, globbing, subshell and portability mistakes in shell scripts."
+      },
+      {
+        "id": "shfmt",
+        "label": "shfmt",
+        "url": "https://github.com/mvdan/sh",
+        "language": "bash",
+        "kind": "formatter",
+        "authority": "equivalent_quality_gate",
+        "role": "Provides a stable shell formatting baseline analogous to Norm look-and-feel discipline."
+      },
+      {
+        "id": "bats",
+        "label": "bats",
+        "url": "https://github.com/bats-core/bats-core",
+        "language": "bash",
+        "kind": "test_runner",
+        "authority": "equivalent_quality_gate",
+        "role": "Makes shell behavior testable instead of relying only on manual terminal checks."
+      }
+    ],
+    "quality_equivalents": [
+      {
+        "language": "c",
+        "positioning": "Absolute reference track. Keep the historical 42 rigor intact.",
+        "quality_contract": "The Norm v4.1 is the default source of truth, norminette checks the objective subset, and project-specific testers plus evaluator review cover behavior and subjective quality.",
+        "automated_gates": [
+          "norminette",
+          "cc -Wall -Wextra -Werror",
+          "project testers",
+          "valgrind or leak checks when relevant"
+        ],
+        "human_review_focus": [
+          "clarity of decomposition",
+          "reasoning under constraints",
+          "defense readiness",
+          "starred Norm items not enforced by norminette"
+        ]
+      },
+      {
+        "language": "python",
+        "positioning": "Equivalent rigor without pretending Python should mimic C syntax.",
+        "quality_contract": "Prefer short explicit functions, predictable IO, typed boundaries, no hidden magic, and tests for happy path plus edge cases.",
+        "automated_gates": [
+          "ruff check",
+          "ruff format",
+          "mypy",
+          "pytest"
+        ],
+        "human_review_focus": [
+          "data-flow readability",
+          "controlled abstraction",
+          "algorithmic explanations",
+          "no blind framework dependence"
+        ]
+      },
+      {
+        "language": "bash",
+        "positioning": "Terminal-first discipline aligned with Piscine pressure and automation habits.",
+        "quality_contract": "Scripts must be explicit, quote correctly, fail loudly, stay small, and remain readable under shell constraints.",
+        "automated_gates": [
+          "shellcheck",
+          "shfmt",
+          "bats or smoke scripts"
+        ],
+        "human_review_focus": [
+          "command composition",
+          "quoting and expansion safety",
+          "error-path handling",
+          "debuggability in a terminal session"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- merge main into develop on a dedicated branch to resolve the promotion conflicts
- preserve the official reference stack and subject reference fields introduced on main
- keep the richer develop curriculum and frontend shape intact

## Validation
- npm run lint
- npm run build

This PR is intended to unblock promotion PR #167.