### PR TITLE
feat: defense session with terminal-aware Q&A (#188)

### DIFF
--- a/apps/web/app/defense/DefenseClient.tsx
+++ b/apps/web/app/defense/DefenseClient.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 
+import { TerminalPane } from "@/app/components/TerminalPane";
+
 /* ------------------------------------------------------------------ */
 /*  Types matching the AI Gateway defense API                          */
 /* ------------------------------------------------------------------ */
@@ -73,20 +75,28 @@ type ModuleOption = {
   trackTitle: string;
 };
 
+type TmuxSessionOption = {
+  name: string;
+  status: string;
+  attached: boolean;
+};
+
 type Props = {
   modules: ModuleOption[];
   apiUrl: string;
+  tmuxSessions?: TmuxSessionOption[];
 };
 
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
-export default function DefenseClient({ modules, apiUrl }: Props) {
+export default function DefenseClient({ modules, apiUrl, tmuxSessions = [] }: Props) {
   /* Setup state */
   const [selectedModule, setSelectedModule] = useState(modules[0]?.id ?? "");
   const [numQuestions, setNumQuestions] = useState(3);
   const [timeLimit, setTimeLimit] = useState(60);
+  const [selectedTmux, setSelectedTmux] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -147,6 +157,24 @@ export default function DefenseClient({ modules, apiUrl }: Props) {
     const modulePhase = currentModule?.phase ?? "foundation";
 
     try {
+      /* Capture terminal context if a tmux session is selected */
+      let terminalContext: Record<string, unknown> | undefined;
+      if (selectedTmux) {
+        try {
+          const paneRes = await fetch(
+            `${apiUrl}/api/v1/tmux/pane/${encodeURIComponent(selectedTmux)}`
+          );
+          if (paneRes.ok) {
+            const pane = await paneRes.json();
+            terminalContext = {
+              panes: { [selectedTmux]: pane.content },
+            };
+          }
+        } catch {
+          /* Terminal context is optional — proceed without it */
+        }
+      }
+
       const res = await fetch(`${apiUrl}/api/v1/defense/start`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -156,6 +184,7 @@ export default function DefenseClient({ modules, apiUrl }: Props) {
           phase: modulePhase,
           num_questions: numQuestions,
           question_time_limit_seconds: timeLimit,
+          ...(terminalContext && { terminal_context: terminalContext }),
         }),
       });
 
@@ -342,6 +371,23 @@ export default function DefenseClient({ modules, apiUrl }: Props) {
             </label>
           </div>
 
+          {tmuxSessions.length > 0 && (
+            <label className="defense-field">
+              <span>Terminal session (optional)</span>
+              <select
+                value={selectedTmux}
+                onChange={(e) => setSelectedTmux(e.target.value)}
+              >
+                <option value="">None — no terminal context</option>
+                {tmuxSessions.map((s) => (
+                  <option key={s.name} value={s.name}>
+                    {s.name} ({s.status}{s.attached ? ", attached" : ""})
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
           <button
             className="action-btn"
             onClick={handleStart}
@@ -362,8 +408,8 @@ export default function DefenseClient({ modules, apiUrl }: Props) {
     const timerWarning = secondsLeft <= 15 && secondsLeft > 0;
     const timerCritical = secondsLeft <= 5;
 
-    return (
-      <section className="defense-active">
+    const qaColumn = (
+      <div className="defense-qa-column">
         {/* Progress bar */}
         <div className="defense-progress panel">
           <div className="defense-progress-header">
@@ -434,6 +480,17 @@ export default function DefenseClient({ modules, apiUrl }: Props) {
             >
               {submitting ? "Submitting..." : "Submit answer"}
             </button>
+          </div>
+        )}
+      </div>
+    );
+
+    return (
+      <section className={`defense-active ${selectedTmux ? "defense-active--split" : ""}`}>
+        {qaColumn}
+        {selectedTmux && (
+          <div className="defense-terminal-column">
+            <TerminalPane session={selectedTmux} />
           </div>
         )}
       </section>

--- a/apps/web/app/defense/page.tsx
+++ b/apps/web/app/defense/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { getDashboardData } from "@/lib/api";
+import { getDashboardData, getTmuxSessions } from "@/lib/api";
 
 import DefenseClient from "./DefenseClient";
 
@@ -25,6 +25,14 @@ export default async function DefensePage() {
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
+  /* Fetch available tmux sessions so the learner can attach terminal context */
+  const tmuxData = await getTmuxSessions();
+  const tmuxSessions = tmuxData.sessions.map((s) => ({
+    name: s.name,
+    status: s.status,
+    attached: s.attached,
+  }));
+
   return (
     <main className="page-shell defense-page">
       <nav className="breadcrumb">
@@ -44,7 +52,7 @@ export default async function DefensePage() {
         </p>
       </section>
 
-      <DefenseClient modules={modules} apiUrl={apiUrl} />
+      <DefenseClient modules={modules} apiUrl={apiUrl} tmuxSessions={tmuxSessions} />
     </main>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1620,6 +1620,10 @@ a {
   max-width: 900px;
 }
 
+.defense-page:has(.defense-active--split) {
+  max-width: 1400px;
+}
+
 .defense-hero h1 {
   margin: 0 0 8px;
   font-size: clamp(1.8rem, 4vw, 2.8rem);
@@ -1675,6 +1679,30 @@ a {
 .defense-active {
   display: grid;
   gap: 16px;
+}
+
+.defense-active--split {
+  grid-template-columns: 1fr 1fr;
+  align-items: start;
+}
+
+.defense-qa-column {
+  display: grid;
+  gap: 16px;
+}
+
+.defense-terminal-column {
+  position: sticky;
+  top: 80px;
+}
+
+@media (max-width: 900px) {
+  .defense-active--split {
+    grid-template-columns: 1fr;
+  }
+  .defense-terminal-column {
+    position: static;
+  }
 }
 
 .defense-progress {


### PR DESCRIPTION
## Summary
- **Terminal selector in setup**: optional tmux session picker populated from `/api/v1/tmux/sessions`
- **Split layout during active phase**: Q&A column + live `TerminalPane` side-by-side when a session is selected
- **Terminal context sent to backend**: pane content captured at start and passed as `terminal_context` to `POST /defense/start` for context-aware question generation
- **Responsive**: stacks on mobile (<900px), sticky terminal on desktop, page widens to 1400px in split mode

## Changes
- `apps/web/app/defense/page.tsx` — fetch tmux sessions server-side, pass to client
- `apps/web/app/defense/DefenseClient.tsx` — tmux selector, split layout with `TerminalPane`, terminal context capture
- `apps/web/app/globals.css` — `.defense-active--split`, `.defense-qa-column`, `.defense-terminal-column` + responsive rules

## Test plan
- [x] API tests: 245 passed (2 pre-existing Alembic failures)
- [x] AI gateway tests: 245 passed
- [x] Ruff: clean on both services
- [ ] Web build: pre-existing Turbopack issue on local host (CI should pass)

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)