### PR TITLE
feat: add retry and recovery for interrupted defense evaluations (#175)

### DIFF
--- a/services/ai_gateway/app/defense.py
+++ b/services/ai_gateway/app/defense.py
@@ -416,6 +416,22 @@ def _keywords_for_skill(skill: str, track_id: str) -> list[str]:
     return base + skill_keywords.get(skill.lower(), [])
 
 
+def resume_session(session: DefenseSession) -> DefenseSession:
+    """Resume an interrupted defense session.
+
+    Re-registers the session in the in-memory store and resets the
+    current question timer so the learner gets a fresh deadline.
+    Returns the session unchanged if it is already completed.
+    """
+    if session.completed:
+        _sessions[session.session_id] = session
+        return session
+
+    session.current_question_started_at = _utc_now()
+    _sessions[session.session_id] = session
+    return session
+
+
 def clear_sessions() -> None:
     """Clear all sessions. Used for testing only."""
     _sessions.clear()

--- a/services/ai_gateway/app/defense_persistence.py
+++ b/services/ai_gateway/app/defense_persistence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from datetime import UTC, datetime
 from typing import Any, cast
 
@@ -15,9 +16,50 @@ DEFAULT_API_BASE_URL = "http://localhost:8000"
 SESSION_STATE_ARTIFACT = "defense_session_state"
 SESSION_RESULT_ARTIFACT = "defense_session_result"
 
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 0.5
+
 
 class DefensePersistenceError(RuntimeError):
     """Raised when the API backend cannot persist or restore defense state."""
+
+
+def _is_transient(exc: Exception) -> bool:
+    """Return True for errors worth retrying (5xx, timeouts, connection errors)."""
+    if isinstance(exc, httpx.TimeoutException | httpx.ConnectError):
+        return True
+    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
+
+
+def _retry_request(fn: Any, *args: Any, **kwargs: Any) -> httpx.Response:
+    """Execute an httpx call with retry on transient failures."""
+    last_exc: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = fn(*args, **kwargs)
+            if response.status_code >= 500 and attempt < MAX_RETRIES - 1:
+                logger.warning(
+                    "Transient %d from backend (attempt %d/%d), retrying",
+                    response.status_code,
+                    attempt + 1,
+                    MAX_RETRIES,
+                )
+                time.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            return response
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            last_exc = exc
+            if attempt < MAX_RETRIES - 1:
+                logger.warning(
+                    "Transient error %s (attempt %d/%d), retrying",
+                    type(exc).__name__,
+                    attempt + 1,
+                    MAX_RETRIES,
+                )
+                time.sleep(RETRY_BASE_DELAY * (2**attempt))
+            else:
+                raise DefensePersistenceError(f"Backend unreachable after {MAX_RETRIES} attempts") from exc
+    raise DefensePersistenceError(f"Backend unreachable after {MAX_RETRIES} attempts") from last_exc
 
 
 def _api_base_url() -> str:
@@ -155,7 +197,8 @@ def restore_defense_session(payload: dict[str, Any]) -> DefenseSession:
 
 
 def create_defense_session(session: DefenseSession) -> dict[str, Any]:
-    response = httpx.post(
+    response = _retry_request(
+        httpx.post,
         f"{_api_base_url()}/api/v1/defense-sessions",
         json=_defense_session_payload(session),
         timeout=2.0,
@@ -170,7 +213,8 @@ def create_defense_session(session: DefenseSession) -> dict[str, Any]:
 
 
 def sync_defense_session(session: DefenseSession, *, allow_create: bool = True) -> dict[str, Any]:
-    response = httpx.put(
+    response = _retry_request(
+        httpx.put,
         f"{_api_base_url()}/api/v1/defense-sessions/{session.session_id}",
         json=_defense_session_update_payload(session),
         timeout=2.0,
@@ -187,7 +231,8 @@ def sync_defense_session(session: DefenseSession, *, allow_create: bool = True) 
 
 
 def load_defense_session(session_id: str) -> DefenseSession | None:
-    response = httpx.get(
+    response = _retry_request(
+        httpx.get,
         f"{_api_base_url()}/api/v1/defense-sessions/{session_id}",
         timeout=2.0,
     )
@@ -239,7 +284,8 @@ def persist_review_attempt(session: DefenseSession) -> dict[str, Any] | None:
         ],
     }
 
-    response = httpx.post(
+    response = _retry_request(
+        httpx.post,
         f"{_api_base_url()}/api/v1/review-attempts",
         json=payload,
         timeout=2.0,

--- a/services/ai_gateway/app/main.py
+++ b/services/ai_gateway/app/main.py
@@ -11,6 +11,7 @@ from .defense import (
     create_session,
     get_current_question,
     get_current_question_deadline,
+    resume_session,
     submit_answer,
 )
 from .defense_persistence import (
@@ -33,6 +34,8 @@ from .schemas import (
     DefenseQuestionOut,
     DefenseQuestionResult,
     DefenseResultResponse,
+    DefenseResumeRequest,
+    DefenseResumeResponse,
     DefenseStartRequest,
     DefenseStartResponse,
     IntentRequest,
@@ -371,6 +374,50 @@ def defense_answer(request: DefenseAnswerRequest) -> DefenseAnswerResponse:
         elapsed_seconds=result["elapsed_seconds"],
         next_question_id=result["next_question_id"],
         next_question_deadline=result["next_question_deadline"],
+    )
+
+
+@app.post("/api/v1/defense/resume", response_model=DefenseResumeResponse)
+def defense_resume(request: DefenseResumeRequest) -> DefenseResumeResponse:
+    """Resume an interrupted defense session from persisted state."""
+    try:
+        session = load_defense_session(request.session_id)
+    except DefensePersistenceError as exc:
+        logger.warning("Defense session load failed during resume", exc_info=True)
+        raise HTTPException(status_code=503, detail="Defense persistence unavailable") from exc
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    session = resume_session(session)
+    try:
+        sync_defense_session(session)
+    except DefensePersistenceError as exc:
+        logger.warning("Defense session sync failed during resume", exc_info=True)
+        raise HTTPException(status_code=503, detail="Defense persistence unavailable") from exc
+
+    current_question = get_current_question(session)
+    questions_answered = sum(1 for q in session.questions if q.answered)
+
+    return DefenseResumeResponse(
+        status="ok",
+        session_id=session.session_id,
+        track_id=session.track_id,
+        module_id=session.module_id,
+        questions=[
+            DefenseQuestionOut(
+                question_id=q.id,
+                text=q.text,
+                skill=q.skill,
+                time_limit_seconds=session.question_time_limit_seconds,
+            )
+            for q in session.questions
+        ],
+        total_questions=len(session.questions),
+        questions_answered=questions_answered,
+        question_time_limit_seconds=session.question_time_limit_seconds,
+        active_question_id=current_question.id if current_question else None,
+        current_question_deadline=get_current_question_deadline(session),
+        completed=session.completed,
     )
 
 

--- a/services/ai_gateway/app/schemas.py
+++ b/services/ai_gateway/app/schemas.py
@@ -193,6 +193,24 @@ class DefenseQuestionResult(BaseModel):
     elapsed_seconds: float = 0.0
 
 
+class DefenseResumeRequest(BaseModel):
+    session_id: str
+
+
+class DefenseResumeResponse(BaseModel):
+    status: str
+    session_id: str
+    track_id: str
+    module_id: str
+    questions: list[DefenseQuestionOut]
+    total_questions: int
+    questions_answered: int
+    question_time_limit_seconds: int
+    active_question_id: str | None
+    current_question_deadline: datetime | None
+    completed: bool
+
+
 class DefenseResultResponse(BaseModel):
     status: str
     session_id: str

--- a/services/ai_gateway/tests/test_defense.py
+++ b/services/ai_gateway/tests/test_defense.py
@@ -633,3 +633,196 @@ def test_result_question_results_structure() -> None:
     assert "answered" in qr
     assert "timed_out" in qr
     assert "elapsed_seconds" in qr
+
+
+# === Resume interrupted session ===
+
+RESUME_ENDPOINT = "/api/v1/defense/resume"
+
+
+def test_resume_interrupted_session_after_cache_clear(
+    _fake_persistence_backend: dict[str, Any],
+) -> None:
+    """Resuming a session whose in-memory state was lost reloads from persistence."""
+    session = _start_session(learner_id="learner-1", num_questions=2)
+    first_question = session["questions"][0]
+    client.post(
+        ANSWER_ENDPOINT,
+        json={
+            "session_id": session["session_id"],
+            "question_id": first_question["question_id"],
+            "answer": "pwd prints the current working directory because it tells me exactly where I am.",
+        },
+    )
+    clear_sessions()
+
+    response = client.post(RESUME_ENDPOINT, json={"session_id": session["session_id"]})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["session_id"] == session["session_id"]
+    assert data["questions_answered"] == 1
+    assert data["completed"] is False
+    assert data["active_question_id"] == session["questions"][1]["question_id"]
+    assert data["current_question_deadline"] is not None
+
+
+def test_resume_completed_session() -> None:
+    session = _start_session(num_questions=1)
+    q = session["questions"][0]
+    client.post(
+        ANSWER_ENDPOINT,
+        json={
+            "session_id": session["session_id"],
+            "question_id": q["question_id"],
+            "answer": "This concept is fundamental because it allows filesystem navigation.",
+        },
+    )
+    clear_sessions()
+
+    response = client.post(RESUME_ENDPOINT, json={"session_id": session["session_id"]})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["completed"] is True
+    assert data["active_question_id"] is None
+    assert data["current_question_deadline"] is None
+
+
+def test_resume_nonexistent_session() -> None:
+    response = client.post(RESUME_ENDPOINT, json={"session_id": "does-not-exist"})
+    assert response.status_code == 404
+
+
+def test_resume_then_continue_answering(
+    _fake_persistence_backend: dict[str, Any],
+) -> None:
+    """After resume, the learner can continue answering remaining questions."""
+    session = _start_session(learner_id="learner-1", num_questions=2)
+    first_question = session["questions"][0]
+    client.post(
+        ANSWER_ENDPOINT,
+        json={
+            "session_id": session["session_id"],
+            "question_id": first_question["question_id"],
+            "answer": "pwd prints the current working directory because it helps me navigate.",
+        },
+    )
+    clear_sessions()
+
+    client.post(RESUME_ENDPOINT, json={"session_id": session["session_id"]})
+
+    second_question = session["questions"][1]
+    response = client.post(
+        ANSWER_ENDPOINT,
+        json={
+            "session_id": session["session_id"],
+            "question_id": second_question["question_id"],
+            "answer": "ls lists files in a directory because it reads the directory entries. For example, ls -la shows hidden files.",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["questions_remaining"] == 0
+
+    result_response = client.get(f"/api/v1/defense/{session['session_id']}/result")
+    result_data = result_response.json()
+    assert len(result_data["question_results"]) == 2
+
+
+def test_resume_resets_question_timer(
+    _fake_persistence_backend: dict[str, Any],
+) -> None:
+    """Resuming should give a fresh deadline for the current question."""
+    start = datetime(2026, 3, 29, 12, 0, 0, tzinfo=UTC)
+    with patch("app.defense._utc_now", return_value=start):
+        session = _start_session(num_questions=2, question_time_limit_seconds=30)
+
+    first_question = session["questions"][0]
+    with patch("app.defense._utc_now", return_value=start + timedelta(seconds=10)):
+        client.post(
+            ANSWER_ENDPOINT,
+            json={
+                "session_id": session["session_id"],
+                "question_id": first_question["question_id"],
+                "answer": "pwd prints the current working directory because it helps me know where I am.",
+            },
+        )
+
+    clear_sessions()
+
+    resume_time = start + timedelta(minutes=30)
+    with patch("app.defense._utc_now", return_value=resume_time):
+        response = client.post(RESUME_ENDPOINT, json={"session_id": session["session_id"]})
+
+    data = response.json()
+    deadline_str = data["current_question_deadline"]
+    assert deadline_str is not None
+    deadline = datetime.fromisoformat(deadline_str)
+    expected_deadline = resume_time + timedelta(seconds=30)
+    assert abs((deadline - expected_deadline).total_seconds()) < 2
+
+
+# === Retry on transient persistence failures ===
+
+
+def test_retry_recovers_from_transient_post_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persistence retries on 5xx and succeeds on subsequent attempt."""
+    call_count = 0
+    original_post = defense_persistence.httpx.post
+
+    def flaky_post(*args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeHttpxResponse(503, {"detail": "Service unavailable"})
+        return original_post(*args, **kwargs)
+
+    monkeypatch.setattr(defense_persistence, "RETRY_BASE_DELAY", 0.01)
+    monkeypatch.setattr(defense_persistence.httpx, "post", flaky_post)
+
+    response = client.post(
+        START_ENDPOINT,
+        json={"track_id": "shell", "module_id": "shell-basics"},
+    )
+    assert response.status_code == 200
+    assert call_count >= 2
+
+
+def test_retry_exhaustion_returns_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After all retries are exhausted, the endpoint returns 503."""
+
+    def always_fail(*args: Any, **kwargs: Any) -> _FakeHttpxResponse:
+        return _FakeHttpxResponse(503, {"detail": "Service unavailable"})
+
+    monkeypatch.setattr(defense_persistence, "RETRY_BASE_DELAY", 0.01)
+    monkeypatch.setattr(defense_persistence.httpx, "post", always_fail)
+
+    response = client.post(
+        START_ENDPOINT,
+        json={"track_id": "shell", "module_id": "shell-basics"},
+    )
+    assert response.status_code == 503
+
+
+def test_retry_recovers_from_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persistence retries on timeout exception and succeeds on retry."""
+    import httpx as real_httpx
+
+    call_count = 0
+    original_get = defense_persistence.httpx.get
+
+    def flaky_get(*args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise real_httpx.ConnectError("Connection refused")
+        return original_get(*args, **kwargs)
+
+    session = _start_session(num_questions=1)
+
+    monkeypatch.setattr(defense_persistence, "RETRY_BASE_DELAY", 0.01)
+    monkeypatch.setattr(defense_persistence.httpx, "get", flaky_get)
+
+    response = client.get(f"/api/v1/defense/{session['session_id']}/result")
+    assert response.status_code == 200
+    assert call_count >= 2


### PR DESCRIPTION
## Summary

- Add retry with exponential backoff (3 attempts, 0.5s base delay) to all `defense_persistence.py` HTTP calls — recovers from transient 5xx errors, timeouts, and connection failures
- Add `POST /api/v1/defense/resume` endpoint that reloads an interrupted session from backend persistence, resets the current question timer, and re-registers it in the in-memory store
- Add `resume_session()` to `defense.py` and `DefenseResumeRequest`/`DefenseResumeResponse` schemas

## Test plan

- [x] Resume interrupted session after in-memory cache loss (8 new tests)
- [x] Resume completed session returns completed state
- [x] Resume nonexistent session returns 404
- [x] Resume then continue answering remaining questions
- [x] Timer reset on resume verified with mocked clock
- [x] Retry recovers from transient 503 on POST
- [x] Retry exhaustion returns 503 to client
- [x] Retry recovers from `ConnectError` on GET
- [x] All 211 existing + new tests pass, lint clean

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)