### PR TITLE
feat: semantic track and status CSS classes (#210)

### DIFF
--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -3,10 +3,10 @@ import Link from "next/link";
 import { getAnalyticsData } from "@/lib/api";
 import type { AnalyticsChartRow } from "@/lib/api";
 
-const TRACK_COLORS: Record<string, string> = {
-  shell: "var(--shell)",
-  c: "var(--c)",
-  python_ai: "var(--python)",
+const TRACK_CLASS: Record<string, string> = {
+  shell: "track-shell",
+  c: "track-c",
+  python_ai: "track-python",
 };
 
 function formatMinutes(value: number): string {
@@ -64,13 +64,10 @@ function AnalyticsBarChart({
                   </div>
                   <span className="analytics-bar-value">{formatter(row)}</span>
                 </div>
-                <div className="analytics-bar-track">
+                <div className={`analytics-bar-track ${TRACK_CLASS[row.track_id] ?? ""}`}>
                   <div
                     className="analytics-bar-fill"
-                    style={{
-                      width,
-                      backgroundColor: TRACK_COLORS[row.track_id] ?? "var(--accent)",
-                    }}
+                    style={{ width }}
                   />
                 </div>
               </div>

--- a/apps/web/app/components/TmuxSessions.tsx
+++ b/apps/web/app/components/TmuxSessions.tsx
@@ -1,15 +1,16 @@
 import type { TmuxSession } from "@/lib/api";
 
 function StatusDot({ status }: { status: TmuxSession["status"] }) {
-  const color = status === "active" ? "var(--python)" : "var(--muted)";
+  const cls = status === "active" ? "status-in-progress" : "status-locked";
   return (
     <span
+      className={cls}
       style={{
         display: "inline-block",
         width: 8,
         height: 8,
         borderRadius: "50%",
-        backgroundColor: color,
+        backgroundColor: "var(--status-color)",
         marginRight: 6,
       }}
     />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -17,6 +17,18 @@
 }
 
 /* ------------------------------------------------------------------ */
+/*  Semantic track & status classes                                    */
+/* ------------------------------------------------------------------ */
+
+.track-shell  { --track-color: var(--shell); }
+.track-c      { --track-color: var(--c); }
+.track-python { --track-color: var(--python); }
+
+.status-completed   { --status-color: var(--accent); }
+.status-in-progress { --status-color: var(--shell); }
+.status-locked      { --status-color: var(--muted); }
+
+/* ------------------------------------------------------------------ */
 /*  Reset & base (mobile-first)                                        */
 /* ------------------------------------------------------------------ */
 
@@ -225,6 +237,9 @@ a {
 .track-card:nth-child(1) { border-top: 6px solid var(--shell); }
 .track-card:nth-child(2) { border-top: 6px solid var(--c); }
 .track-card:nth-child(3) { border-top: 6px solid var(--python); }
+
+/* Semantic alternative: .track-card.track-shell etc. */
+.track-card[class*="track-"] { border-top: 6px solid var(--track-color); }
 
 .card-topline {
   display: flex;
@@ -718,6 +733,7 @@ a {
   height: 100%;
   border-radius: 3px;
   transition: width 0.3s ease;
+  background-color: var(--track-color, var(--accent));
 }
 
 .prog-next-action {
@@ -799,6 +815,7 @@ a {
   height: 100%;
   border-radius: 999px;
   transition: width 0.28s ease;
+  background-color: var(--track-color, var(--accent));
 }
 
 .prog-next-content h2 {
@@ -2371,6 +2388,10 @@ a {
   margin-right: 4px;
 }
 
+.talent-legend-icon.status-completed   { color: var(--status-color); }
+.talent-legend-icon.status-in-progress { color: var(--status-color); }
+.talent-legend-icon.status-locked      { color: var(--status-color); }
+
 .talent-trees {
   display: flex;
   flex-direction: column;
@@ -2386,7 +2407,7 @@ a {
 
 .talent-track-header {
   padding: 24px 28px;
-  border-left: 6px solid var(--accent);
+  border-left: 6px solid var(--track-color, var(--accent));
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -2416,6 +2437,7 @@ a {
   height: 100%;
   border-radius: 4px;
   transition: width 0.4s ease;
+  background-color: var(--track-color, var(--accent));
 }
 
 .talent-phase {
@@ -2476,6 +2498,11 @@ a {
   flex-shrink: 0;
   width: 24px;
   text-align: center;
+  color: var(--track-color, var(--accent));
+}
+
+.talent-node--locked .talent-node-icon {
+  color: var(--muted);
 }
 
 .talent-node-body {
@@ -2532,7 +2559,7 @@ a {
 .talent-edge {
   width: 2px;
   height: 12px;
-  border-left: 2px dashed var(--line);
+  border-left: 2px dashed var(--track-color, var(--line));
   margin-left: 35px;
 }
 

--- a/apps/web/app/progression/page.tsx
+++ b/apps/web/app/progression/page.tsx
@@ -59,10 +59,10 @@ function stateLabel(state: ModuleState): string {
   }
 }
 
-const TRACK_COLORS: Record<string, string> = {
-  shell: "var(--shell)",
-  c: "var(--c)",
-  python_ai: "var(--python)",
+const TRACK_CLASS: Record<string, string> = {
+  shell: "track-shell",
+  c: "track-c",
+  python_ai: "track-python",
 };
 
 /* ------------------------------------------------------------------ */
@@ -165,16 +165,13 @@ export default async function ProgressionPage() {
             <p className="muted">{totalDone} / {totalModules} modules</p>
           </div>
           {trackStats.map((ts) => (
-            <div key={ts.id} className="metric-card">
+            <div key={ts.id} className={`metric-card ${TRACK_CLASS[ts.id] ?? ""}`}>
               <span>{ts.title}</span>
               <strong>{ts.percent}%</strong>
               <div className="progress-bar">
                 <div
                   className="progress-bar-fill"
-                  style={{
-                    width: `${ts.percent}%`,
-                    backgroundColor: TRACK_COLORS[ts.id] ?? "var(--accent)",
-                  }}
+                  style={{ width: `${ts.percent}%` }}
                 />
               </div>
               <p className="muted">{ts.done} / {ts.total} modules</p>

--- a/apps/web/app/tracks/page.tsx
+++ b/apps/web/app/tracks/page.tsx
@@ -45,10 +45,10 @@ const STATE_ICON: Record<ModuleState, string> = {
   locked: "◇",
 };
 
-const TRACK_COLORS: Record<string, string> = {
-  shell: "var(--shell)",
-  c: "var(--c)",
-  python_ai: "var(--python)",
+const TRACK_CLASS: Record<string, string> = {
+  shell: "track-shell",
+  c: "track-c",
+  python_ai: "track-python",
 };
 
 /* ------------------------------------------------------------------ */
@@ -58,12 +58,10 @@ const TRACK_COLORS: Record<string, string> = {
 function TalentNode({
   mod,
   state,
-  trackColor,
   isLast,
 }: {
   mod: ModuleItem;
   state: ModuleState;
-  trackColor: string;
   isLast: boolean;
 }) {
   const phaseLabel = mod.phase.charAt(0).toUpperCase() + mod.phase.slice(1);
@@ -71,7 +69,7 @@ function TalentNode({
   return (
     <div className="talent-node-wrapper">
       <div className={`talent-node talent-node--${state}`}>
-        <div className="talent-node-icon" style={{ color: state === "locked" ? "var(--muted)" : trackColor }}>
+        <div className="talent-node-icon">
           {STATE_ICON[state]}
         </div>
         <div className="talent-node-body">
@@ -101,7 +99,7 @@ function TalentNode({
         </div>
       </div>
       {!isLast && (
-        <div className="talent-edge" style={{ borderColor: trackColor }} />
+        <div className="talent-edge" />
       )}
     </div>
   );
@@ -116,7 +114,7 @@ function TrackTree({
   activeTrack: string | undefined;
   activeModule: string | undefined;
 }) {
-  const trackColor = TRACK_COLORS[track.id] ?? "var(--accent)";
+  const trackCls = TRACK_CLASS[track.id] ?? "";
   const phases = [...new Set(track.modules.map((m) => m.phase))].sort(
     (a, b) => (PHASE_ORDER[a] ?? 99) - (PHASE_ORDER[b] ?? 99),
   );
@@ -127,8 +125,8 @@ function TrackTree({
   const pct = track.modules.length > 0 ? Math.round((doneCount / track.modules.length) * 100) : 0;
 
   return (
-    <article className="talent-track">
-      <div className="talent-track-header" style={{ borderLeftColor: trackColor }}>
+    <article className={`talent-track ${trackCls}`}>
+      <div className="talent-track-header">
         <div>
           <p className="eyebrow">{track.id}</p>
           <h2>{track.title}</h2>
@@ -138,7 +136,7 @@ function TrackTree({
           <div className="talent-track-bar">
             <div
               className="talent-track-bar-fill"
-              style={{ width: `${pct}%`, backgroundColor: trackColor }}
+              style={{ width: `${pct}%` }}
             />
           </div>
           <span className="muted">
@@ -163,7 +161,6 @@ function TrackTree({
                     key={mod.id}
                     mod={mod}
                     state={state}
-                    trackColor={trackColor}
                     isLast={isLastInPhase && isLastPhase}
                   />
                 );
@@ -204,10 +201,10 @@ export default async function TracksPage() {
           Complete modules to unlock the next tier and progress through foundation, practice, core and advanced phases.
         </p>
         <div className="talent-legend">
-          <span><span className="talent-legend-icon" style={{ color: "var(--accent)" }}>◆</span> Done</span>
-          <span><span className="talent-legend-icon" style={{ color: "var(--shell)" }}>▶</span> In progress</span>
+          <span><span className="talent-legend-icon status-completed">◆</span> Done</span>
+          <span><span className="talent-legend-icon status-in-progress">▶</span> In progress</span>
           <span><span className="talent-legend-icon">○</span> Available</span>
-          <span><span className="talent-legend-icon" style={{ color: "var(--muted)" }}>◇</span> Locked</span>
+          <span><span className="talent-legend-icon status-locked">◇</span> Locked</span>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Adds 6 semantic CSS classes that set CSS custom properties, replacing all inline `TRACK_COLORS` maps
- `.track-shell`, `.track-c`, `.track-python` → set `--track-color`
- `.status-completed`, `.status-in-progress`, `.status-locked` → set `--status-color`
- CSS rules for progress bars, analytics bars, talent tree nodes/edges/headers now read from `--track-color` with fallback
- Removes all `TRACK_COLORS` dictionaries and inline `style={{ backgroundColor }}` from 4 components

## Files changed
| File | Change |
|---|---|
| `globals.css` | Add semantic class definitions + update `.progress-bar-fill`, `.analytics-bar-fill`, `.talent-track-header`, `.talent-track-bar-fill`, `.talent-node-icon`, `.talent-edge`, `.talent-legend-icon` to use `--track-color` / `--status-color` |
| `tracks/page.tsx` | Replace `TRACK_COLORS` → `TRACK_CLASS`, remove `trackColor` prop from `TalentNode`, use class on `<article>` |
| `analytics/page.tsx` | Replace `TRACK_COLORS` → `TRACK_CLASS`, apply class to `.analytics-bar-track` parent |
| `progression/page.tsx` | Replace `TRACK_COLORS` → `TRACK_CLASS`, apply class to `.metric-card` |
| `TmuxSessions.tsx` | Replace inline color ternary with `.status-in-progress`/`.status-locked` class |

## Test plan
- [x] `tsc --noEmit` — no type errors
- [x] `eslint .` — no lint errors
- [x] No `TRACK_COLORS` references remain in `apps/web/`
- [x] Frontend only — no backend changes

Parent: #208
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)