### PR TITLE
feat: dashboard with skill graph and tmux session indicators

### DIFF
--- a/apps/web/app/components/NavHeader.tsx
+++ b/apps/web/app/components/NavHeader.tsx
@@ -4,7 +4,8 @@ import { AuthStatus } from "@/app/components/AuthStatus";
 import { getDashboardData } from "@/lib/api";
 
 const NAV_LINKS = [
-  { href: "/", label: "Dashboard" },
+  { href: "/", label: "Home" },
+  { href: "/dashboard", label: "Skills" },
   { href: "/progression", label: "Progression" },
   { href: "/defense", label: "Defense" },
   { href: "/review", label: "Review" },

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,271 @@
+import Link from "next/link";
+
+import { getDashboardData, getTmuxSessions } from "@/lib/api";
+import type { ModuleItem, TrackItem } from "@/lib/api";
+import { TmuxSessions } from "@/app/components/TmuxSessions";
+
+/* ------------------------------------------------------------------ */
+/*  Prerequisite map (same as module detail page)                      */
+/* ------------------------------------------------------------------ */
+
+const PREREQUISITE_MAP: Record<string, string[]> = {
+  "shell-basics": [],
+  "shell-streams": ["shell-basics"],
+  "shell-permissions": ["shell-basics"],
+  "shell-tooling": ["shell-streams", "shell-permissions"],
+  "c-basics": ["shell-basics"],
+  "c-memory": ["c-basics"],
+  "c-build-debug": ["c-basics", "shell-streams"],
+  "c-libft-pushswap-bridge": ["c-memory", "c-build-debug"],
+  "python-basics": ["shell-basics"],
+  "python-oop-scripting": ["python-basics"],
+  "ai-rag-agents": ["python-oop-scripting"],
+};
+
+/* ------------------------------------------------------------------ */
+/*  Skill state derivation                                             */
+/* ------------------------------------------------------------------ */
+
+type SkillState = "done" | "in_progress" | "todo";
+type ModuleState = "done" | "in_progress" | "todo";
+
+function deriveModuleState(
+  moduleId: string,
+  trackId: string,
+  activeTrack: string,
+  activeModule: string,
+  modules: ModuleItem[],
+): ModuleState {
+  if (trackId !== activeTrack) return "todo";
+  if (moduleId === activeModule) return "in_progress";
+  const activeIndex = modules.findIndex((m) => m.id === activeModule);
+  const currentIndex = modules.findIndex((m) => m.id === moduleId);
+  if (activeIndex === -1) return "todo";
+  return currentIndex < activeIndex ? "done" : "todo";
+}
+
+function deriveSkillState(
+  skill: string,
+  completedItems: string[],
+  inProgressItems: string[],
+): SkillState {
+  const lower = skill.toLowerCase();
+  if (completedItems.some((c) => c.toLowerCase().includes(lower))) return "done";
+  if (inProgressItems.some((c) => c.toLowerCase().includes(lower))) return "in_progress";
+  return "todo";
+}
+
+function stateLabel(state: ModuleState): string {
+  switch (state) {
+    case "done": return "Completed";
+    case "in_progress": return "In progress";
+    case "todo": return "Not started";
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Stat helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+type TrackStats = {
+  total: number;
+  done: number;
+  inProgress: number;
+};
+
+function computeTrackStats(
+  track: TrackItem,
+  activeTrack: string,
+  activeModule: string,
+): TrackStats {
+  let done = 0;
+  let inProgress = 0;
+  for (const mod of track.modules) {
+    const state = deriveModuleState(mod.id, track.id, activeTrack, activeModule, track.modules);
+    if (state === "done") done++;
+    else if (state === "in_progress") inProgress++;
+  }
+  return { total: track.modules.length, done, inProgress };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
+
+export default async function DashboardPage() {
+  const [data, tmuxData] = await Promise.all([getDashboardData(), getTmuxSessions()]);
+  const { curriculum, progression } = data;
+
+  const activeTrack = progression.learning_plan?.active_course ?? "shell";
+  const activeModule = progression.learning_plan?.active_module ?? "";
+  const completedItems = progression.progress?.completed ?? [];
+  const inProgressItems = progression.progress?.in_progress ?? [];
+
+  const totalSkills = curriculum.tracks.reduce(
+    (sum, t) => sum + t.modules.reduce((s, m) => s + m.skills.length, 0),
+    0,
+  );
+  const totalModules = curriculum.tracks.reduce((sum, t) => sum + t.modules.length, 0);
+
+  return (
+    <main className="page-shell dashboard-page">
+      {/* Hero */}
+      <section className="dashboard-hero panel">
+        <div className="dashboard-hero-copy">
+          <p className="eyebrow">Skill Dashboard</p>
+          <h1>Competency map across all tracks</h1>
+          <p className="lead">
+            Visual overview of every skill in the curriculum, organized by track and module.
+            Each node reflects your current progression state.
+          </p>
+        </div>
+        <div className="dashboard-hero-stats">
+          <div className="metric-card">
+            <span>Tracks</span>
+            <strong>{curriculum.tracks.length}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Modules</span>
+            <strong>{totalModules}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Skills</span>
+            <strong>{totalSkills}</strong>
+          </div>
+          <div className="metric-card">
+            <span>Active</span>
+            <strong>{activeTrack}</strong>
+          </div>
+        </div>
+      </section>
+
+      {/* Main body: skill graph + sidebar */}
+      <section className="section split dashboard-body">
+        <div className="dashboard-main">
+          {curriculum.tracks.map((track) => {
+            const stats = computeTrackStats(track, activeTrack, activeModule);
+            const pct = stats.total > 0 ? Math.round((stats.done / stats.total) * 100) : 0;
+
+            return (
+              <article key={track.id} className="panel dashboard-track">
+                <div className="dashboard-track-header">
+                  <div>
+                    <p className="eyebrow">{track.id} track</p>
+                    <h2>{track.title}</h2>
+                    <p className="muted">{track.summary}</p>
+                  </div>
+                  <div className="dashboard-track-progress">
+                    <span className="dashboard-track-pct">{pct}%</span>
+                    <div className="progress-bar">
+                      <div
+                        className="progress-bar-fill"
+                        style={{
+                          width: `${pct}%`,
+                          background: `var(--${track.id === "python_ai" ? "python" : track.id})`,
+                        }}
+                      />
+                    </div>
+                    <span className="muted">
+                      {stats.done}/{stats.total} modules
+                    </span>
+                  </div>
+                </div>
+
+                <div className="skill-graph">
+                  {track.modules.map((mod) => {
+                    const modState = deriveModuleState(
+                      mod.id, track.id, activeTrack, activeModule, track.modules,
+                    );
+                    const prereqs = mod.prerequisites ?? PREREQUISITE_MAP[mod.id] ?? [];
+
+                    return (
+                      <div key={mod.id} className="skill-graph-node-group">
+                        {/* Module header node */}
+                        <Link
+                          href={`/modules/${mod.id}`}
+                          className={`skill-graph-module skill-graph-module--${modState}`}
+                        >
+                          <div className="skill-graph-module-header">
+                            <span className={`skill-graph-dot skill-graph-dot--${modState}`} />
+                            <strong>{mod.title}</strong>
+                            <span className="skill-graph-state">{stateLabel(modState)}</span>
+                          </div>
+                          {prereqs.length > 0 && (
+                            <div className="skill-graph-prereqs">
+                              {prereqs.map((p) => (
+                                <span key={p} className="skill-graph-prereq-tag">{p}</span>
+                              ))}
+                            </div>
+                          )}
+                        </Link>
+
+                        {/* Skill nodes under this module */}
+                        <div className="skill-graph-skills">
+                          {mod.skills.map((skill) => {
+                            const ss = modState === "todo"
+                              ? "todo"
+                              : deriveSkillState(skill, completedItems, inProgressItems);
+                            return (
+                              <div
+                                key={skill}
+                                className={`skill-graph-skill skill-graph-skill--${ss}`}
+                              >
+                                <span className={`skill-graph-skill-dot skill-graph-skill-dot--${ss}`} />
+                                <span>{skill}</span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+
+        {/* Sidebar: tmux sessions + legend */}
+        <aside className="dashboard-sidebar">
+          <article className="panel">
+            <p className="eyebrow">Agent Sessions</p>
+            <h2>Tmux workspace</h2>
+            <TmuxSessions sessions={tmuxData.sessions} />
+          </article>
+
+          <article className="panel">
+            <p className="eyebrow">Legend</p>
+            <h2>Skill states</h2>
+            <div className="dashboard-legend">
+              <div className="dashboard-legend-item">
+                <span className="skill-graph-dot skill-graph-dot--done" />
+                <span>Completed</span>
+              </div>
+              <div className="dashboard-legend-item">
+                <span className="skill-graph-dot skill-graph-dot--in_progress" />
+                <span>In progress</span>
+              </div>
+              <div className="dashboard-legend-item">
+                <span className="skill-graph-dot skill-graph-dot--todo" />
+                <span>Not started</span>
+              </div>
+            </div>
+          </article>
+
+          <article className="panel">
+            <p className="eyebrow">Current focus</p>
+            <h2>Active session</h2>
+            <p>{progression.progress?.current_exercise ?? "No active exercise"}</p>
+            <p className="muted">{progression.progress?.current_step ?? "No current step"}</p>
+            {progression.next_command && (
+              <div className="dashboard-next-cmd">
+                <span className="muted">Next command</span>
+                <code className="prog-code">{progression.next_command}</code>
+              </div>
+            )}
+          </article>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -433,6 +433,259 @@ a {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Dashboard skill graph (Issue #185)                                  */
+/* ------------------------------------------------------------------ */
+
+.dashboard-page {
+  max-width: 1300px;
+}
+
+.dashboard-hero {
+  display: grid;
+  gap: 20px;
+}
+
+.dashboard-hero-copy h1 {
+  margin: 8px 0 6px;
+  font-size: clamp(1.6rem, 3.5vw, 2.4rem);
+  line-height: 1.1;
+}
+
+.dashboard-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.dashboard-body {
+  align-items: start;
+}
+
+.dashboard-main {
+  display: grid;
+  gap: 20px;
+}
+
+.dashboard-sidebar {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.dashboard-track {
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-track-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.dashboard-track-header h2 {
+  margin: 4px 0 0;
+}
+
+.dashboard-track-progress {
+  display: grid;
+  gap: 6px;
+  min-width: 120px;
+  text-align: right;
+}
+
+.dashboard-track-pct {
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* Skill graph layout */
+
+.skill-graph {
+  display: grid;
+  gap: 14px;
+}
+
+.skill-graph-node-group {
+  display: grid;
+  gap: 8px;
+}
+
+.skill-graph-module {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.5);
+  text-decoration: none;
+  color: var(--ink);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.skill-graph-module:hover {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.skill-graph-module--done {
+  border-left: 4px solid var(--python);
+}
+
+.skill-graph-module--in_progress {
+  border-left: 4px solid var(--accent);
+  background: rgba(216, 166, 87, 0.06);
+}
+
+.skill-graph-module--todo {
+  border-left: 4px solid var(--line);
+  opacity: 0.75;
+}
+
+.skill-graph-module-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.skill-graph-module-header strong {
+  flex: 1;
+  min-width: 0;
+}
+
+.skill-graph-state {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.skill-graph-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.skill-graph-dot--done {
+  background: var(--python);
+}
+
+.skill-graph-dot--in_progress {
+  background: var(--accent);
+  animation: pulse 2s infinite;
+}
+
+.skill-graph-dot--todo {
+  background: var(--line);
+}
+
+.skill-graph-prereqs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.skill-graph-prereq-tag {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: rgba(28, 26, 23, 0.06);
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+}
+
+/* Skill nodes */
+
+.skill-graph-skills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-left: 20px;
+}
+
+.skill-graph-skill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.4);
+  font-size: 13px;
+}
+
+.skill-graph-skill--done {
+  background: rgba(53, 95, 59, 0.08);
+  border-color: rgba(53, 95, 59, 0.18);
+}
+
+.skill-graph-skill--in_progress {
+  background: rgba(216, 166, 87, 0.1);
+  border-color: rgba(216, 166, 87, 0.25);
+}
+
+.skill-graph-skill--todo {
+  opacity: 0.6;
+}
+
+.skill-graph-skill-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skill-graph-skill-dot--done {
+  background: var(--python);
+}
+
+.skill-graph-skill-dot--in_progress {
+  background: var(--accent);
+}
+
+.skill-graph-skill-dot--todo {
+  background: var(--line);
+}
+
+/* Legend */
+
+.dashboard-legend {
+  display: grid;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.dashboard-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+}
+
+.dashboard-next-cmd {
+  display: grid;
+  gap: 4px;
+  margin-top: 10px;
+}
+
+@media (min-width: 600px) {
+  .dashboard-hero-stats {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .dashboard-body {
+    grid-template-columns: 1.4fr 0.6fr;
+  }
+}
+
+/* ------------------------------------------------------------------ */
 /*  Progression page                                                   */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## Summary

Closes #185

New `/dashboard` page providing a visual competency map with tmux workspace status.

- **Skill graph** (`apps/web/app/dashboard/page.tsx`): Server component showing all skills organized by track and module. Each module is a clickable node (links to `/modules/{id}`) with a colored left border reflecting state (done=green, in_progress=amber, todo=grey). Skills appear as smaller nodes beneath their parent module. Prerequisite tags displayed on each module. Per-track progress bar with percentage.
- **Tmux session indicators**: Sidebar reuses the existing `TmuxSessions` component to show active agent sessions (mentor, librarian, reviewer, examiner, orchestrator).
- **Additional sidebar panels**: Skill state legend, current session focus with next command.
- **Navigation**: NavHeader updated — "Dashboard" renamed to "Home", new "Skills" link points to `/dashboard`.
- **CSS**: ~190 lines of dashboard-specific styles in `globals.css` — skill graph nodes, module state variants, responsive grid (2-column on desktop).

No API changes. No new dependencies.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint .` — clean
- [ ] Manual: navigate to `/dashboard`, verify skill graph renders all tracks/modules/skills with correct states, click module nodes to navigate to detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)