### PR TITLE
feat: watch_mentor.sh periodic check-ins visible in web analytics (#183)

### DIFF
--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -92,6 +92,7 @@ export default async function AnalyticsPage() {
     { label: "Checkpoint pass rate", value: analytics.summary.checkpoint_success_rate },
     { label: "Mentor queries", value: analytics.summary.mentor_queries },
     { label: "Defenses started", value: analytics.summary.defenses_started },
+    { label: "Watch check-ins", value: analytics.summary.watch_mentor_checkins },
   ];
 
   return (

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -142,6 +142,7 @@ export type AnalyticsSummary = {
   checkpoint_success_rate: number;
   mentor_queries: number;
   defenses_started: number;
+  watch_mentor_checkins: number;
 };
 
 export type AnalyticsChartRow = {
@@ -423,6 +424,7 @@ const fallbackAnalyticsData: AnalyticsData = {
     checkpoint_success_rate: 71.4,
     mentor_queries: 11,
     defenses_started: 2,
+    watch_mentor_checkins: 4,
   },
   modules_completed: [
     {

--- a/scripts/watch_mentor.sh
+++ b/scripts/watch_mentor.sh
@@ -3,14 +3,29 @@ set -euo pipefail
 
 INTERVAL="${1:-900}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_URL="${API_URL:-http://localhost:8000}"
+LEARNER_ID="${LEARNER_ID:-default}"
 CYCLE=0
 
 echo "Mentor watch - every $((INTERVAL / 60)) min. Ctrl+C to stop."
 echo ""
 
+_emit_checkin() {
+  curl -sf -X POST "${API_URL}/api/v1/events" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"event_type\": \"watch_mentor_checkin\",
+      \"learner_id\": \"${LEARNER_ID}\",
+      \"source_service\": \"api\",
+      \"payload\": {\"cycle\": ${CYCLE}, \"interval_seconds\": ${INTERVAL}}
+    }" >/dev/null 2>&1 || true
+}
+
 while true; do
   CYCLE=$((CYCLE + 1))
   echo "--- cycle ${CYCLE} - $(date '+%H:%M') ---"
+
+  _emit_checkin
 
   "${SCRIPT_DIR}/ask_mentor.sh" \
     "Periodic check-in: observe the learning session. If the student seems stuck, ask one guiding question and give one hint. If progress is healthy, validate briefly and suggest the next useful check."

--- a/services/api/app/analytics.py
+++ b/services/api/app/analytics.py
@@ -80,6 +80,7 @@ def build_analytics_dashboard(
                 "checkpoint_success_rate": 0.0,
                 "mentor_queries": 0,
                 "defenses_started": 0,
+                "watch_mentor_checkins": 0,
             },
             modules_completed=[],
             average_time=[],
@@ -91,6 +92,7 @@ def build_analytics_dashboard(
     checkpoint_passes: Counter[str] = Counter()
     mentor_queries = 0
     defenses_started = 0
+    watch_mentor_checkins = 0
 
     durations_by_module: dict[str, list[float]] = defaultdict(list)
     starts_by_key: dict[tuple[str, str], deque[datetime]] = defaultdict(deque)
@@ -134,6 +136,10 @@ def build_analytics_dashboard(
             defenses_started += 1
             continue
 
+        if event_type == "watch_mentor_checkin":
+            watch_mentor_checkins += 1
+            continue
+
     average_time_by_module = {
         module_id: (sum(durations) / len(durations))
         for module_id, durations in durations_by_module.items()
@@ -159,6 +165,7 @@ def build_analytics_dashboard(
             "checkpoint_success_rate": round(overall_success_rate, 1),
             "mentor_queries": mentor_queries,
             "defenses_started": defenses_started,
+            "watch_mentor_checkins": watch_mentor_checkins,
         },
         modules_completed=_chart_rows(completion_counts, curriculum, suffix=" completions"),  # type: ignore[arg-type]
         average_time=_chart_rows(average_time_by_module, curriculum, suffix=" min"),  # type: ignore[arg-type]

--- a/services/api/app/cleanup_events.py
+++ b/services/api/app/cleanup_events.py
@@ -11,6 +11,7 @@ from .db import get_session_factory
 from .models import PedagogicalEvent
 
 MENTOR_QUERY_RETENTION = timedelta(days=90)
+WATCH_CHECKIN_RETENTION = timedelta(days=90)
 CHECKPOINT_RETENTION = timedelta(days=365)
 MODULE_RETENTION = timedelta(days=730)
 MODULE_EVENT_TYPES = ("module_started", "module_completed", "module_skipped")
@@ -19,12 +20,15 @@ MODULE_EVENT_TYPES = ("module_started", "module_completed", "module_skipped")
 @dataclass(slots=True)
 class CleanupSummary:
     deleted_mentor_queries: int
+    deleted_watch_checkins: int
     deleted_checkpoints: int
     deleted_modules: int
 
     @property
     def total_deleted(self) -> int:
-        return self.deleted_mentor_queries + self.deleted_checkpoints + self.deleted_modules
+        return (
+            self.deleted_mentor_queries + self.deleted_watch_checkins + self.deleted_checkpoints + self.deleted_modules
+        )
 
 
 async def _delete_before(
@@ -56,6 +60,11 @@ async def cleanup_expired_events(
             event_types=("mentor_query",),
             cutoff=current_time - MENTOR_QUERY_RETENTION,
         )
+        deleted_watch_checkins = await _delete_before(
+            session,
+            event_types=("watch_mentor_checkin",),
+            cutoff=current_time - WATCH_CHECKIN_RETENTION,
+        )
         deleted_checkpoints = await _delete_before(
             session,
             event_types=("checkpoint_submitted",),
@@ -70,6 +79,7 @@ async def cleanup_expired_events(
 
     return CleanupSummary(
         deleted_mentor_queries=deleted_mentor_queries,
+        deleted_watch_checkins=deleted_watch_checkins,
         deleted_checkpoints=deleted_checkpoints,
         deleted_modules=deleted_modules,
     )
@@ -85,6 +95,7 @@ def main() -> int:
     print(
         "Deleted pedagogical events:",
         f"mentor_query={summary.deleted_mentor_queries}",
+        f"watch_mentor_checkin={summary.deleted_watch_checkins}",
         f"checkpoint_submitted={summary.deleted_checkpoints}",
         f"module_events={summary.deleted_modules}",
         f"total={summary.total_deleted}",

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -310,6 +310,7 @@ PedagogicalEventType = Literal[
     "checkpoint_submitted",
     "mentor_query",
     "defense_started",
+    "watch_mentor_checkin",
 ]
 
 
@@ -335,6 +336,7 @@ class AnalyticsSummary(BaseModel):
     checkpoint_success_rate: float
     mentor_queries: int
     defenses_started: int
+    watch_mentor_checkins: int
 
 
 class AnalyticsChartRow(BaseModel):

--- a/services/api/tests/test_analytics.py
+++ b/services/api/tests/test_analytics.py
@@ -72,6 +72,7 @@ def test_build_analytics_dashboard_computes_summary_and_charts() -> None:
     assert data.summary.checkpoint_success_rate == 50.0
     assert data.summary.mentor_queries == 1
     assert data.summary.defenses_started == 1
+    assert data.summary.watch_mentor_checkins == 0
 
     assert [row.module_id for row in data.modules_completed] == ["shell-basics", "shell-streams"]
     assert data.average_time[0].module_id == "shell-streams"

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -192,6 +192,7 @@ class TestAnalyticsDashboard:
                             "checkpoint_success_rate": 66.7,
                             "mentor_queries": 1,
                             "defenses_started": 1,
+                            "watch_mentor_checkins": 0,
                         },
                         "modules_completed": [],
                         "average_time": [],

--- a/services/api/tests/test_cleanup_events.py
+++ b/services/api/tests/test_cleanup_events.py
@@ -90,6 +90,7 @@ def test_cleanup_expired_events_deletes_only_records_past_ttl(tmp_path: Path) ->
 
         summary = await cleanup_expired_events(now=now, session_factory=session_factory)
         assert summary.deleted_mentor_queries == 1
+        assert summary.deleted_watch_checkins == 0
         assert summary.deleted_checkpoints == 1
         assert summary.deleted_modules == 1
         assert summary.total_deleted == 3

--- a/services/api/tests/test_events_analytics_e2e.py
+++ b/services/api/tests/test_events_analytics_e2e.py
@@ -131,6 +131,7 @@ def test_emit_event_helper_persists_to_table_and_feeds_analytics_dashboard(
         "checkpoint_success_rate": 100.0,
         "mentor_queries": 1,
         "defenses_started": 0,
+        "watch_mentor_checkins": 0,
     }
     assert data["modules_completed"][0]["module_id"] == "shell-basics"
     assert data["average_time"][0]["value"] == 30.0
@@ -215,6 +216,7 @@ def test_public_events_endpoint_writes_events_that_dashboard_aggregates(
         "checkpoint_success_rate": 0.0,
         "mentor_queries": 0,
         "defenses_started": 1,
+        "watch_mentor_checkins": 0,
     }
     assert data["modules_completed"][0]["module_id"] == "shell-streams"
     assert data["average_time"][0]["module_id"] == "shell-streams"


### PR DESCRIPTION
## Summary
- Adds `watch_mentor_checkin` event type to the full analytics pipeline (schema → aggregation → cleanup → frontend)
- `scripts/watch_mentor.sh` emits this event via `POST /api/v1/events` at each check-in cycle
- Analytics dashboard displays a new "Watch check-ins" metric card

## Files changed

**Backend (services/api/):**
- `app/schemas.py` — add `watch_mentor_checkin` to `PedagogicalEventType`, add `watch_mentor_checkins` to `AnalyticsSummary`
- `app/analytics.py` — count `watch_mentor_checkin` events in dashboard builder
- `app/cleanup_events.py` — 90-day retention policy for watch check-in events

**Script:**
- `scripts/watch_mentor.sh` — emit `watch_mentor_checkin` event via curl before each mentor query

**Frontend (apps/web/):**
- `lib/api.ts` — add `watch_mentor_checkins` to `AnalyticsSummary` type + fallback data
- `app/analytics/page.tsx` — display "Watch check-ins" summary card

**Tests updated:**
- `test_analytics.py`, `test_events_analytics_e2e.py`, `test_cleanup_events.py`, `test_api.py` — updated summary assertions

## Test plan
- [x] 205/206 API tests pass (1 pre-existing Alembic/SQLite failure)
- [x] Frontend type-check clean (`tsc --noEmit`)
- [x] ruff lint + format clean

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)