### PR TITLE
feat: Windows distributable via Electron (#230)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,53 @@
+name: Build Windows
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: npm ci
+
+      - name: Build Next.js standalone
+        working-directory: apps/web
+        run: npm run build
+
+      - name: Verify standalone output
+        run: |
+          if (!(Test-Path "apps/web/.next/standalone")) {
+            Write-Error "Standalone build directory not found"
+            exit 1
+          }
+        shell: pwsh
+
+      - name: Install Electron dependencies
+        working-directory: desktop
+        run: npm ci
+
+      - name: Build Windows distributable
+        working-directory: desktop
+        run: npx electron-builder --win
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-dist
+          path: |
+            desktop/dist/*.exe
+            desktop/dist/*.msi
+          retention-days: 30

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,0 +1,162 @@
+/**
+ * Electron main process for 42 Training desktop shell.
+ *
+ * Lifecycle:
+ *   1. Spawn the Next.js standalone server from extraResources.
+ *   2. Wait for the health-check endpoint to respond.
+ *   3. Open a BrowserWindow pointing at the local server.
+ *   4. On quit, tear down the child process.
+ *
+ * The Python backend services (API + AI Gateway) are expected to run
+ * independently — either via Docker Desktop or manually.
+ * Set NEXT_PUBLIC_API_URL and NEXT_PUBLIC_AI_GATEWAY_URL env vars to
+ * point the frontend at the running backends.
+ */
+
+const { app, BrowserWindow, dialog } = require("electron");
+const { spawn } = require("child_process");
+const path = require("path");
+const http = require("http");
+
+const WEB_PORT = Number(process.env.PORT) || 3042;
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+let mainWindow = null;
+let serverProcess = null;
+
+/* ------------------------------------------------------------------ */
+/*  Next.js server management                                          */
+/* ------------------------------------------------------------------ */
+
+function getServerPath() {
+  const resourcesPath = process.resourcesPath || path.join(__dirname, "..");
+  return path.join(resourcesPath, "web", "apps", "web", "server.js");
+}
+
+function startServer() {
+  const serverPath = getServerPath();
+
+  serverProcess = spawn(process.execPath.includes("electron") ? "node" : process.execPath, [serverPath], {
+    env: {
+      ...process.env,
+      PORT: String(WEB_PORT),
+      HOSTNAME: "127.0.0.1",
+      NEXT_PUBLIC_API_URL: API_URL,
+      NEXT_PUBLIC_AI_GATEWAY_URL: process.env.NEXT_PUBLIC_AI_GATEWAY_URL || "http://localhost:8100",
+      NODE_ENV: "production",
+    },
+    stdio: "pipe",
+  });
+
+  serverProcess.stdout?.on("data", (data) => {
+    console.log(`[next] ${data.toString().trim()}`);
+  });
+
+  serverProcess.stderr?.on("data", (data) => {
+    console.error(`[next] ${data.toString().trim()}`);
+  });
+
+  serverProcess.on("error", (err) => {
+    console.error("Failed to start Next.js server:", err.message);
+    dialog.showErrorBox(
+      "Server Error",
+      `Could not start the web server.\n\n${err.message}\n\nMake sure the application was built correctly.`
+    );
+  });
+
+  serverProcess.on("exit", (code) => {
+    console.log(`Next.js server exited with code ${code}`);
+    serverProcess = null;
+  });
+}
+
+function stopServer() {
+  if (serverProcess) {
+    serverProcess.kill();
+    serverProcess = null;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Health check                                                       */
+/* ------------------------------------------------------------------ */
+
+function waitForServer(url, retries = 30, interval = 500) {
+  return new Promise((resolve, reject) => {
+    let attempts = 0;
+
+    function check() {
+      attempts += 1;
+      http
+        .get(url, (res) => {
+          if (res.statusCode === 200 || res.statusCode === 307) {
+            resolve();
+          } else if (attempts < retries) {
+            setTimeout(check, interval);
+          } else {
+            reject(new Error(`Server not ready after ${retries} attempts (last status: ${res.statusCode})`));
+          }
+        })
+        .on("error", () => {
+          if (attempts < retries) {
+            setTimeout(check, interval);
+          } else {
+            reject(new Error(`Server not reachable after ${retries} attempts`));
+          }
+        });
+    }
+
+    check();
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Window                                                             */
+/* ------------------------------------------------------------------ */
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 900,
+    minWidth: 800,
+    minHeight: 600,
+    title: "42 Training",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  mainWindow.loadURL(`http://127.0.0.1:${WEB_PORT}`);
+
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  App lifecycle                                                      */
+/* ------------------------------------------------------------------ */
+
+app.on("ready", async () => {
+  startServer();
+
+  try {
+    await waitForServer(`http://127.0.0.1:${WEB_PORT}/health`);
+  } catch {
+    // Fallback: try loading anyway — the page may still serve
+    console.warn("Health check failed, loading frontend anyway");
+  }
+
+  createWindow();
+});
+
+app.on("window-all-closed", () => {
+  stopServer();
+  app.quit();
+});
+
+app.on("before-quit", () => {
+  stopServer();
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "42-training-desktop",
+  "version": "0.1.0",
+  "description": "Windows desktop shell for 42 Training",
+  "main": "main.js",
+  "private": true,
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder --win",
+    "build:msi": "electron-builder --win nsis",
+    "build:portable": "electron-builder --win portable"
+  },
+  "dependencies": {
+    "electron-is-dev": "^2.0.0"
+  },
+  "devDependencies": {
+    "electron": "^33.0.0",
+    "electron-builder": "^25.1.0"
+  },
+  "build": {
+    "appId": "com.42training.desktop",
+    "productName": "42 Training",
+    "directories": {
+      "output": "dist"
+    },
+    "files": [
+      "main.js",
+      "preload.js",
+      "icon.png"
+    ],
+    "extraResources": [
+      {
+        "from": "../apps/web/.next/standalone",
+        "to": "web",
+        "filter": ["**/*"]
+      },
+      {
+        "from": "../apps/web/public",
+        "to": "web/apps/web/public",
+        "filter": ["**/*"]
+      },
+      {
+        "from": "../apps/web/.next/static",
+        "to": "web/apps/web/.next/static",
+        "filter": ["**/*"]
+      },
+      {
+        "from": "../packages",
+        "to": "packages",
+        "filter": ["**/*"]
+      },
+      {
+        "from": "../progression.json",
+        "to": "progression.json"
+      }
+    ],
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        },
+        {
+          "target": "portable",
+          "arch": ["x64"]
+        }
+      ],
+      "icon": "icon.png"
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "installerIcon": "icon.png",
+      "uninstallerIcon": "icon.png",
+      "license": "../LICENSE"
+    },
+    "portable": {
+      "artifactName": "42-Training-${version}-portable.exe"
+    }
+  }
+}

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,0 +1,13 @@
+/**
+ * Electron preload script.
+ *
+ * Exposes a minimal API to the renderer via contextBridge.
+ * Keeps contextIsolation enabled for security.
+ */
+
+const { contextBridge } = require("electron");
+
+contextBridge.exposeInMainWorld("desktop", {
+  platform: process.platform,
+  isElectron: true,
+});

--- a/docs/WINDOWS_SETUP.md
+++ b/docs/WINDOWS_SETUP.md
@@ -1,0 +1,116 @@
+# Windows Setup — 42 Training Desktop
+
+## Overview
+
+The 42 Training desktop app packages the Next.js frontend as a native Windows
+application via Electron. Backend services (API + AI Gateway) run separately,
+either through Docker Desktop or manual Python setup.
+
+## Architecture
+
+```
+┌──────────────────────────────────┐
+│   42 Training (.exe)             │
+│   ┌────────────────────────────┐ │
+│   │  Electron shell            │ │
+│   │  ┌──────────────────────┐  │ │
+│   │  │ Next.js standalone   │  │ │
+│   │  │ (port 3042)          │  │ │
+│   │  └──────────────────────┘  │ │
+│   └────────────────────────────┘ │
+└──────────┬───────────────────────┘
+           │ HTTP
+┌──────────▼───────────────────────┐
+│  Backend (Docker Desktop)        │
+│  ├─ API (port 8000)             │
+│  ├─ AI Gateway (port 8100)      │
+│  ├─ PostgreSQL (port 5432)      │
+│  └─ Redis (port 6379)           │
+└──────────────────────────────────┘
+```
+
+## Prerequisites
+
+| Requirement        | Version   | Purpose                     |
+|--------------------|-----------|-----------------------------|
+| Windows            | 10+ x64   | Target platform             |
+| Node.js            | >= 20     | Build + Next.js runtime     |
+| Docker Desktop     | >= 4.0    | Backend services            |
+| Git                | >= 2.40   | Clone repository            |
+| Python (optional)  | 3.13      | Run backends without Docker |
+
+## Quick Start (Docker backends)
+
+```powershell
+# 1. Clone and enter the repository
+git clone https://github.com/decarvalhoe/42-training.git
+cd 42-training
+
+# 2. Start backend services via Docker
+docker compose up -d api ai_gateway
+
+# 3. Run the desktop app in development mode
+cd desktop
+npm install
+npm start
+```
+
+## Building the Installer
+
+```powershell
+# From the repository root
+.\scripts\build-windows.ps1
+```
+
+This produces two artifacts in `desktop\dist\`:
+- **NSIS installer** — standard Windows setup wizard (.exe)
+- **Portable** — single-file executable, no installation required
+
+## Manual Backend Setup (without Docker)
+
+If Docker Desktop is not available, run the backends manually:
+
+```powershell
+# Terminal 1 — API
+cd services\api
+pip install -r requirements.txt
+$env:DATABASE_URL = "sqlite+aiosqlite:///training.db"
+uvicorn app.main:app --host 127.0.0.1 --port 8000
+
+# Terminal 2 — AI Gateway
+cd services\ai_gateway
+pip install -r requirements.txt
+$env:AI_GATEWAY_API_BASE_URL = "http://localhost:8000"
+uvicorn app.main:app --host 127.0.0.1 --port 8100
+```
+
+## Environment Variables
+
+| Variable                        | Default                  | Description              |
+|---------------------------------|--------------------------|--------------------------|
+| `PORT`                          | `3042`                   | Frontend port            |
+| `NEXT_PUBLIC_API_URL`           | `http://localhost:8000`  | Backend API URL          |
+| `NEXT_PUBLIC_AI_GATEWAY_URL`    | `http://localhost:8100`  | AI Gateway URL           |
+| `DATABASE_URL`                  | PostgreSQL connection    | API database             |
+
+## CI/CD
+
+The `build-windows.yml` workflow runs on:
+- Git tags matching `v*` (releases)
+- Manual dispatch (`workflow_dispatch`)
+
+Artifacts are uploaded to the Actions run and retained for 30 days.
+
+## Troubleshooting
+
+**"Server Error" on startup**
+The desktop app starts a Next.js server internally. If it fails, ensure the
+build was run with `output: "standalone"` in `next.config.mjs`.
+
+**Backend unreachable**
+The frontend defaults to `http://localhost:8000` for the API. Start backends
+via `docker compose up -d` or the manual setup above before launching the app.
+
+**Build fails on electron-builder**
+Ensure you are running the build on a Windows machine or in a Windows CI
+runner. Cross-compilation from Linux is not supported for NSIS installers.

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Build a Windows distributable (.exe / .msi) for 42 Training.
+
+.DESCRIPTION
+    1. Builds the Next.js frontend in standalone mode.
+    2. Runs electron-builder to produce an NSIS installer and portable .exe.
+    Outputs land in desktop/dist/.
+
+.PREREQUISITES
+    - Node.js >= 20
+    - npm
+    - Python 3.13 (for backend services — not bundled)
+    - Docker Desktop (recommended for running backend services)
+#>
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
+Write-Host "=== 42 Training Windows Build ===" -ForegroundColor Cyan
+
+# ---- Step 1: Build Next.js standalone ----
+Write-Host "`n[1/3] Building Next.js standalone..." -ForegroundColor Yellow
+Push-Location "$RepoRoot\apps\web"
+npm ci
+npm run build
+Pop-Location
+
+if (-not (Test-Path "$RepoRoot\apps\web\.next\standalone")) {
+    Write-Error "Standalone build not found. Ensure next.config.mjs has output: 'standalone'."
+    exit 1
+}
+
+Write-Host "  Next.js standalone build OK" -ForegroundColor Green
+
+# ---- Step 2: Install Electron deps ----
+Write-Host "`n[2/3] Installing Electron dependencies..." -ForegroundColor Yellow
+Push-Location "$RepoRoot\desktop"
+npm ci
+Pop-Location
+
+Write-Host "  Electron deps OK" -ForegroundColor Green
+
+# ---- Step 3: Build Electron distributable ----
+Write-Host "`n[3/3] Building Windows distributable..." -ForegroundColor Yellow
+Push-Location "$RepoRoot\desktop"
+npx electron-builder --win
+Pop-Location
+
+Write-Host "`n=== Build complete ===" -ForegroundColor Cyan
+Write-Host "Output: desktop\dist\" -ForegroundColor Green
+Write-Host "  - NSIS installer (.exe)"
+Write-Host "  - Portable (.exe)"


### PR DESCRIPTION
## Summary
Adds native Windows packaging for 42 Training via Electron + electron-builder.

### New files
- **`desktop/`** — Electron app (main process, preload, electron-builder config)
  - Spawns Next.js standalone server on port 3042
  - Waits for health check before opening window
  - Clean shutdown of child processes on quit
  - Produces NSIS installer + portable .exe via electron-builder
- **`scripts/build-windows.ps1`** — PowerShell build script (3 steps: Next.js build, Electron deps, electron-builder)
- **`.github/workflows/build-windows.yml`** — CI workflow on `v*` tags and manual dispatch, uploads artifacts
- **`docs/WINDOWS_SETUP.md`** — Prerequisites (Win10+ x64, Node 20+, Docker Desktop), quick start, manual backend setup, env vars, troubleshooting

### Modified
- **`apps/web/next.config.mjs`** — adds `output: "standalone"` for self-contained server build

### Design decisions
- Backend services (API + AI Gateway + PostgreSQL + Redis) are **not bundled** — they run via Docker Desktop or manual Python setup
- The Electron shell wraps only the frontend, keeping the architecture simple
- Port 3042 avoids conflict with dev server (3000) and API (8000)

## Test plan
- [x] API tests: 224 passed
- [x] Ruff: clean on both services
- [x] No backend changes beyond next.config.mjs
- [ ] Windows build: requires Windows runner (CI workflow provided)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)