### PR TITLE
feat: implement module learning with tabbed terminal viewer and objectives (#187)

### DIFF
--- a/apps/web/app/components/TabbedTerminalViewer.tsx
+++ b/apps/web/app/components/TabbedTerminalViewer.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type PaneData = {
+  session: string;
+  content: string;
+  rows: number;
+  cols: number;
+  timestamp: string;
+};
+
+const POLL_INTERVAL_MS = 2000;
+const TABS = ["work", "build", "tests"] as const;
+type TabName = (typeof TABS)[number];
+
+export function TabbedTerminalViewer({ sessionPrefix }: { sessionPrefix: string }) {
+  const [activeTab, setActiveTab] = useState<TabName>("work");
+  const [panes, setPanes] = useState<Record<TabName, PaneData | null>>({
+    work: null,
+    build: null,
+    tests: null,
+  });
+  const [errors, setErrors] = useState<Record<TabName, string | null>>({
+    work: null,
+    build: null,
+    tests: null,
+  });
+  const [lastActivity, setLastActivity] = useState<Record<TabName, number>>({
+    work: 0,
+    build: 0,
+    tests: 0,
+  });
+  const [paused, setPaused] = useState(false);
+  const preRef = useRef<HTMLPreElement>(null);
+
+  const fetchPane = useCallback(
+    async (tab: TabName) => {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+      const session = `${sessionPrefix}:${tab}`;
+      try {
+        const resp = await fetch(`${apiUrl}/api/v1/tmux/pane/${encodeURIComponent(session)}`);
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({ detail: `HTTP ${resp.status}` }));
+          setErrors((prev) => ({ ...prev, [tab]: body.detail ?? `HTTP ${resp.status}` }));
+          return;
+        }
+        const payload = (await resp.json()) as PaneData;
+        setPanes((prev) => {
+          const oldContent = prev[tab]?.content;
+          if (oldContent !== payload.content) {
+            setLastActivity((la) => ({ ...la, [tab]: Date.now() }));
+          }
+          return { ...prev, [tab]: payload };
+        });
+        setErrors((prev) => ({ ...prev, [tab]: null }));
+      } catch {
+        setErrors((prev) => ({ ...prev, [tab]: "Cannot reach API" }));
+      }
+    },
+    [sessionPrefix],
+  );
+
+  useEffect(() => {
+    if (paused) return;
+
+    const fetchAll = () => TABS.forEach((tab) => fetchPane(tab));
+    fetchAll();
+    const id = setInterval(fetchAll, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [fetchPane, paused]);
+
+  useEffect(() => {
+    if (preRef.current) {
+      preRef.current.scrollTop = preRef.current.scrollHeight;
+    }
+  }, [panes, activeTab]);
+
+  const mostRecentTab = TABS.reduce((a, b) => (lastActivity[a] >= lastActivity[b] ? a : b));
+
+  const activeData = panes[activeTab];
+  const activeError = errors[activeTab];
+
+  return (
+    <article className="panel terminal-viewer">
+      <div className="terminal-viewer-tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab}
+            className={`terminal-viewer-tab${tab === activeTab ? " terminal-viewer-tab--active" : ""}${tab === mostRecentTab && lastActivity[tab] > 0 ? " terminal-viewer-tab--recent" : ""}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+        <div className="terminal-viewer-spacer" />
+        <span className="terminal-pane-session">
+          {sessionPrefix}:{activeTab}
+        </span>
+        <button
+          className="terminal-pane-toggle"
+          onClick={() => setPaused((p) => !p)}
+          title={paused ? "Resume polling" : "Pause polling"}
+        >
+          {paused ? "Resume" : "Pause"}
+        </button>
+      </div>
+
+      {activeError ? (
+        <div className="terminal-pane-error">{activeError}</div>
+      ) : (
+        <pre
+          ref={preRef}
+          className="terminal-pane-content"
+          style={{
+            minHeight: activeData ? `${Math.min(activeData.rows, 24) * 1.3}em` : "12em",
+          }}
+        >
+          {activeData?.content ?? "Connecting..."}
+        </pre>
+      )}
+    </article>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1613,6 +1613,142 @@ a {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Tabbed terminal viewer                                             */
+/* ------------------------------------------------------------------ */
+
+.terminal-viewer {
+  display: grid;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid rgba(28, 26, 23, 0.18);
+}
+
+.terminal-viewer-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 0 12px;
+  background: rgba(28, 26, 23, 0.04);
+  border-bottom: 1px solid var(--line);
+}
+
+.terminal-viewer-tab {
+  padding: 10px 16px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.terminal-viewer-tab:hover {
+  color: var(--ink);
+}
+
+.terminal-viewer-tab--active {
+  color: var(--shell);
+  border-bottom-color: var(--shell);
+}
+
+.terminal-viewer-tab--recent:not(.terminal-viewer-tab--active) {
+  color: var(--accent);
+}
+
+.terminal-viewer-spacer {
+  flex: 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Checklist (objectives & skills)                                    */
+/* ------------------------------------------------------------------ */
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.checklist-item {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+
+.checklist-item--done {
+  color: var(--muted);
+}
+
+.checklist-box {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: 1.5px solid var(--line);
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.checklist-item--done .checklist-box {
+  border-color: var(--shell);
+  color: var(--shell);
+  background: rgba(28, 93, 99, 0.08);
+}
+
+.checklist-badge {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(216, 166, 87, 0.1);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Module action buttons                                              */
+/* ------------------------------------------------------------------ */
+
+.module-actions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.action-btn--secondary {
+  background: var(--panel);
+  color: var(--ink);
+  border: 1.5px solid var(--line);
+  text-align: center;
+  text-decoration: none;
+  padding: 10px 18px;
+  font-weight: 600;
+  font-size: 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.action-btn--secondary:hover {
+  background: rgba(28, 26, 23, 0.05);
+}
+
+/* ------------------------------------------------------------------ */
 /*  Defense page                                                       */
 /* ------------------------------------------------------------------ */
 

--- a/apps/web/app/modules/[id]/page.tsx
+++ b/apps/web/app/modules/[id]/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { getDashboardData } from "@/lib/api";
 import type { ModuleItem } from "@/lib/api";
 import { SourcePolicyBadge } from "@/app/components/SourcePolicyBadge";
-import { TerminalPane } from "@/app/components/TerminalPane";
+import { TabbedTerminalViewer } from "@/app/components/TabbedTerminalViewer";
 import { isDisplayableSourcePolicyTier } from "@/lib/sourcePolicy";
 
 /* ------------------------------------------------------------------ */
@@ -196,34 +196,40 @@ export default async function ModuleDetailPage({
       {/* Two-column body */}
       <section className="section split module-detail-body">
         <div className="module-detail-main">
-          {/* Objectives (if enriched data available) */}
+          {/* Objectives checklist */}
           {foundModule.objectives && foundModule.objectives.length > 0 && (
             <article className="panel">
               <p className="eyebrow">Objectives</p>
-              <ul className="objective-list">
-                {foundModule.objectives.map((obj) => (
-                  <li key={obj}>{obj}</li>
-                ))}
+              <ul className="checklist">
+                {foundModule.objectives.map((obj) => {
+                  const done = completedItems.some((c) => c.toLowerCase().includes(obj.toLowerCase().split(" ")[0]));
+                  return (
+                    <li key={obj} className={`checklist-item${done ? " checklist-item--done" : ""}`}>
+                      <span className="checklist-box">{done ? "\u2713" : "\u00A0"}</span>
+                      <span>{obj}</span>
+                    </li>
+                  );
+                })}
               </ul>
             </article>
           )}
 
-          {/* Skills */}
+          {/* Skills checklist */}
           <article className="panel">
             <p className="eyebrow">Skills</p>
             <h2>Competencies to acquire</h2>
-            <div className="skill-grid">
+            <ul className="checklist">
               {foundModule.skills.map((skill) => {
                 const ss = state === "todo" ? "todo" : skillState(skill);
                 return (
-                  <div key={skill} className={`skill-item skill-item--${ss}`}>
-                    <span className="skill-indicator" />
+                  <li key={skill} className={`checklist-item${ss === "done" ? " checklist-item--done" : ""}`}>
+                    <span className="checklist-box">{ss === "done" ? "\u2713" : "\u00A0"}</span>
                     <span>{skill}</span>
-                    <span className="muted skill-state-label">{stateLabel(ss)}</span>
-                  </div>
+                    {ss === "in_progress" && <span className="checklist-badge">in progress</span>}
+                  </li>
                 );
               })}
-            </div>
+            </ul>
           </article>
 
           {/* Exit criteria (if enriched data available) */}
@@ -238,9 +244,9 @@ export default async function ModuleDetailPage({
             </article>
           )}
 
-          {/* Live terminal (visible when module is in progress) */}
+          {/* Live terminal viewer (visible when module is active) */}
           {state === "in_progress" && (
-            <TerminalPane session={id} />
+            <TabbedTerminalViewer sessionPrefix="learn42" />
           )}
         </div>
 
@@ -282,6 +288,27 @@ export default async function ModuleDetailPage({
               </div>
             )}
           </article>
+
+          {/* Actions */}
+          {state === "in_progress" && (
+            <article className="panel module-actions">
+              <p className="eyebrow">Actions</p>
+              <div className="module-actions-list">
+                <Link
+                  href={`/mentor?module_id=${id}&track_id=${foundTrackId}`}
+                  className="action-btn action-btn--secondary"
+                >
+                  Ask Mentor
+                </Link>
+                <Link
+                  href={`/defense?track_id=${foundTrackId}&module_id=${id}`}
+                  className="action-btn action-btn--in_progress"
+                >
+                  Start Defense
+                </Link>
+              </div>
+            </article>
+          )}
         </aside>
       </section>
     </main>


### PR DESCRIPTION
## Summary

- Add `TabbedTerminalViewer` client component — tabbed interface (work | build | tests) polling all 3 learn42 tmux panes simultaneously, with activity glow on the tab with most recent output
- Replace single `TerminalPane` with `TabbedTerminalViewer` on the module detail page when module is in progress
- Upgrade objectives and skills lists to checkbox-style checklists (`✓` done / ` ` pending) derived from progression state, with "in progress" badge for active skills
- Add **Ask Mentor** and **Start Defense** action links in sidebar (pre-loaded with track/module context via query params)
- CSS: tabbed terminal styles, checklist component, secondary action button variant — all using existing design tokens

## Files changed

| File | Change |
|---|---|
| `apps/web/app/components/TabbedTerminalViewer.tsx` | **New** — tabbed terminal viewer client component |
| `apps/web/app/modules/[id]/page.tsx` | Replace TerminalPane with TabbedTerminalViewer, upgrade objectives/skills to checklists, add action links |
| `apps/web/app/globals.css` | Tabbed terminal, checklist, and action button styles |

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] ESLint passes on changed files
- [x] Build error on `/_global-error` is pre-existing on develop (Next.js 16 + React 19 static export issue), not introduced by this PR
- [ ] Manual: verify tabbed terminal renders work/build/tests tabs when module is in_progress
- [ ] Manual: verify tab activity indicator highlights tab with most recent output
- [ ] Manual: verify objectives and skills show checkbox state from progression
- [ ] Manual: verify Ask Mentor and Start Defense links navigate with correct query params

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)