### PR TITLE
fix: restore CSS custom property styles lost during rebase

### DIFF
--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -73,7 +73,7 @@ function AnalyticsBarChart({
                 <div className={`analytics-bar-track ${TRACK_CLASS[row.track_id] ?? ""}`}>
                   <div
                     className="analytics-bar-fill"
-                    style={{ "--bar-width": width } as React.CSSProperties}
+                    style={{ "--bar-width": width, "--bar-color": TRACK_COLORS[row.track_id] ?? "var(--accent)" } as React.CSSProperties}
                   />
                 </div>
               </div>

--- a/apps/web/app/progression/page.tsx
+++ b/apps/web/app/progression/page.tsx
@@ -177,7 +177,7 @@ export default async function ProgressionPage() {
               <div className="progress-bar">
                 <div
                   className="progress-bar-fill"
-                  style={{ "--bar-width": `${ts.percent}%` } as React.CSSProperties}
+                  style={{ "--bar-width": `${ts.percent}%`, "--bar-color": TRACK_COLORS[ts.id] ?? "var(--accent)" } as React.CSSProperties}
                 />
               </div>
               <p className="muted">{ts.done} / {ts.total} modules</p>

--- a/apps/web/app/tracks/page.tsx
+++ b/apps/web/app/tracks/page.tsx
@@ -71,7 +71,7 @@ function TalentNode({
   return (
     <div className="talent-node-wrapper">
       <div className={`talent-node talent-node--${state}`}>
-        <div className="talent-node-icon">
+        <div className="talent-node-icon" style={{ "--track-color": state === "locked" ? "var(--muted)" : trackColor } as React.CSSProperties}>
           {STATE_ICON[state]}
         </div>
         <div className="talent-node-body">
@@ -101,7 +101,7 @@ function TalentNode({
         </div>
       </div>
       {!isLast && (
-        <div className="talent-edge" />
+        <div className="talent-edge" style={{ "--track-color": trackColor } as React.CSSProperties} />
       )}
     </div>
   );
@@ -127,8 +127,8 @@ function TrackTree({
   const pct = track.modules.length > 0 ? Math.round((doneCount / track.modules.length) * 100) : 0;
 
   return (
-    <article className={`talent-track ${trackCls}`}>
-      <div className="talent-track-header">
+    <article className="talent-track">
+      <div className="talent-track-header" style={{ "--track-color": trackColor } as React.CSSProperties}>
         <div>
           <p className="eyebrow">{track.id}</p>
           <h2>{track.title}</h2>
@@ -138,7 +138,7 @@ function TrackTree({
           <div className="talent-track-bar">
             <div
               className="talent-track-bar-fill"
-              style={{ "--bar-width": `${pct}%` } as React.CSSProperties}
+              style={{ "--track-color": trackColor, "--bar-width": `${pct}%` } as React.CSSProperties}
             />
           </div>
           <span className="muted">


### PR DESCRIPTION
Restores --bar-color and --track-color CSS custom properties in analytics, progression, and tracks pages.