### PR TITLE
feat: tmux session lifecycle management (#181)

### DIFF
--- a/apps/web/app/components/NavHeader.tsx
+++ b/apps/web/app/components/NavHeader.tsx
@@ -10,6 +10,7 @@ const NAV_LINKS = [
   { href: "/review", label: "Review" },
   { href: "/evidence", label: "Evidence" },
   { href: "/profiles", label: "Profiles" },
+  { href: "/sessions", label: "Sessions" },
   { href: "/analytics", label: "Analytics" },
 ] as const;
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1871,3 +1871,108 @@ a {
     align-items: start;
   }
 }
+
+/* ------------------------------------------------------------------ */
+/*  Sessions page                                                      */
+/* ------------------------------------------------------------------ */
+
+.sessions-hero { margin-bottom: 20px; }
+
+.sessions-content {
+  display: grid;
+  gap: 20px;
+}
+
+.sessions-form {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.sessions-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--panel);
+  color: var(--ink);
+}
+
+.sessions-input::placeholder { color: var(--muted); }
+
+.sessions-error {
+  margin-top: 8px;
+  color: var(--c);
+  font-size: 13px;
+}
+
+.sessions-attach-hint {
+  font-size: 14px;
+}
+
+.sessions-cmd {
+  display: block;
+  margin-top: 6px;
+  padding: 10px 14px;
+  background: var(--ink);
+  color: var(--bg);
+  border-radius: 6px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 13px;
+  user-select: all;
+}
+
+.sessions-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.sessions-table th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 2px solid var(--line);
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.sessions-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.sessions-name {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 600;
+}
+
+.sessions-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.btn--small {
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--ink);
+}
+
+.btn--small:hover { background: var(--bg); }
+
+.btn--danger {
+  color: var(--c);
+  border-color: var(--c);
+}
+
+.btn--danger:hover {
+  background: var(--c);
+  color: #fff;
+}

--- a/apps/web/app/sessions/SessionsClient.tsx
+++ b/apps/web/app/sessions/SessionsClient.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type TmuxSession = {
+  name: string;
+  created_at: number;
+  windows: number;
+  attached: boolean;
+};
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+async function fetchSessions(): Promise<TmuxSession[]> {
+  const res = await fetch(`${API_URL}/api/v1/tmux`, { cache: "no-store" });
+  if (!res.ok) return [];
+  return (await res.json()) as TmuxSession[];
+}
+
+async function startSession(name: string): Promise<{ ok: boolean; detail?: string }> {
+  const res = await fetch(`${API_URL}/api/v1/tmux/start`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    return { ok: false, detail: body.detail ?? `Error ${res.status}` };
+  }
+  return { ok: true };
+}
+
+async function attachSession(name: string): Promise<string | null> {
+  const res = await fetch(`${API_URL}/api/v1/tmux/attach`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) return null;
+  const body = (await res.json()) as { command: string };
+  return body.command;
+}
+
+async function killSession(name: string): Promise<boolean> {
+  const res = await fetch(`${API_URL}/api/v1/tmux/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+  return res.ok;
+}
+
+function formatCreated(epoch: number): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(epoch * 1000));
+}
+
+export default function SessionsClient() {
+  const [sessions, setSessions] = useState<TmuxSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newName, setNewName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [attachCmd, setAttachCmd] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setSessions(await fetchSessions());
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSessions().then((data) => {
+      if (!cancelled) {
+        setSessions(data);
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  async function handleStart() {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    setError(null);
+    const result = await startSession(trimmed);
+    if (!result.ok) {
+      setError(result.detail ?? "Failed to start session");
+      return;
+    }
+    setNewName("");
+    await refresh();
+  }
+
+  async function handleAttach(name: string) {
+    setAttachCmd(null);
+    const cmd = await attachSession(name);
+    if (cmd) setAttachCmd(cmd);
+  }
+
+  async function handleKill(name: string) {
+    await killSession(name);
+    setAttachCmd(null);
+    await refresh();
+  }
+
+  return (
+    <section className="sessions-content">
+      <div className="panel sessions-create">
+        <h2>Start a new session</h2>
+        <div className="sessions-form">
+          <input
+            className="sessions-input"
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Session name (e.g. shell-practice)"
+            pattern="^[a-zA-Z0-9_-]+$"
+            maxLength={64}
+            onKeyDown={(e) => { if (e.key === "Enter") handleStart(); }}
+          />
+          <button className="btn btn--primary" onClick={handleStart} disabled={!newName.trim()}>
+            Start
+          </button>
+        </div>
+        {error && <p className="sessions-error">{error}</p>}
+      </div>
+
+      {attachCmd && (
+        <div className="panel sessions-attach-hint">
+          <p>Run this in your terminal to attach:</p>
+          <code className="sessions-cmd">{attachCmd}</code>
+        </div>
+      )}
+
+      <div className="panel sessions-list">
+        <h2>Active sessions</h2>
+        {loading && <p className="muted">Loading...</p>}
+        {!loading && sessions.length === 0 && (
+          <p className="muted">No active sessions. Start one above.</p>
+        )}
+        {!loading && sessions.length > 0 && (
+          <table className="sessions-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Created</th>
+                <th>Windows</th>
+                <th>Attached</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((s) => (
+                <tr key={s.name}>
+                  <td className="sessions-name">{s.name}</td>
+                  <td>{formatCreated(s.created_at)}</td>
+                  <td>{s.windows}</td>
+                  <td>{s.attached ? "yes" : "no"}</td>
+                  <td className="sessions-actions">
+                    <button className="btn btn--small" onClick={() => handleAttach(s.name)}>
+                      Attach
+                    </button>
+                    <button className="btn btn--small btn--danger" onClick={() => handleKill(s.name)}>
+                      Kill
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/sessions/page.tsx
+++ b/apps/web/app/sessions/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Sessions — 42 Training",
+  description: "Manage tmux shell practice sessions",
+};
+
+export default function SessionsPage() {
+  return (
+    <main className="page-shell sessions-page">
+      <nav className="breadcrumb">
+        <Link href="/">Dashboard</Link>
+        <span className="breadcrumb-sep">/</span>
+        <span>Sessions</span>
+      </nav>
+
+      <section className="sessions-hero panel">
+        <p className="eyebrow">Sessions</p>
+        <h1>Manage your shell practice sessions from here.</h1>
+        <p className="lead">
+          Start, inspect or tear down tmux sessions used for hands-on shell
+          exercises. Each session is an isolated terminal you can reconnect to
+          at any time.
+        </p>
+      </section>
+
+      <SessionsClient />
+    </main>
+  );
+}
+
+import SessionsClient from "./SessionsClient";

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -44,11 +44,9 @@ from .schemas import (
     ProgressUpdate,
     ReviewAttemptCreate,
     ReviewAttemptRecord,
-    TmuxSessionsResponse,
     TrackDetail,
     TrackSummary,
 )
-from .tmux import list_tmux_sessions
 from .tmux import router as tmux_router
 from .validation import find_module, validate_module_activation
 
@@ -182,16 +180,6 @@ async def unhandled_exception_handler(_request: Request, exc: Exception) -> JSON
 @app.get("/health")
 def health() -> HealthResponse:
     return HealthResponse(status="ok", service="api")
-
-
-# ---------------------------------------------------------------------------
-# Tmux sessions (Issue #178)
-# ---------------------------------------------------------------------------
-
-
-@app.get("/api/v1/tmux/sessions", response_model=TmuxSessionsResponse)
-def tmux_sessions() -> TmuxSessionsResponse:
-    return list_tmux_sessions()
 
 
 # ---------------------------------------------------------------------------

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -384,3 +384,29 @@ class TmuxSession(BaseModel):
 class TmuxSessionsResponse(BaseModel):
     sessions: list[TmuxSession]
     total: int
+
+
+# --- Tmux session lifecycle schemas (Issue #181) ---
+
+
+class TmuxStartRequest(BaseModel):
+    """Request to start or attach to a tmux session."""
+
+    name: str = Field(min_length=1, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
+
+
+class TmuxStartResponse(BaseModel):
+    name: str
+    status: str
+
+
+class TmuxAttachResponse(BaseModel):
+    name: str
+    command: str
+
+
+class TmuxSessionInfo(BaseModel):
+    name: str
+    created_at: int
+    windows: int
+    attached: bool

--- a/services/api/app/tmux.py
+++ b/services/api/app/tmux.py
@@ -1,4 +1,4 @@
-"""Tmux session discovery and pane capture (Issues #178, #179)."""
+"""Tmux session discovery, pane capture, and lifecycle (Issues #178, #179, #181)."""
 
 from __future__ import annotations
 
@@ -8,9 +8,17 @@ import shutil
 import subprocess
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 
-from .schemas import TmuxPaneResponse, TmuxSession, TmuxSessionsResponse
+from .schemas import (
+    TmuxAttachResponse,
+    TmuxPaneResponse,
+    TmuxSession,
+    TmuxSessionInfo,
+    TmuxSessionsResponse,
+    TmuxStartRequest,
+    TmuxStartResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +30,12 @@ router = APIRouter(prefix="/api/v1/tmux", tags=["tmux"])
 
 _DEFAULT_ROWS = 24
 _DEFAULT_COLS = 80
+_TMUX = "tmux"
+
+
+# ---------------------------------------------------------------------------
+# Read-only pane capture (Issue #179)
+# ---------------------------------------------------------------------------
 
 
 async def _capture_pane(session: str) -> tuple[str, int, int]:
@@ -92,7 +106,7 @@ async def get_tmux_pane(session: str) -> TmuxPaneResponse:
 # Session listing (Issue #178)
 # ---------------------------------------------------------------------------
 
-_IDLE_THRESHOLD_SECONDS = 300  # 5 minutes without activity → idle
+_IDLE_THRESHOLD_SECONDS = 300  # 5 minutes without activity -> idle
 
 
 def _epoch_to_iso(epoch_str: str) -> str:
@@ -112,7 +126,7 @@ def _parse_status(last_activity_epoch: str, attached: bool) -> str:
         return "idle"
 
 
-def list_tmux_sessions() -> TmuxSessionsResponse:
+def list_tmux_sessions_legacy() -> TmuxSessionsResponse:
     """Run ``tmux list-sessions`` and return structured data."""
     try:
         result = subprocess.run(
@@ -156,3 +170,109 @@ def list_tmux_sessions() -> TmuxSessionsResponse:
         )
 
     return TmuxSessionsResponse(sessions=sessions, total=len(sessions))
+
+
+@router.get("/sessions", response_model=TmuxSessionsResponse)
+def get_tmux_sessions() -> TmuxSessionsResponse:
+    """List tmux sessions with status and activity metadata."""
+    return list_tmux_sessions_legacy()
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle (Issue #181)
+# ---------------------------------------------------------------------------
+
+
+def _run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a tmux sub-command and return the result."""
+    return subprocess.run(
+        [_TMUX, *args],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=check,
+    )
+
+
+def _list_sessions() -> list[TmuxSessionInfo]:
+    """Return all live tmux sessions."""
+    result = _run(
+        ["list-sessions", "-F", "#{session_name}\t#{session_created}\t#{session_windows}\t#{session_attached}"],
+        check=False,
+    )
+    if result.returncode != 0:
+        # tmux returns 1 when there are no sessions
+        return []
+
+    sessions: list[TmuxSessionInfo] = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) < 4:
+            continue
+        sessions.append(
+            TmuxSessionInfo(
+                name=parts[0],
+                created_at=int(parts[1]),
+                windows=int(parts[2]),
+                attached=int(parts[3]) > 0,
+            )
+        )
+    return sessions
+
+
+def _session_exists(name: str) -> bool:
+    result = _run(["has-session", "-t", name], check=False)
+    return result.returncode == 0
+
+
+@router.get("", response_model=list[TmuxSessionInfo])
+def list_tmux_sessions() -> list[TmuxSessionInfo]:
+    """List all active tmux sessions."""
+    return _list_sessions()
+
+
+@router.post("/start", response_model=TmuxStartResponse, status_code=status.HTTP_201_CREATED)
+def start_tmux_session(payload: TmuxStartRequest) -> TmuxStartResponse:
+    """Create a new tmux session."""
+    name = payload.name
+
+    if _session_exists(name):
+        raise HTTPException(status_code=409, detail=f"Session '{name}' already exists")
+
+    cmd = ["new-session", "-d", "-s", name, "-x", "200", "-y", "50"]
+    try:
+        _run(cmd)
+    except subprocess.CalledProcessError as exc:
+        logger.error("tmux new-session failed: %s", exc.stderr)
+        raise HTTPException(status_code=500, detail="Failed to create tmux session") from exc
+
+    return TmuxStartResponse(name=name, status="created")
+
+
+@router.post("/attach", response_model=TmuxAttachResponse)
+def attach_tmux_session(payload: TmuxStartRequest) -> TmuxAttachResponse:
+    """Return the command needed to attach to an existing session."""
+    name = payload.name
+
+    if not _session_exists(name):
+        raise HTTPException(status_code=404, detail=f"Session '{name}' not found")
+
+    return TmuxAttachResponse(
+        name=name,
+        command=f"tmux attach-session -t {name}",
+    )
+
+
+@router.delete("/{session_name}", status_code=status.HTTP_200_OK)
+def kill_tmux_session(session_name: str) -> dict[str, str]:
+    """Kill (tear down) a tmux session."""
+    if not _session_exists(session_name):
+        raise HTTPException(status_code=404, detail=f"Session '{session_name}' not found")
+
+    try:
+        _run(["kill-session", "-t", session_name])
+    except subprocess.CalledProcessError as exc:
+        logger.error("tmux kill-session failed: %s", exc.stderr)
+        raise HTTPException(status_code=500, detail="Failed to kill tmux session") from exc
+
+    return {"name": session_name, "status": "killed"}

--- a/services/api/tests/test_tmux.py
+++ b/services/api/tests/test_tmux.py
@@ -1,4 +1,4 @@
-"""Tests for tmux pane capture (Issue #179) and session listing (Issue #178)."""
+"""Tests for tmux pane capture (#179), session listing (#178), and lifecycle (#181)."""
 
 from __future__ import annotations
 
@@ -195,3 +195,108 @@ class TestTmuxSessions:
         with patch("app.tmux.subprocess.run", return_value=result):
             r = client.get("/api/v1/tmux/sessions")
         assert r.json()["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle tests (Issue #181)
+# ---------------------------------------------------------------------------
+
+
+def _fake_list_output(sessions: list[tuple[str, int, int, int]]) -> subprocess.CompletedProcess[str]:
+    """Build a fake tmux list-sessions result."""
+    lines = "\n".join(f"{name}\t{created}\t{windows}\t{attached}" for name, created, windows, attached in sessions)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=lines, stderr="")
+
+
+def _no_sessions() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="no server running")
+
+
+def _ok() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def _fail() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="error")
+
+
+class TestListSessions:
+    def test_returns_empty_when_no_sessions(self) -> None:
+        with patch("app.tmux._run", return_value=_no_sessions()):
+            response = client.get("/api/v1/tmux")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_returns_parsed_sessions(self) -> None:
+        fake = _fake_list_output([("shell-practice", 1711700000, 2, 1), ("c-debug", 1711700100, 1, 0)])
+        with patch("app.tmux._run", return_value=fake):
+            response = client.get("/api/v1/tmux")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "shell-practice"
+        assert data[0]["attached"] is True
+        assert data[1]["name"] == "c-debug"
+        assert data[1]["attached"] is False
+
+
+class TestStartSession:
+    def test_creates_new_session(self) -> None:
+        with patch("app.tmux._run") as mock_run:
+            mock_run.side_effect = [_fail(), _ok()]  # has-session fails, new-session ok
+            response = client.post("/api/v1/tmux/start", json={"name": "test-sess"})
+        assert response.status_code == 201
+        assert response.json()["name"] == "test-sess"
+        assert response.json()["status"] == "created"
+
+    def test_rejects_duplicate_session(self) -> None:
+        with patch("app.tmux._run", return_value=_ok()):  # has-session succeeds
+            response = client.post("/api/v1/tmux/start", json={"name": "existing"})
+        assert response.status_code == 409
+
+    def test_rejects_invalid_name(self) -> None:
+        response = client.post("/api/v1/tmux/start", json={"name": "bad name!"})
+        assert response.status_code == 422
+
+    def test_rejects_empty_name(self) -> None:
+        response = client.post("/api/v1/tmux/start", json={"name": ""})
+        assert response.status_code == 422
+
+    def test_handles_tmux_failure(self) -> None:
+        with patch("app.tmux._run") as mock_run:
+            mock_run.side_effect = [_fail(), subprocess.CalledProcessError(1, "tmux")]
+            response = client.post("/api/v1/tmux/start", json={"name": "broken"})
+        assert response.status_code == 500
+
+
+class TestAttachSession:
+    def test_returns_attach_command(self) -> None:
+        with patch("app.tmux._run", return_value=_ok()):  # has-session succeeds
+            response = client.post("/api/v1/tmux/attach", json={"name": "my-sess"})
+        assert response.status_code == 200
+        assert response.json()["command"] == "tmux attach-session -t my-sess"
+
+    def test_returns_404_for_missing_session(self) -> None:
+        with patch("app.tmux._run", return_value=_fail()):  # has-session fails
+            response = client.post("/api/v1/tmux/attach", json={"name": "ghost"})
+        assert response.status_code == 404
+
+
+class TestKillSession:
+    def test_kills_existing_session(self) -> None:
+        with patch("app.tmux._run") as mock_run:
+            mock_run.side_effect = [_ok(), _ok()]  # has-session ok, kill-session ok
+            response = client.delete("/api/v1/tmux/test-sess")
+        assert response.status_code == 200
+        assert response.json()["status"] == "killed"
+
+    def test_returns_404_for_missing_session(self) -> None:
+        with patch("app.tmux._run", return_value=_fail()):
+            response = client.delete("/api/v1/tmux/ghost")
+        assert response.status_code == 404
+
+    def test_handles_kill_failure(self) -> None:
+        with patch("app.tmux._run") as mock_run:
+            mock_run.side_effect = [_ok(), subprocess.CalledProcessError(1, "tmux")]
+            response = client.delete("/api/v1/tmux/broken")
+        assert response.status_code == 500


### PR DESCRIPTION
## Summary
- **Backend**: New `services/api/app/tmux.py` router with 4 endpoints wrapping tmux CLI
  - `GET /api/v1/tmux` — list active sessions
  - `POST /api/v1/tmux/start` — create a new session (409 if duplicate, 422 on invalid name)
  - `POST /api/v1/tmux/attach` — return attach command for existing session
  - `DELETE /api/v1/tmux/{session_name}` — kill a session
- **Frontend**: `/sessions` page with `SessionsClient` component — start, inspect, attach-info and kill sessions from the web
- **Nav**: "Sessions" link added to NavHeader
- **Schemas**: `TmuxStartRequest`, `TmuxStartResponse`, `TmuxAttachResponse`, `TmuxSessionInfo`

## Test plan
- [x] 12 backend tests pass (`services/api/tests/test_tmux.py`) — all mocked, no real tmux needed
- [x] Full API suite: 212 passed
- [x] Full AI gateway suite: 217 passed
- [x] Ruff lint + format: clean
- [ ] Web build: pre-existing Turbopack workspace root issue on local host (CI should pass)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)