### PR TITLE
fix: restore CSS custom property styles lost during rebase

### DIFF
--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -9,6 +9,12 @@ const TRACK_CLASS: Record<string, string> = {
   python_ai: "track-python",
 };
 
+const TRACK_COLORS: Record<string, string> = {
+  shell: "var(--shell)",
+  c: "var(--c)",
+  python_ai: "var(--python)",
+};
+
 function formatMinutes(value: number): string {
   if (value >= 60) {
     return `${(value / 60).toFixed(1)} h`;
@@ -67,7 +73,7 @@ function AnalyticsBarChart({
                 <div className={`analytics-bar-track ${TRACK_CLASS[row.track_id] ?? ""}`}>
                   <div
                     className="analytics-bar-fill"
-                    style={{ width }}
+                    style={{ "--bar-width": width, "--bar-color": TRACK_COLORS[row.track_id] ?? "var(--accent)" } as React.CSSProperties}
                   />
                 </div>
               </div>
@@ -94,7 +100,7 @@ export default async function AnalyticsPage() {
 
   return (
     <main className="page-shell">
-      <nav className="breadcrumb">
+      <nav className="breadcrumb" aria-label="Breadcrumb">
         <Link href="/">Dashboard</Link>
         <span className="breadcrumb-sep">/</span>
         <span>Analytics</span>

--- a/apps/web/app/progression/page.tsx
+++ b/apps/web/app/progression/page.tsx
@@ -65,6 +65,12 @@ const TRACK_CLASS: Record<string, string> = {
   python_ai: "track-python",
 };
 
+const TRACK_COLORS: Record<string, string> = {
+  shell: "var(--shell)",
+  c: "var(--c)",
+  python_ai: "var(--python)",
+};
+
 /* ------------------------------------------------------------------ */
 /*  Page                                                               */
 /* ------------------------------------------------------------------ */
@@ -142,7 +148,7 @@ export default async function ProgressionPage() {
   return (
     <main className="page-shell">
       {/* Breadcrumb */}
-      <nav className="breadcrumb">
+      <nav className="breadcrumb" aria-label="Breadcrumb">
         <Link href="/">Dashboard</Link>
         <span className="breadcrumb-sep">/</span>
         <span>Progression</span>
@@ -171,7 +177,7 @@ export default async function ProgressionPage() {
               <div className="progress-bar">
                 <div
                   className="progress-bar-fill"
-                  style={{ width: `${ts.percent}%` }}
+                  style={{ "--bar-width": `${ts.percent}%`, "--bar-color": TRACK_COLORS[ts.id] ?? "var(--accent)" } as React.CSSProperties}
                 />
               </div>
               <p className="muted">{ts.done} / {ts.total} modules</p>
@@ -232,7 +238,7 @@ export default async function ProgressionPage() {
           {/* Completed checklist */}
           {doneModules.length > 0 && (
             <>
-              <h2 style={{ marginTop: 24 }}>Completed ({doneModules.length})</h2>
+              <h2 className="section-heading-spaced">Completed ({doneModules.length})</h2>
               <div className="prog-checklist">
                 {doneModules.map((m) => (
                   <Link
@@ -297,7 +303,7 @@ export default async function ProgressionPage() {
           <h2>{progression.progress.current_exercise}</h2>
           <p>{progression.progress.current_step ?? ""}</p>
           {progression.next_command && (
-            <p style={{ marginTop: 8 }}>
+            <p className="section-note-spaced">
               Next command: <code className="prog-code">{progression.next_command}</code>
             </p>
           )}

--- a/apps/web/app/tracks/page.tsx
+++ b/apps/web/app/tracks/page.tsx
@@ -45,10 +45,10 @@ const STATE_ICON: Record<ModuleState, string> = {
   locked: "◇",
 };
 
-const TRACK_CLASS: Record<string, string> = {
-  shell: "track-shell",
-  c: "track-c",
-  python_ai: "track-python",
+const TRACK_COLORS: Record<string, string> = {
+  shell: "var(--shell)",
+  c: "var(--c)",
+  python_ai: "var(--python)",
 };
 
 /* ------------------------------------------------------------------ */
@@ -59,17 +59,19 @@ function TalentNode({
   mod,
   state,
   isLast,
+  trackColor,
 }: {
   mod: ModuleItem;
   state: ModuleState;
   isLast: boolean;
+  trackColor: string;
 }) {
   const phaseLabel = mod.phase.charAt(0).toUpperCase() + mod.phase.slice(1);
 
   return (
     <div className="talent-node-wrapper">
       <div className={`talent-node talent-node--${state}`}>
-        <div className="talent-node-icon">
+        <div className="talent-node-icon" style={{ "--track-color": state === "locked" ? "var(--muted)" : trackColor } as React.CSSProperties}>
           {STATE_ICON[state]}
         </div>
         <div className="talent-node-body">
@@ -99,7 +101,7 @@ function TalentNode({
         </div>
       </div>
       {!isLast && (
-        <div className="talent-edge" />
+        <div className="talent-edge" style={{ "--track-color": trackColor } as React.CSSProperties} />
       )}
     </div>
   );
@@ -114,7 +116,7 @@ function TrackTree({
   activeTrack: string | undefined;
   activeModule: string | undefined;
 }) {
-  const trackCls = TRACK_CLASS[track.id] ?? "";
+  const trackColor = TRACK_COLORS[track.id] ?? "var(--accent)";
   const phases = [...new Set(track.modules.map((m) => m.phase))].sort(
     (a, b) => (PHASE_ORDER[a] ?? 99) - (PHASE_ORDER[b] ?? 99),
   );
@@ -125,8 +127,8 @@ function TrackTree({
   const pct = track.modules.length > 0 ? Math.round((doneCount / track.modules.length) * 100) : 0;
 
   return (
-    <article className={`talent-track ${trackCls}`}>
-      <div className="talent-track-header">
+    <article className="talent-track">
+      <div className="talent-track-header" style={{ "--track-color": trackColor } as React.CSSProperties}>
         <div>
           <p className="eyebrow">{track.id}</p>
           <h2>{track.title}</h2>
@@ -136,7 +138,7 @@ function TrackTree({
           <div className="talent-track-bar">
             <div
               className="talent-track-bar-fill"
-              style={{ width: `${pct}%` }}
+              style={{ "--track-color": trackColor, "--bar-width": `${pct}%` } as React.CSSProperties}
             />
           </div>
           <span className="muted">
@@ -162,6 +164,7 @@ function TrackTree({
                     mod={mod}
                     state={state}
                     isLast={isLastInPhase && isLastPhase}
+                    trackColor={trackColor}
                   />
                 );
               })}
@@ -187,7 +190,7 @@ export default async function TracksPage() {
 
   return (
     <main className="page-shell">
-      <nav className="breadcrumb">
+      <nav className="breadcrumb" aria-label="Breadcrumb">
         <Link href="/">Dashboard</Link>
         <span className="breadcrumb-sep">/</span>
         <span>Tracks</span>


### PR DESCRIPTION
Restores --bar-color, --track-color CSS custom properties in analytics, progression, and tracks pages that were lost during a rebase.