### PR TITLE
feat: upgrade defense scoring to claude eval (#172)

### DIFF
--- a/services/ai_gateway/app/defense.py
+++ b/services/ai_gateway/app/defense.py
@@ -11,10 +11,16 @@ replace this once the database is available.
 
 from __future__ import annotations
 
+import logging
+import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
+
+from .llm_client import get_defense_evaluation
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -88,15 +94,8 @@ def create_session(
     return session
 
 
-def score_answer(question: DefenseQuestion, answer: str) -> tuple[float, str]:
-    """Score a learner's answer and produce pedagogical feedback.
-
-    Scoring is rule-based (MVP). A future version will use LLM evaluation.
-    The scorer never reveals the correct answer — it only assesses whether
-    the learner demonstrated understanding.
-
-    Returns (score, feedback) where score is 0.0 to 1.0.
-    """
+def _score_answer_rule_based(question: DefenseQuestion, answer: str) -> tuple[float, str]:
+    """Fallback defense scorer used when LLM evaluation is unavailable."""
     answer_lower = answer.lower().strip()
 
     if len(answer_lower) < 10:
@@ -139,6 +138,34 @@ def score_answer(question: DefenseQuestion, answer: str) -> tuple[float, str]:
         feedback = f"Your explanation of '{question.skill}' needs more depth. Think about what this concept does, why it exists, and how you would demonstrate it."
 
     return round(score, 2), feedback
+
+
+def score_answer(
+    question: DefenseQuestion,
+    answer: str,
+    *,
+    track_id: str = "shell",
+    module_id: str = "unknown-module",
+    phase: str = "foundation",
+) -> tuple[float, str]:
+    """Score a learner's answer with Claude, then fall back to rules."""
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return _score_answer_rule_based(question, answer)
+
+    try:
+        evaluation = get_defense_evaluation(
+            track_id=track_id,
+            module_id=module_id,
+            phase=phase,
+            question_text=question.text,
+            skill=question.skill,
+            expected_keywords=question.expected_keywords,
+            answer=answer,
+        )
+        return float(evaluation["score"]), str(evaluation["feedback"])
+    except Exception:
+        logger.warning("Defense LLM scoring failed, using rule-based fallback", exc_info=True)
+        return _score_answer_rule_based(question, answer)
 
 
 def compute_session_result(session: DefenseSession) -> dict[str, Any]:
@@ -232,7 +259,13 @@ def submit_answer(session: DefenseSession, question_id: str, answer: str) -> dic
         )
     else:
         current_question.answer = answer
-        score_val, feedback = score_answer(current_question, answer)
+        score_val, feedback = score_answer(
+            current_question,
+            answer,
+            track_id=session.track_id,
+            module_id=session.module_id,
+            phase=session.phase,
+        )
 
     current_question.score = score_val
     current_question.feedback = feedback

--- a/services/ai_gateway/app/llm_client.py
+++ b/services/ai_gateway/app/llm_client.py
@@ -50,6 +50,32 @@ Reponds UNIQUEMENT en JSON valide avec cette structure exacte:
 Pas de texte avant ou apres le JSON. Pas de markdown autour du JSON.
 """
 
+DEFENSE_SYSTEM_PROMPT = """\
+Tu es un examinateur de defense orale pour la preparation a 42 Lausanne.
+
+Ta mission:
+- evaluer la qualite d'une reponse de l'apprenant a une question de defense
+- attribuer un score entre 0.0 et 1.0
+- donner un feedback pedagogique court
+
+Regles absolues:
+- N'ecris JAMAIS la reponse correcte complete.
+- N'indique jamais "la bonne reponse est".
+- Explique ce qui est compris, ce qui manque, et comment approfondir.
+- Sois strict mais juste, dans l'esprit d'une evaluation 42.
+- Le score 1.0 signifie une comprehension solide, precise et bien expliquee.
+- Le score 0.0 signifie aucune comprehension exploitable.
+
+Format de reponse:
+Retourne UNIQUEMENT un JSON valide avec cette structure exacte:
+{
+  "score": 0.0,
+  "feedback": "..."
+}
+
+Pas de texte avant ou apres le JSON. Pas de markdown autour du JSON.
+"""
+
 
 def _build_user_message(request: MentorRequest, track_title: str, module_title: str | None, active_course: str) -> str:
     parts = [
@@ -104,6 +130,32 @@ def _parse_response_payload(raw_text: str) -> dict[str, str]:
     return normalized
 
 
+def _parse_defense_payload(raw_text: str) -> dict[str, Any]:
+    payload_text = raw_text.strip()
+    start = payload_text.find("{")
+    end = payload_text.rfind("}")
+    if start != -1 and end != -1 and start < end:
+        payload_text = payload_text[start : end + 1]
+
+    parsed = json.loads(payload_text)
+    if not isinstance(parsed, dict):
+        raise ValueError("Claude defense response must be a JSON object")
+
+    score = parsed.get("score")
+    feedback = parsed.get("feedback")
+    if not isinstance(score, (int, float)):
+        raise ValueError("Claude defense response missing valid 'score' field")
+    if not 0.0 <= float(score) <= 1.0:
+        raise ValueError("Claude defense response score must be between 0.0 and 1.0")
+    if not isinstance(feedback, str) or not feedback.strip():
+        raise ValueError("Claude defense response missing valid 'feedback' field")
+
+    return {
+        "score": round(float(score), 2),
+        "feedback": feedback.strip(),
+    }
+
+
 def _build_anthropic_client(api_key: str) -> Any:
     import anthropic
 
@@ -137,3 +189,47 @@ def get_mentor_response(
 
     raw = _extract_text_content(message)
     return _parse_response_payload(raw)
+
+
+def get_defense_evaluation(
+    *,
+    track_id: str,
+    module_id: str,
+    phase: str,
+    question_text: str,
+    skill: str,
+    expected_keywords: list[str],
+    answer: str,
+) -> dict[str, Any]:
+    """Call Claude API to evaluate a defense answer.
+
+    Raises on API errors or malformed JSON so the caller can fall back.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+
+    client = _build_anthropic_client(api_key)
+    user_message = "\n".join(
+        [
+            f"Track: {track_id}",
+            f"Module: {module_id}",
+            f"Phase: {phase}",
+            f"Skill cible: {skill}",
+            f"Mots-cles attendus: {', '.join(expected_keywords) if expected_keywords else 'aucun'}",
+            f"Question de defense: {question_text}",
+            f"Reponse de l'apprenant: {answer}",
+            "IMPORTANT: evalue la comprehension sans reveler la solution et retourne uniquement le JSON demande.",
+        ]
+    )
+
+    message = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=512,
+        temperature=0,
+        system=DEFENSE_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": [{"type": "text", "text": user_message}]}],
+    )
+
+    raw = _extract_text_content(message)
+    return _parse_defense_payload(raw)

--- a/services/ai_gateway/tests/test_defense.py
+++ b/services/ai_gateway/tests/test_defense.py
@@ -545,6 +545,56 @@ def test_score_rewards_explanation() -> None:
     assert score >= 0.5
 
 
+def test_score_answer_uses_llm_when_api_key_available() -> None:
+    q = DefenseQuestion(id="q-1", text="Explain ls", skill="ls", expected_keywords=["list", "files", "directory"])
+
+    with (
+        patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=False),
+        patch(
+            "app.defense.get_defense_evaluation",
+            return_value={"score": 0.91, "feedback": "Bonne maitrise, ajoute encore un exemple concret."},
+        ) as mock_evaluation,
+    ):
+        score, feedback = score_answer(
+            q,
+            "ls liste les fichiers d'un dossier et permet de verifier rapidement l'etat du repertoire courant.",
+            track_id="shell",
+            module_id="shell-basics",
+            phase="foundation",
+        )
+
+    assert score == 0.91
+    assert feedback == "Bonne maitrise, ajoute encore un exemple concret."
+    mock_evaluation.assert_called_once_with(
+        track_id="shell",
+        module_id="shell-basics",
+        phase="foundation",
+        question_text="Explain ls",
+        skill="ls",
+        expected_keywords=["list", "files", "directory"],
+        answer="ls liste les fichiers d'un dossier et permet de verifier rapidement l'etat du repertoire courant.",
+    )
+
+
+def test_score_answer_falls_back_to_rule_based_when_llm_fails() -> None:
+    q = DefenseQuestion(id="q-1", text="Explain ls", skill="ls", expected_keywords=["list", "files", "directory"])
+
+    with (
+        patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=False),
+        patch("app.defense.get_defense_evaluation", side_effect=RuntimeError("Claude unavailable")),
+    ):
+        score, feedback = score_answer(
+            q,
+            "The ls command is used to list files in a directory because it reads directory entries.",
+            track_id="shell",
+            module_id="shell-basics",
+            phase="foundation",
+        )
+
+    assert score >= 0.5
+    assert "understanding" in feedback.lower() or "explanation" in feedback.lower()
+
+
 def test_score_rewards_examples() -> None:
     q = DefenseQuestion(id="q-1", text="Explain ls", skill="ls", expected_keywords=["list", "files", "directory"])
     score_with, _ = score_answer(

--- a/services/ai_gateway/tests/test_llm_client.py
+++ b/services/ai_gateway/tests/test_llm_client.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.llm_client import get_mentor_response
+from app.llm_client import get_defense_evaluation, get_mentor_response
 from app.schemas import MentorRequest
 
 
@@ -93,3 +93,68 @@ def test_get_mentor_response_rejects_missing_required_field() -> None:
         pytest.raises(ValueError, match="next_action"),
     ):
         get_mentor_response(request, "Shell 0 to Hero", "Shell Basics", "shell")
+
+
+def test_get_defense_evaluation_calls_anthropic_sdk() -> None:
+    fake_message = _build_fake_message(
+        """
+        {
+          "score": 0.82,
+          "feedback": "Bonne comprehension globale. Il manque encore un exemple concret pour montrer la maitrise."
+        }
+        """
+    )
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = fake_message
+
+    with (
+        patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=False),
+        patch("app.llm_client._build_anthropic_client", return_value=fake_client) as mock_builder,
+    ):
+        response = get_defense_evaluation(
+            track_id="shell",
+            module_id="shell-basics",
+            phase="foundation",
+            question_text="Explain ls",
+            skill="ls",
+            expected_keywords=["list", "files", "directory"],
+            answer="ls liste les fichiers d'un dossier et me permet de verifier l'etat courant du filesystem.",
+        )
+
+    assert response == {
+        "score": 0.82,
+        "feedback": "Bonne comprehension globale. Il manque encore un exemple concret pour montrer la maitrise.",
+    }
+    mock_builder.assert_called_once_with("test-key")
+    fake_client.messages.create.assert_called_once()
+    kwargs = fake_client.messages.create.call_args.kwargs
+    assert kwargs["model"] == "claude-sonnet-4-20250514"
+    assert "examinateur de defense orale" in kwargs["system"]
+    assert "Question de defense: Explain ls" in kwargs["messages"][0]["content"][0]["text"]
+
+
+def test_get_defense_evaluation_rejects_out_of_range_score() -> None:
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _build_fake_message(
+        """
+        {
+          "score": 1.4,
+          "feedback": "Trop genereux."
+        }
+        """
+    )
+
+    with (
+        patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=False),
+        patch("app.llm_client._build_anthropic_client", return_value=fake_client),
+        pytest.raises(ValueError, match=r"between 0\.0 and 1\.0"),
+    ):
+        get_defense_evaluation(
+            track_id="shell",
+            module_id="shell-basics",
+            phase="foundation",
+            question_text="Explain ls",
+            skill="ls",
+            expected_keywords=["list", "files", "directory"],
+            answer="ls liste les fichiers.",
+        )


### PR DESCRIPTION
Closes #172.

## Summary
- add a Claude-based defense evaluation call returning structured score and feedback
- switch defense scoring to use the LLM when ANTHROPIC_API_KEY is present, with rule-based fallback on missing key or runtime failure
- extend llm client and defense tests to cover Claude evaluation and fallback behavior

## Validation
- python3 -m ruff check services/ai_gateway
- python3 -m ruff format --check services/ai_gateway
- mypy app
- pytest -q services/ai_gateway/tests