### PR TITLE
feat: wire real auth flow to frontend pages (#169)

### DIFF
--- a/apps/web/app/components/AuthGuard.tsx
+++ b/apps/web/app/components/AuthGuard.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+import { useAuth } from "@/app/components/AuthProvider";
+
+const PUBLIC_PATHS = new Set(["/login"]);
+
+function normalizeNextPath(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/";
+  }
+
+  return value;
+}
+
+export function AuthGuard({ children, header }: { children: ReactNode; header: ReactNode }) {
+  const { status } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentPath = pathname ?? "/";
+  const isPublicPath = PUBLIC_PATHS.has(currentPath);
+
+  useEffect(() => {
+    if (status === "unauthenticated" && !isPublicPath) {
+      const currentSearch = typeof window === "undefined" ? "" : window.location.search;
+      const nextTarget = `${currentPath}${currentSearch}`;
+      router.replace(`/login?next=${encodeURIComponent(nextTarget)}`);
+    }
+  }, [currentPath, isPublicPath, router, status]);
+
+  useEffect(() => {
+    if (status === "authenticated" && currentPath === "/login") {
+      const nextTarget =
+        typeof window === "undefined" ? null : new URLSearchParams(window.location.search).get("next");
+      router.replace(normalizeNextPath(nextTarget));
+    }
+  }, [currentPath, router, status]);
+
+  if (isPublicPath) {
+    return children;
+  }
+
+  if (status === "authenticated") {
+    return (
+      <>
+        {header}
+        {children}
+      </>
+    );
+  }
+
+  return (
+    <main className="page-shell auth-gate-page">
+      <section className="panel auth-gate-panel" aria-live="polite">
+        <p className="eyebrow">Authentication</p>
+        <h1>{status === "loading" ? "Checking your session..." : "Redirecting to login..."}</h1>
+        <p className="lead">
+          {status === "loading"
+            ? "The frontend is validating the stored JWT with /auth/me before opening the workspace."
+            : "This page requires an authenticated learner account."}
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/components/AuthProvider.tsx
+++ b/apps/web/app/components/AuthProvider.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+import {
+  clearStoredAuth,
+  fetchCurrentSession,
+  getStoredAccessToken,
+  getStoredAuthSession,
+  loginWithPassword,
+  registerWithPassword,
+  type AuthCredentials,
+  type AuthSession,
+} from "@/services/auth";
+
+type AuthStatus = "loading" | "authenticated" | "unauthenticated";
+
+type AuthContextValue = {
+  status: AuthStatus;
+  session: AuthSession | null;
+  login: (payload: AuthCredentials) => Promise<AuthSession>;
+  register: (payload: AuthCredentials) => Promise<AuthSession>;
+  logout: () => void;
+  refreshSession: () => Promise<AuthSession>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<AuthStatus>("loading");
+  const [session, setSession] = useState<AuthSession | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function bootstrap() {
+      const storedToken = getStoredAccessToken();
+      const storedSession = getStoredAuthSession();
+
+      if (!storedToken) {
+        if (!cancelled) {
+          setSession(storedSession);
+          setStatus("unauthenticated");
+        }
+        return;
+      }
+
+      if (storedSession && !cancelled) {
+        setSession(storedSession);
+      }
+
+      try {
+        const nextSession = await fetchCurrentSession(storedToken);
+        if (!cancelled) {
+          setSession(nextSession);
+          setStatus("authenticated");
+        }
+      } catch {
+        clearStoredAuth();
+        if (!cancelled) {
+          setSession(null);
+          setStatus("unauthenticated");
+        }
+      }
+    }
+
+    void bootstrap();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function login(payload: AuthCredentials) {
+    const nextSession = await loginWithPassword(payload);
+    setSession(nextSession);
+    setStatus("authenticated");
+    return nextSession;
+  }
+
+  async function register(payload: AuthCredentials) {
+    const nextSession = await registerWithPassword(payload);
+    setSession(nextSession);
+    setStatus("authenticated");
+    return nextSession;
+  }
+
+  async function refreshSession() {
+    const nextSession = await fetchCurrentSession();
+    setSession(nextSession);
+    setStatus("authenticated");
+    return nextSession;
+  }
+
+  function logout() {
+    clearStoredAuth();
+    setSession(null);
+    setStatus("unauthenticated");
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        status,
+        session,
+        login,
+        register,
+        logout,
+        refreshSession,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === null) {
+    throw new Error("useAuth must be used inside AuthProvider");
+  }
+
+  return context;
+}

--- a/apps/web/app/components/AuthStatus.tsx
+++ b/apps/web/app/components/AuthStatus.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { useAuth } from "@/app/components/AuthProvider";
+
+export function AuthStatus() {
+  const router = useRouter();
+  const { logout, session, status } = useAuth();
+
+  if (status === "loading") {
+    return <span className="nav-auth-loading">Checking session...</span>;
+  }
+
+  if (status !== "authenticated" || session === null) {
+    return null;
+  }
+
+  function handleLogout() {
+    logout();
+    router.replace("/login");
+    router.refresh();
+  }
+
+  return (
+    <div className="nav-auth">
+      <div className="nav-auth-copy">
+        <strong>{session.user.email}</strong>
+        <span>{session.learnerProfile ? `${session.learnerProfile.track} profile` : "No active profile"}</span>
+      </div>
+      <button type="button" className="nav-auth-btn" onClick={handleLogout}>
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/components/NavHeader.tsx
+++ b/apps/web/app/components/NavHeader.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { AuthStatus } from "@/app/components/AuthStatus";
 import { getDashboardData } from "@/lib/api";
 
 const NAV_LINKS = [
@@ -10,7 +11,6 @@ const NAV_LINKS = [
   { href: "/evidence", label: "Evidence" },
   { href: "/profiles", label: "Profiles" },
   { href: "/analytics", label: "Analytics" },
-  { href: "/login", label: "Login" },
 ] as const;
 
 export async function NavHeader() {
@@ -38,6 +38,7 @@ export async function NavHeader() {
             {track.title}
           </Link>
         ))}
+        <AuthStatus />
       </nav>
     </header>
   );

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -321,6 +321,49 @@ a {
   -webkit-overflow-scrolling: touch;
 }
 
+.nav-auth {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+  padding-left: 8px;
+}
+
+.nav-auth-copy {
+  display: grid;
+  gap: 2px;
+  text-align: right;
+  min-width: max-content;
+}
+
+.nav-auth-copy strong,
+.nav-auth-copy span,
+.nav-auth-loading {
+  font-size: 12px;
+}
+
+.nav-auth-copy span,
+.nav-auth-loading {
+  color: var(--muted);
+}
+
+.nav-auth-btn {
+  min-height: 34px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--ink);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.nav-auth-btn:hover {
+  background: rgba(28, 26, 23, 0.05);
+}
+
 .nav-link {
   padding: 8px 14px;
   border-radius: 10px;
@@ -858,6 +901,15 @@ a {
 /*  Login page                                                         */
 /* ------------------------------------------------------------------ */
 
+.auth-gate-page {
+  min-height: calc(100vh - 96px);
+  place-items: center;
+}
+
+.auth-gate-panel {
+  max-width: 680px;
+}
+
 .login-page {
   max-width: 1100px;
 }
@@ -894,6 +946,33 @@ a {
 .login-card-header {
   display: grid;
   gap: 4px;
+}
+
+.login-mode-toggle {
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 6px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.login-mode-btn {
+  min-height: 40px;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.login-mode-btn--active {
+  background: rgba(28, 93, 99, 0.12);
+  color: var(--shell);
 }
 
 .login-form {
@@ -1160,6 +1239,10 @@ a {
     overflow-x: visible;
   }
 
+  .nav-auth {
+    padding-left: 16px;
+  }
+
   .prog-next-content {
     flex-direction: row;
     align-items: center;
@@ -1249,6 +1332,11 @@ a {
 
   .nav-header {
     padding: 14px 32px;
+  }
+
+  .nav-auth-copy strong,
+  .nav-auth-copy span {
+    font-size: 13px;
   }
 
   .prog-stats-grid {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,8 @@ import "./globals.css";
 
 import type { Viewport } from "next";
 
+import { AuthGuard } from "@/app/components/AuthGuard";
+import { AuthProvider } from "@/app/components/AuthProvider";
 import { NavHeader } from "@/app/components/NavHeader";
 
 export const viewport: Viewport = {
@@ -19,8 +21,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <NavHeader />
-        <div className="app-content">{children}</div>
+        <AuthProvider>
+          <AuthGuard header={<NavHeader />}>
+            <div className="app-content">{children}</div>
+          </AuthGuard>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-import { loginWithPassword } from "@/services/auth";
+import { useAuth } from "@/app/components/AuthProvider";
+import { isAuthApiError } from "@/services/auth";
 
 type FormState = {
   email: string;
@@ -16,6 +18,14 @@ const INITIAL_STATE: FormState = {
   email: "",
   password: "",
 };
+
+function normalizeNextPath(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/";
+  }
+
+  return value;
+}
 
 function validateLoginForm(values: FormState): FormErrors {
   const errors: FormErrors = {};
@@ -36,7 +46,10 @@ function validateLoginForm(values: FormState): FormErrors {
 }
 
 export default function LoginPage() {
+  const { login, register } = useAuth();
+  const router = useRouter();
   const [form, setForm] = useState<FormState>(INITIAL_STATE);
+  const [mode, setMode] = useState<"login" | "register">("login");
   const [errors, setErrors] = useState<FormErrors>({});
   const [serverMessage, setServerMessage] = useState<string | null>(null);
   const [submitState, setSubmitState] = useState<"idle" | "success" | "error">("idle");
@@ -64,11 +77,23 @@ export default function LoginPage() {
     setIsSubmitting(true);
 
     try {
-      const result = await loginWithPassword(form);
-      setServerMessage(result.message);
-      setSubmitState(result.ok ? "success" : "error");
-    } catch {
-      setServerMessage("The mocked login flow failed unexpectedly.");
+      const session = mode === "login" ? await login(form) : await register(form);
+      const nextTarget =
+        typeof window === "undefined" ? "/" : normalizeNextPath(new URLSearchParams(window.location.search).get("next"));
+      setServerMessage(
+        mode === "login"
+          ? `Signed in as ${session.user.email}.`
+          : `Account created for ${session.user.email}. Redirecting to your workspace...`,
+      );
+      setSubmitState("success");
+      router.replace(nextTarget);
+      router.refresh();
+    } catch (error) {
+      setServerMessage(
+        isAuthApiError(error)
+          ? error.message
+          : `The ${mode === "login" ? "login" : "registration"} flow failed unexpectedly.`,
+      );
       setSubmitState("error");
     } finally {
       setIsSubmitting(false);
@@ -82,34 +107,52 @@ export default function LoginPage() {
           <p className="eyebrow">Authentication</p>
           <h1>Sign in with your learner account.</h1>
           <p className="lead">
-            The backend authentication flow is still in progress. This page validates client-side inputs
-            and uses a mocked password login so the web flow can be integrated now.
+            The web app now calls the real authentication endpoints, stores the JWT locally and reuses it to
+            protect the learning workspace.
           </p>
           <div className="login-highlights">
             <div className="login-highlight">
-              <strong>Email + password</strong>
-              <span className="muted">No API key exposed in the browser.</span>
+              <strong>Real API flow</strong>
+              <span className="muted">Uses `/auth/login`, `/auth/register` and `/auth/me`.</span>
             </div>
             <div className="login-highlight">
               <strong>Client validation</strong>
               <span className="muted">Checks email format and a minimal password length.</span>
             </div>
             <div className="login-highlight">
-              <strong>Mocked backend call</strong>
-              <span className="muted">Ready to swap with the real API when auth endpoints exist.</span>
+              <strong>Protected pages</strong>
+              <span className="muted">Unauthenticated access is redirected back to this screen.</span>
             </div>
           </div>
           <p className="muted">
-            Demo note: use any valid email and a password of at least 8 characters. The address
-            <span className="prog-code"> blocked@42lausanne.ch </span>
-            returns a mocked failure state.
+            Use an existing account to sign in, or switch to create mode to register a new learner account from
+            the same screen.
           </p>
         </article>
 
         <section className="login-card panel" aria-labelledby="login-form-title">
           <div className="login-card-header">
-            <p className="eyebrow">Web Login</p>
-            <h2 id="login-form-title">Access 42-training</h2>
+            <p className="eyebrow">Web Auth</p>
+            <h2 id="login-form-title">{mode === "login" ? "Access 42-training" : "Create your account"}</h2>
+          </div>
+
+          <div className="login-mode-toggle" aria-label="Authentication mode">
+            <button
+              type="button"
+              className={`login-mode-btn ${mode === "login" ? "login-mode-btn--active" : ""}`}
+              onClick={() => setMode("login")}
+              aria-pressed={mode === "login"}
+            >
+              Sign in
+            </button>
+            <button
+              type="button"
+              className={`login-mode-btn ${mode === "register" ? "login-mode-btn--active" : ""}`}
+              onClick={() => setMode("register")}
+              aria-pressed={mode === "register"}
+            >
+              Create account
+            </button>
           </div>
 
           <form className="login-form" noValidate onSubmit={handleSubmit}>
@@ -137,7 +180,7 @@ export default function LoginPage() {
               <input
                 type="password"
                 name="password"
-                autoComplete="current-password"
+                autoComplete={mode === "login" ? "current-password" : "new-password"}
                 placeholder="Minimum 8 characters"
                 value={form.password}
                 onChange={(event) => updateField("password", event.target.value)}
@@ -153,7 +196,13 @@ export default function LoginPage() {
 
             <div className="login-actions">
               <button type="submit" className="action-btn login-submit" disabled={isSubmitting}>
-                {isSubmitting ? "Signing in..." : "Sign in"}
+                {isSubmitting
+                  ? mode === "login"
+                    ? "Signing in..."
+                    : "Creating account..."
+                  : mode === "login"
+                    ? "Sign in"
+                    : "Create account"}
               </button>
               <Link href="/" className="login-secondary-link">
                 Back to dashboard

--- a/apps/web/app/profiles/page.tsx
+++ b/apps/web/app/profiles/page.tsx
@@ -3,8 +3,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { useAuth } from "@/app/components/AuthProvider";
 import { getDashboardData, type TrackItem } from "@/lib/api";
-import { getMockSessionEmail } from "@/services/auth";
 import {
   createProfile,
   listProfiles,
@@ -52,10 +52,10 @@ function formatDateLabel(value: string) {
 }
 
 export default function ProfilesPage() {
+  const { session } = useAuth();
   const [tracks, setTracks] = useState<TrackItem[]>([]);
   const [profilesState, setProfilesState] = useState<ProfilesState | null>(null);
   const [form, setForm] = useState<ProfileFormState>(INITIAL_FORM);
-  const [sessionEmail, setSessionEmail] = useState("demo@42lausanne.ch");
   const [errors, setErrors] = useState<FormErrors>({});
   const [loadingState, setLoadingState] = useState<"loading" | "ready" | "error">("loading");
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -73,7 +73,6 @@ export default function ProfilesPage() {
           return;
         }
 
-        setSessionEmail(getMockSessionEmail() ?? "demo@42lausanne.ch");
         setTracks(dashboard.curriculum.tracks);
         setProfilesState(profiles);
         setForm((current) => ({
@@ -95,6 +94,7 @@ export default function ProfilesPage() {
     };
   }, []);
   const activeProfile = profilesState?.activeProfile ?? null;
+  const sessionEmail = session?.user.email ?? "Authenticated learner";
 
   function updateField(field: keyof ProfileFormState, value: string) {
     setForm((current) => ({ ...current, [field]: value }));
@@ -203,7 +203,7 @@ export default function ProfilesPage() {
           </div>
           <div className="metric-card">
             <span>Data source</span>
-            <strong>{profilesState.mocked ? "Mocked web state" : "API live state"}</strong>
+            <strong>{profilesState.mocked ? "Profiles fallback" : "API live state"}</strong>
           </div>
         </div>
       </section>
@@ -313,8 +313,8 @@ export default function ProfilesPage() {
           <div className="profiles-note">
             <strong>Current integration state</strong>
             <p className="muted">
-              The page calls the real `/api/v1/profiles` endpoints when a bearer token is available. Otherwise it keeps
-              the same UX using mocked browser state so frontend work can progress independently.
+              This page uses the JWT created at login time and calls the real `/api/v1/profiles` endpoints. A browser
+              fallback remains available only when the profile API is temporarily unreachable.
             </p>
           </div>
         </aside>

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { ACCESS_TOKEN_COOKIE_KEY } from "@/services/auth";
+
+function normalizeNextPath(pathname: string, search: string) {
+  return `${pathname}${search}`;
+}
+
+function isSafeRelativePath(value: string | null): value is string {
+  return Boolean(value && value.startsWith("/") && !value.startsWith("//"));
+}
+
+export function proxy(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+  const token = request.cookies.get(ACCESS_TOKEN_COOKIE_KEY)?.value;
+
+  if (pathname === "/login") {
+    if (!token) {
+      return NextResponse.next();
+    }
+
+    const requestedTarget = request.nextUrl.searchParams.get("next");
+    const safeTarget = isSafeRelativePath(requestedTarget) ? requestedTarget : "/";
+    return NextResponse.redirect(new URL(safeTarget, request.url));
+  }
+
+  if (token) {
+    return NextResponse.next();
+  }
+
+  const loginUrl = request.nextUrl.clone();
+  loginUrl.pathname = "/login";
+  loginUrl.search = "";
+  loginUrl.searchParams.set("next", normalizeNextPath(pathname, search));
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/apps/web/services/auth.ts
+++ b/apps/web/services/auth.ts
@@ -1,32 +1,152 @@
-export type LoginPayload = {
+export type AuthCredentials = {
   email: string;
   password: string;
 };
 
-export type LoginResult = {
-  ok: boolean;
-  message: string;
-  mocked: true;
+export type AuthUser = {
+  id: string;
+  email: string;
+  status: string;
 };
 
-const MOCK_LATENCY_MS = 700;
-export const MOCK_SESSION_EMAIL_KEY = "training-mock-user-email";
-export const ACCESS_TOKEN_STORAGE_KEY = "training-access-token";
+export type AuthProfile = {
+  id: string;
+  login: string;
+  track: string;
+  current_module: string | null;
+};
 
-function persistMockSessionEmail(email: string) {
+type AuthTokenResponse = {
+  access_token: string;
+  token_type: "bearer";
+  expires_in: number;
+  user: AuthUser;
+  learner_profile: AuthProfile | null;
+  profiles: AuthProfile[];
+};
+
+type AuthMeResponse = {
+  user: AuthUser;
+  learner_profile: AuthProfile | null;
+  profiles: AuthProfile[];
+};
+
+export type AuthSession = {
+  accessToken: string;
+  tokenType: "bearer";
+  expiresIn: number | null;
+  user: AuthUser;
+  learnerProfile: AuthProfile | null;
+  profiles: AuthProfile[];
+};
+
+export const ACCESS_TOKEN_STORAGE_KEY = "training-access-token";
+export const AUTH_SESSION_STORAGE_KEY = "training-auth-session";
+export const ACCESS_TOKEN_COOKIE_KEY = "training-access-token";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export class AuthApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "AuthApiError";
+    this.status = status;
+  }
+}
+
+function normalizeCredentials(payload: AuthCredentials): AuthCredentials {
+  return {
+    email: payload.email.trim().toLowerCase(),
+    password: payload.password,
+  };
+}
+
+function buildSessionFromTokenResponse(data: AuthTokenResponse): AuthSession {
+  return {
+    accessToken: data.access_token,
+    tokenType: data.token_type,
+    expiresIn: data.expires_in,
+    user: data.user,
+    learnerProfile: data.learner_profile ?? null,
+    profiles: data.profiles,
+  };
+}
+
+function serializeSession(session: AuthSession) {
   if (typeof window === "undefined") {
     return;
   }
 
-  window.localStorage.setItem(MOCK_SESSION_EMAIL_KEY, email);
+  window.localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, session.accessToken);
+  window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify(session));
 }
 
-export function getMockSessionEmail(): string | null {
-  if (typeof window === "undefined") {
-    return null;
+function setTokenCookie(token: string, maxAgeSeconds: number | null) {
+  if (typeof document === "undefined") {
+    return;
   }
 
-  return window.localStorage.getItem(MOCK_SESSION_EMAIL_KEY);
+  const cookieParts = [
+    `${ACCESS_TOKEN_COOKIE_KEY}=${encodeURIComponent(token)}`,
+    "Path=/",
+    "SameSite=Lax",
+  ];
+
+  if (typeof maxAgeSeconds === "number") {
+    cookieParts.push(`Max-Age=${Math.max(0, Math.floor(maxAgeSeconds))}`);
+  }
+
+  document.cookie = cookieParts.join("; ");
+}
+
+function clearTokenCookie() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.cookie = `${ACCESS_TOKEN_COOKIE_KEY}=; Path=/; Max-Age=0; SameSite=Lax`;
+}
+
+function persistSession(session: AuthSession): AuthSession {
+  serializeSession(session);
+  setTokenCookie(session.accessToken, session.expiresIn);
+  return session;
+}
+
+function extractErrorMessage(payload: unknown, fallback: string) {
+  if (payload && typeof payload === "object" && "detail" in payload && typeof payload.detail === "string") {
+    return payload.detail;
+  }
+
+  return fallback;
+}
+
+async function authRequest<T>(path: string, init?: RequestInit, token?: string): Promise<T> {
+  const headers = new Headers(init?.headers);
+  if (init?.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const response = await fetch(`${API_URL}${path}`, {
+    ...init,
+    headers,
+    cache: "no-store",
+  });
+
+  const payload = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) {
+    throw new AuthApiError(
+      extractErrorMessage(payload, `Authentication failed with status ${response.status}.`),
+      response.status,
+    );
+  }
+
+  return payload as T;
 }
 
 export function getStoredAccessToken(): string | null {
@@ -37,24 +157,71 @@ export function getStoredAccessToken(): string | null {
   return window.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
 }
 
-export async function loginWithPassword(payload: LoginPayload): Promise<LoginResult> {
-  await new Promise((resolve) => setTimeout(resolve, MOCK_LATENCY_MS));
-
-  const email = payload.email.trim().toLowerCase();
-
-  if (email === "blocked@42lausanne.ch") {
-    return {
-      ok: false,
-      message: "This demo account is blocked in the mocked auth service.",
-      mocked: true,
-    };
+export function getStoredAuthSession(): AuthSession | null {
+  if (typeof window === "undefined") {
+    return null;
   }
 
-  persistMockSessionEmail(email);
+  const raw = window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
 
-  return {
-    ok: true,
-    message: `Signed in as ${email}. Backend auth is not wired yet, so this is a mocked response.`,
-    mocked: true,
-  };
+  try {
+    return JSON.parse(raw) as AuthSession;
+  } catch {
+    return null;
+  }
+}
+
+export function getStoredSessionEmail(): string | null {
+  return getStoredAuthSession()?.user.email ?? null;
+}
+
+export function clearStoredAuth() {
+  if (typeof window !== "undefined") {
+    window.localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+    window.localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
+  }
+
+  clearTokenCookie();
+}
+
+export async function loginWithPassword(payload: AuthCredentials): Promise<AuthSession> {
+  const response = await authRequest<AuthTokenResponse>("/api/v1/auth/login", {
+    method: "POST",
+    body: JSON.stringify(normalizeCredentials(payload)),
+  });
+
+  return persistSession(buildSessionFromTokenResponse(response));
+}
+
+export async function registerWithPassword(payload: AuthCredentials): Promise<AuthSession> {
+  const response = await authRequest<AuthTokenResponse>("/api/v1/auth/register", {
+    method: "POST",
+    body: JSON.stringify(normalizeCredentials(payload)),
+  });
+
+  return persistSession(buildSessionFromTokenResponse(response));
+}
+
+export async function fetchCurrentSession(accessToken = getStoredAccessToken()): Promise<AuthSession> {
+  if (!accessToken) {
+    throw new AuthApiError("No bearer token available.", 401);
+  }
+
+  const current = getStoredAuthSession();
+  const response = await authRequest<AuthMeResponse>("/api/v1/auth/me", { method: "GET" }, accessToken);
+  return persistSession({
+    accessToken,
+    tokenType: "bearer",
+    expiresIn: current?.expiresIn ?? null,
+    user: response.user,
+    learnerProfile: response.learner_profile ?? null,
+    profiles: response.profiles,
+  });
+}
+
+export function isAuthApiError(error: unknown): error is AuthApiError {
+  return error instanceof AuthApiError;
 }

--- a/apps/web/services/profiles.ts
+++ b/apps/web/services/profiles.ts
@@ -1,4 +1,4 @@
-import { getMockSessionEmail, getStoredAccessToken } from "@/services/auth";
+import { getStoredAccessToken, getStoredSessionEmail } from "@/services/auth";
 
 export type ProfileItem = {
   id: string;
@@ -82,7 +82,7 @@ function mapApiProfilesState(data: ApiProfilesResponse, mocked: boolean): Profil
 }
 
 function getSessionEmail() {
-  return getMockSessionEmail() ?? FALLBACK_SESSION_EMAIL;
+  return getStoredSessionEmail() ?? FALLBACK_SESSION_EMAIL;
 }
 
 function seedMockProfiles(email: string): ProfilesState {


### PR DESCRIPTION
Closes #169. Replaces the mocked login with real /auth/login, /auth/register and /auth/me calls, stores the JWT in localStorage, adds a proxy-based auth guard for protected routes, and updates nav/profiles to read the real authenticated session. Validation: npm run lint, npm run typecheck, env -u NODE_ENV npm run build.