### PR TITLE
feat: standardize api error response contracts (#170)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
-from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -28,6 +30,7 @@ from .schemas import (
     DefenseSessionCreate,
     DefenseSessionRecord,
     DefenseSessionUpdate,
+    ErrorResponse,
     HealthResponse,
     MetaResponse,
     ModuleCompleteRequest,
@@ -46,6 +49,18 @@ from .schemas import (
 )
 from .validation import find_module, validate_module_activation
 
+logger = logging.getLogger(__name__)
+
+ERROR_CODES_BY_STATUS = {
+    status.HTTP_400_BAD_REQUEST: "bad_request",
+    status.HTTP_401_UNAUTHORIZED: "unauthorized",
+    status.HTTP_403_FORBIDDEN: "forbidden",
+    status.HTTP_404_NOT_FOUND: "not_found",
+    status.HTTP_409_CONFLICT: "conflict",
+    status.HTTP_422_UNPROCESSABLE_ENTITY: "validation_error",
+    status.HTTP_500_INTERNAL_SERVER_ERROR: "internal_server_error",
+}
+
 app = FastAPI(title="42-training API", version="0.1.0")
 
 app.add_middleware(
@@ -58,6 +73,101 @@ app.add_middleware(
 
 app.include_router(auth_router)
 app.include_router(profiles_router)
+
+
+def _default_error_code(status_code: int) -> str:
+    return ERROR_CODES_BY_STATUS.get(status_code, "request_error")
+
+
+def _join_messages(messages: list[str], fallback: str) -> str:
+    filtered = [message for message in messages if message]
+    return "; ".join(filtered) if filtered else fallback
+
+
+def _normalize_http_error(detail: Any, status_code: int) -> tuple[str, str]:
+    default_code = _default_error_code(status_code)
+
+    if isinstance(detail, str) and detail:
+        return detail, default_code
+
+    if isinstance(detail, dict):
+        explicit_code = detail.get("code")
+        normalized_code = explicit_code if isinstance(explicit_code, str) and explicit_code else default_code
+
+        missing_prerequisites = detail.get("missing_prerequisites")
+        if isinstance(missing_prerequisites, list):
+            missing = [str(item) for item in missing_prerequisites if str(item)]
+            message = detail.get("message")
+            if isinstance(message, str) and message:
+                return message, "prerequisites"
+            fallback = f"Prerequisites not met: {', '.join(missing)}" if missing else "Prerequisites not met"
+            return fallback, "prerequisites"
+
+        validation_errors = detail.get("validation_errors")
+        if isinstance(validation_errors, list):
+            messages: list[str] = []
+            error_types: list[str] = []
+            for item in validation_errors:
+                if not isinstance(item, dict):
+                    continue
+                if isinstance(item.get("type"), str) and item["type"]:
+                    error_types.append(item["type"])
+                if isinstance(item.get("message"), str) and item["message"]:
+                    messages.append(item["message"])
+            unique_types = list(dict.fromkeys(error_types))
+            code = unique_types[0] if len(unique_types) == 1 else normalized_code
+            return _join_messages(messages, "Validation failed"), code
+
+        message = detail.get("message")
+        if isinstance(message, str) and message:
+            return message, normalized_code
+
+        nested_detail = detail.get("detail")
+        if isinstance(nested_detail, str) and nested_detail:
+            return nested_detail, normalized_code
+
+    return "Request failed", default_code
+
+
+def _normalize_validation_error(exc: RequestValidationError) -> tuple[str, str]:
+    messages: list[str] = []
+    for error in exc.errors():
+        message = error.get("msg")
+        if not isinstance(message, str) or not message:
+            continue
+        location = [str(part) for part in error.get("loc", []) if part != "body"]
+        if location:
+            messages.append(f"{'.'.join(location)}: {message}")
+        else:
+            messages.append(message)
+    return _join_messages(messages, "Validation failed"), _default_error_code(status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+
+def _error_response(status_code: int, detail: str, code: str) -> JSONResponse:
+    payload = ErrorResponse(detail=detail, code=code, status=status_code)
+    return JSONResponse(status_code=status_code, content=payload.model_dump())
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(_request: Request, exc: HTTPException) -> JSONResponse:
+    detail, code = _normalize_http_error(exc.detail, exc.status_code)
+    return _error_response(exc.status_code, detail, code)
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(_request: Request, exc: RequestValidationError) -> JSONResponse:
+    detail, code = _normalize_validation_error(exc)
+    return _error_response(status.HTTP_422_UNPROCESSABLE_ENTITY, detail, code)
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(_request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled API exception")
+    return _error_response(
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "Internal server error",
+        _default_error_code(status.HTTP_500_INTERNAL_SERVER_ERROR),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -21,6 +21,12 @@ class HealthResponse(BaseModel):
     service: str
 
 
+class ErrorResponse(BaseModel):
+    detail: str
+    code: str
+    status: int
+
+
 class MetaResponse(BaseModel):
     app: str
     campus: str

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -271,7 +271,11 @@ class TestCurriculumTrackDetail:
         with p_cur, p_load, p_write:
             r = client.get("/api/v1/curriculum/tracks/nonexistent")
         assert r.status_code == 404
-        assert "not found" in r.json()["detail"].lower()
+        data = r.json()
+        assert set(data.keys()) == {"detail", "code", "status"}
+        assert data["code"] == "not_found"
+        assert data["status"] == 404
+        assert "not found" in data["detail"].lower()
 
     def test_track_detail_includes_modules(self) -> None:
         p_cur, p_load, p_write, _p, _w = _patch_repo()
@@ -566,3 +570,24 @@ class TestLegacyRedirects:
             r = client.get("/api/v1/tracks/shell", follow_redirects=True)
         assert r.status_code == 200
         assert r.json()["id"] == "shell"
+
+
+class TestErrorContracts:
+    def test_request_validation_errors_use_uniform_contract(self) -> None:
+        response = client.post(
+            "/api/v1/checkpoints/submit",
+            json={
+                "module_id": "shell-basics",
+                "checkpoint_index": 0,
+                "type": "exit_criteria",
+                "evidence": "",
+                "self_evaluation": "pass",
+            },
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert set(data.keys()) == {"detail", "code", "status"}
+        assert data["code"] == "validation_error"
+        assert data["status"] == 422
+        assert "String should have at least 1 character" in data["detail"]

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -126,7 +126,11 @@ def test_register_rejects_duplicate_email(auth_client: tuple[TestClient, async_s
 
     assert first.status_code == 201
     assert duplicate.status_code == 409
-    assert duplicate.json()["detail"] == "Email already registered"
+    assert duplicate.json() == {
+        "detail": "Email already registered",
+        "code": "conflict",
+        "status": 409,
+    }
 
 
 def test_login_returns_jwt_and_updates_last_login(
@@ -153,7 +157,11 @@ def test_login_rejects_invalid_password(auth_client: tuple[TestClient, async_ses
     response = client.post("/api/v1/auth/login", json={"email": "student@example.com", "password": "wrongpass"})
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "Invalid email or password"
+    assert response.json() == {
+        "detail": "Invalid email or password",
+        "code": "unauthorized",
+        "status": 401,
+    }
 
 
 def test_me_returns_current_user_from_bearer_token(
@@ -186,7 +194,11 @@ def test_me_requires_bearer_token(auth_client: tuple[TestClient, async_sessionma
     response = client.get("/api/v1/auth/me")
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "Invalid authentication credentials"
+    assert response.json() == {
+        "detail": "Invalid authentication credentials",
+        "code": "unauthorized",
+        "status": 401,
+    }
 
 
 def test_alembic_upgrade_head_creates_user_accounts_table(tmp_path: Path) -> None:

--- a/services/api/tests/test_module_progression.py
+++ b/services/api/tests/test_module_progression.py
@@ -110,8 +110,10 @@ class TestModuleStart:
         with p_cur, p_load, p_write:
             r = client.post("/api/v1/modules/shell-streams/start")
         assert r.status_code == 409
-        detail = r.json()["detail"]
-        assert "shell-basics" in detail["missing_prerequisites"]
+        data = r.json()
+        assert data["code"] == "prerequisites"
+        assert data["status"] == 409
+        assert "shell-basics" in data["detail"]
 
     def test_start_after_prerequisite_completed(self) -> None:
         prog = _make_progression(

--- a/services/api/tests/test_validation.py
+++ b/services/api/tests/test_validation.py
@@ -388,9 +388,10 @@ class TestProgressionValidation:
         with p_cur, p_load, p_write:
             r = client.post("/api/v1/progression", json={"active_module": "shell-streams"})
         assert r.status_code == 422
-        detail = r.json()["detail"]
-        assert "validation_errors" in detail
-        assert any(e["type"] == "prerequisites" for e in detail["validation_errors"])
+        data = r.json()
+        assert data["code"] == "prerequisites"
+        assert data["status"] == 422
+        assert "Missing prerequisites" in data["detail"]
         assert len(written) == 0  # no write on validation failure
 
     def test_set_active_module_wrong_track(self) -> None:
@@ -398,16 +399,20 @@ class TestProgressionValidation:
         with p_cur, p_load, p_write:
             r = client.post("/api/v1/progression", json={"active_module": "c-basics"})
         assert r.status_code == 422
-        detail = r.json()["detail"]
-        assert any(e["type"] == "track_enrollment" for e in detail["validation_errors"])
+        data = r.json()
+        assert data["code"] == "track_enrollment"
+        assert data["status"] == 422
+        assert "belongs to track 'c'" in data["detail"]
 
     def test_set_active_module_phase_fail(self) -> None:
         p_cur, p_load, p_write, _p, _written = _patch_repo(_prog("shell"))
         with p_cur, p_load, p_write:
             r = client.post("/api/v1/progression", json={"active_module": "shell-tooling"})
         assert r.status_code == 422
-        detail = r.json()["detail"]
-        assert any(e["type"] == "phase_ordering" for e in detail["validation_errors"])
+        data = r.json()
+        assert data["code"] == "validation_error"
+        assert data["status"] == 422
+        assert "Earlier-phase modules not completed" in data["detail"]
 
     def test_set_active_module_after_completing_prereqs(self) -> None:
         completed = ["shell-basics", "shell-streams", "shell-permissions"]


### PR DESCRIPTION
Closes #170.

## Summary
- add a global API error contract returning {detail, code, status}
- standardize FastAPI HTTPException and request validation errors through handlers in app.main
- update backend tests to cover uniform 401, 404, 409 and 422 error responses

## Testing
- pytest -q services/api/tests/test_api.py services/api/tests/test_auth.py services/api/tests/test_validation.py services/api/tests/test_module_progression.py
- pytest -q services/api/tests
- cd services/api && python3 -m ruff check app tests
- cd services/api && python3 -m ruff format --check app tests