### PR TITLE
feat: Track Explorer with RPG talent tree (#186)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2094,3 +2094,205 @@ a {
   background: var(--c);
   color: #fff;
 }
+
+/* ------------------------------------------------------------------ */
+/*  Track Explorer — RPG talent tree                                   */
+/* ------------------------------------------------------------------ */
+
+.talent-hero {
+  text-align: center;
+  padding: 48px 32px;
+}
+
+.talent-legend {
+  display: flex;
+  gap: 24px;
+  justify-content: center;
+  margin-top: 16px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.talent-legend-icon {
+  font-size: 16px;
+  margin-right: 4px;
+}
+
+.talent-trees {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.talent-track {
+  background: var(--panel);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.talent-track-header {
+  padding: 24px 28px;
+  border-left: 6px solid var(--accent);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.talent-track-header h2 {
+  margin: 4px 0 8px;
+}
+
+.talent-track-progress {
+  min-width: 180px;
+  text-align: right;
+  font-size: 13px;
+}
+
+.talent-track-bar {
+  height: 8px;
+  background: var(--line);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.talent-track-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.talent-phase {
+  display: flex;
+  gap: 0;
+  border-top: 1px solid var(--line);
+}
+
+.talent-phase-label {
+  writing-mode: vertical-lr;
+  text-orientation: mixed;
+  transform: rotate(180deg);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted);
+  padding: 16px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  border-right: 1px solid var(--line);
+}
+
+.talent-phase-nodes {
+  flex: 1;
+  padding: 8px 0;
+}
+
+.talent-node-wrapper {
+  position: relative;
+}
+
+.talent-node {
+  display: flex;
+  gap: 16px;
+  padding: 16px 24px;
+  transition: background 0.15s ease;
+}
+
+.talent-node:hover {
+  background: rgba(216, 166, 87, 0.06);
+}
+
+.talent-node--locked {
+  opacity: 0.5;
+}
+
+.talent-node--in_progress {
+  background: rgba(216, 166, 87, 0.08);
+}
+
+.talent-node-icon {
+  font-size: 20px;
+  line-height: 1;
+  padding-top: 2px;
+  flex-shrink: 0;
+  width: 24px;
+  text-align: center;
+}
+
+.talent-node-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.talent-node-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.talent-node-title {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.talent-node-title:hover {
+  text-decoration: underline;
+}
+
+.talent-node--locked .talent-node-title {
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.talent-node-badges {
+  display: flex;
+  gap: 6px;
+}
+
+.talent-node-deliverable {
+  margin: 4px 0 8px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.talent-node-objectives {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.talent-node-objectives li {
+  margin-bottom: 2px;
+}
+
+.talent-edge {
+  width: 2px;
+  height: 12px;
+  border-left: 2px dashed var(--line);
+  margin-left: 35px;
+}
+
+@media (max-width: 640px) {
+  .talent-track-header {
+    flex-direction: column;
+  }
+  .talent-track-progress {
+    text-align: left;
+    min-width: auto;
+  }
+  .talent-legend {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+}

--- a/apps/web/app/tracks/page.tsx
+++ b/apps/web/app/tracks/page.tsx
@@ -1,0 +1,226 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+import { getDashboardData } from "@/lib/api";
+import type { ModuleItem, TrackItem } from "@/lib/api";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function Pill({ children }: { children: ReactNode }) {
+  return <span className="pill">{children}</span>;
+}
+
+type ModuleState = "done" | "in_progress" | "locked" | "available";
+
+function deriveModuleState(
+  moduleId: string,
+  trackId: string,
+  activeTrack: string | undefined,
+  activeModule: string | undefined,
+  modules: ModuleItem[],
+): ModuleState {
+  if (trackId !== activeTrack) return "locked";
+  if (moduleId === activeModule) return "in_progress";
+  const activeIdx = modules.findIndex((m) => m.id === activeModule);
+  const currentIdx = modules.findIndex((m) => m.id === moduleId);
+  if (activeIdx === -1) return currentIdx === 0 ? "available" : "locked";
+  if (currentIdx < activeIdx) return "done";
+  if (currentIdx === activeIdx + 1) return "available";
+  return "locked";
+}
+
+const PHASE_ORDER: Record<string, number> = {
+  foundation: 0,
+  practice: 1,
+  core: 2,
+  advanced: 3,
+};
+
+const STATE_ICON: Record<ModuleState, string> = {
+  done: "◆",
+  in_progress: "▶",
+  available: "○",
+  locked: "◇",
+};
+
+const TRACK_COLORS: Record<string, string> = {
+  shell: "var(--shell)",
+  c: "var(--c)",
+  python_ai: "var(--python)",
+};
+
+/* ------------------------------------------------------------------ */
+/*  Components                                                         */
+/* ------------------------------------------------------------------ */
+
+function TalentNode({
+  mod,
+  state,
+  trackColor,
+  isLast,
+}: {
+  mod: ModuleItem;
+  state: ModuleState;
+  trackColor: string;
+  isLast: boolean;
+}) {
+  const phaseLabel = mod.phase.charAt(0).toUpperCase() + mod.phase.slice(1);
+
+  return (
+    <div className="talent-node-wrapper">
+      <div className={`talent-node talent-node--${state}`}>
+        <div className="talent-node-icon" style={{ color: state === "locked" ? "var(--muted)" : trackColor }}>
+          {STATE_ICON[state]}
+        </div>
+        <div className="talent-node-body">
+          <div className="talent-node-header">
+            <Link href={`/modules/${mod.id}`} className="talent-node-title">
+              {mod.title}
+            </Link>
+            <div className="talent-node-badges">
+              <Pill>{phaseLabel}</Pill>
+              {mod.estimated_hours != null && <Pill>{mod.estimated_hours}h</Pill>}
+            </div>
+          </div>
+          <p className="talent-node-deliverable">{mod.deliverable}</p>
+          <div className="stack-list">
+            {mod.skills.slice(0, 5).map((skill) => (
+              <Pill key={skill}>{skill}</Pill>
+            ))}
+            {mod.skills.length > 5 && <Pill>+{mod.skills.length - 5}</Pill>}
+          </div>
+          {(mod.objectives ?? []).length > 0 && (
+            <ul className="talent-node-objectives">
+              {(mod.objectives ?? []).slice(0, 3).map((obj) => (
+                <li key={obj}>{obj}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+      {!isLast && (
+        <div className="talent-edge" style={{ borderColor: trackColor }} />
+      )}
+    </div>
+  );
+}
+
+function TrackTree({
+  track,
+  activeTrack,
+  activeModule,
+}: {
+  track: TrackItem;
+  activeTrack: string | undefined;
+  activeModule: string | undefined;
+}) {
+  const trackColor = TRACK_COLORS[track.id] ?? "var(--accent)";
+  const phases = [...new Set(track.modules.map((m) => m.phase))].sort(
+    (a, b) => (PHASE_ORDER[a] ?? 99) - (PHASE_ORDER[b] ?? 99),
+  );
+
+  const doneCount = track.modules.filter(
+    (m) => deriveModuleState(m.id, track.id, activeTrack, activeModule, track.modules) === "done",
+  ).length;
+  const pct = track.modules.length > 0 ? Math.round((doneCount / track.modules.length) * 100) : 0;
+
+  return (
+    <article className="talent-track">
+      <div className="talent-track-header" style={{ borderLeftColor: trackColor }}>
+        <div>
+          <p className="eyebrow">{track.id}</p>
+          <h2>{track.title}</h2>
+          <p className="muted">{track.summary}</p>
+        </div>
+        <div className="talent-track-progress">
+          <div className="talent-track-bar">
+            <div
+              className="talent-track-bar-fill"
+              style={{ width: `${pct}%`, backgroundColor: trackColor }}
+            />
+          </div>
+          <span className="muted">
+            {doneCount}/{track.modules.length} modules &middot; {pct}%
+          </span>
+        </div>
+      </div>
+
+      {phases.map((phase) => {
+        const phaseModules = track.modules.filter((m) => m.phase === phase);
+        const phaseLabel = phase.charAt(0).toUpperCase() + phase.slice(1);
+        return (
+          <div key={phase} className="talent-phase">
+            <div className="talent-phase-label">{phaseLabel}</div>
+            <div className="talent-phase-nodes">
+              {phaseModules.map((mod, idx) => {
+                const state = deriveModuleState(mod.id, track.id, activeTrack, activeModule, track.modules);
+                const isLastInPhase = idx === phaseModules.length - 1;
+                const isLastPhase = phase === phases[phases.length - 1];
+                return (
+                  <TalentNode
+                    key={mod.id}
+                    mod={mod}
+                    state={state}
+                    trackColor={trackColor}
+                    isLast={isLastInPhase && isLastPhase}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </article>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
+
+export default async function TracksPage() {
+  const data = await getDashboardData();
+  const { curriculum, progression } = data;
+  const activeTrack = progression.learning_plan?.active_course;
+  const activeModule = progression.learning_plan?.active_module;
+
+  const totalModules = curriculum.tracks.reduce((sum, t) => sum + t.modules.length, 0);
+
+  return (
+    <main className="page-shell">
+      <nav className="breadcrumb">
+        <Link href="/">Dashboard</Link>
+        <span className="breadcrumb-sep">/</span>
+        <span>Tracks</span>
+      </nav>
+
+      <section className="panel talent-hero">
+        <p className="eyebrow">Track Explorer</p>
+        <h1>RPG Talent Tree</h1>
+        <p className="lead">
+          Navigate through {curriculum.tracks.length} tracks and {totalModules} modules.
+          Complete modules to unlock the next tier and progress through foundation, practice, core and advanced phases.
+        </p>
+        <div className="talent-legend">
+          <span><span className="talent-legend-icon" style={{ color: "var(--accent)" }}>◆</span> Done</span>
+          <span><span className="talent-legend-icon" style={{ color: "var(--shell)" }}>▶</span> In progress</span>
+          <span><span className="talent-legend-icon">○</span> Available</span>
+          <span><span className="talent-legend-icon" style={{ color: "var(--muted)" }}>◇</span> Locked</span>
+        </div>
+      </section>
+
+      <section className="talent-trees">
+        {curriculum.tracks.map((track) => (
+          <TrackTree
+            key={track.id}
+            track={track}
+            activeTrack={activeTrack}
+            activeModule={activeModule}
+          />
+        ))}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- New page at `/tracks` rendering an RPG-style talent tree for all curriculum tracks
- Each track displays as a vertical tree grouped by phase (foundation → practice → core → advanced)
- Module nodes show state (done ◆ / in progress ▶ / available ○ / locked ◇), skills, deliverable, objectives
- Per-track progress bar with completion percentage
- Dashed connector edges between sequential nodes
- Responsive layout with mobile breakpoints

## Files changed
- `apps/web/app/tracks/page.tsx` — new page with `TrackTree`, `TalentNode` components
- `apps/web/app/globals.css` — talent tree CSS (~200 lines)

## Test plan
- [x] `tsc --noEmit` passes (no type errors)
- [x] `eslint .` passes
- [x] No backend changes — frontend only

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)