### PR TITLE
Close learner-facing API outage regression gaps

### DIFF
--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { getAnalyticsData } from "@/lib/api";
 import type { AnalyticsChartRow } from "@/lib/api";
+import { DataSourceBadge } from "@/app/components/DataSourceBadge";
 
 const TRACK_CLASS: Record<string, string> = {
   shell: "track-shell",
@@ -113,6 +114,9 @@ export default async function AnalyticsPage() {
           A first internal view of pedagogical events, module throughput and checkpoint quality,
           aligned with the KPI definitions from <code>docs/PRODUCT_METRICS.md</code>.
         </p>
+        <div className="stack-list">
+          <DataSourceBadge sourceMode={analytics.sourceMode} />
+        </div>
 
         <div className="analytics-summary-grid">
           {summaryCards.map((card) => (

--- a/apps/web/app/components/DataSourceBadge.tsx
+++ b/apps/web/app/components/DataSourceBadge.tsx
@@ -1,0 +1,5 @@
+import type { DataSourceMode } from "@/lib/api";
+
+export function DataSourceBadge({ sourceMode }: { sourceMode: DataSourceMode }) {
+  return <span className="pill">{sourceMode === "live" ? "API live" : "Demo mode"}</span>;
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { getDashboardData, getTmuxSessions } from "@/lib/api";
 import type { ModuleItem, TrackItem } from "@/lib/api";
+import { DataSourceBadge } from "@/app/components/DataSourceBadge";
 import { TmuxSessions } from "@/app/components/TmuxSessions";
 
 /* ------------------------------------------------------------------ */
@@ -118,6 +119,9 @@ export default async function DashboardPage() {
             Visual overview of every skill in the curriculum, organized by track and module.
             Each node reflects your current progression state.
           </p>
+          <div className="stack-list">
+            <DataSourceBadge sourceMode={data.sourceMode} />
+          </div>
         </div>
         <div className="dashboard-hero-stats">
           <div className="metric-card">

--- a/apps/web/app/defense/page.tsx
+++ b/apps/web/app/defense/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { getDashboardData, getTmuxSessions } from "@/lib/api";
+import { DataSourceBadge } from "@/app/components/DataSourceBadge";
 
 import DefenseClient from "./DefenseClient";
 
@@ -50,6 +51,9 @@ export default async function DefensePage() {
           simulates the 42-style oral defense where you must demonstrate genuine
           understanding.
         </p>
+        <div className="stack-list">
+          <DataSourceBadge sourceMode={data.sourceMode} />
+        </div>
       </section>
 
       <DefenseClient modules={modules} apiUrl={apiUrl} tmuxSessions={tmuxSessions} />

--- a/apps/web/app/evidence/EvidenceClient.tsx
+++ b/apps/web/app/evidence/EvidenceClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { loadAssessmentFeed, type DefenseSessionRecord, type ReviewAttemptRecord } from "@/services/reviewEvidence";
 
@@ -77,32 +77,33 @@ export default function EvidenceClient({ modules }: Props) {
   const [loadingState, setLoadingState] = useState<"loading" | "ready" | "error">("loading");
   const [mocked, setMocked] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadFeed = useCallback(async (cancelledRef?: { current: boolean }) => {
+    setLoadingState("loading");
 
-    async function loadFeed() {
-      try {
-        const data = await loadAssessmentFeed();
-        if (cancelled) {
-          return;
-        }
-        setReviewAttempts(data.reviewAttempts);
-        setDefenseSessions(data.defenseSessions);
-        setMocked(data.mocked);
-        setLoadingState("ready");
-      } catch {
-        if (!cancelled) {
-          setLoadingState("error");
-        }
+    try {
+      const data = await loadAssessmentFeed();
+      if (cancelledRef?.current) {
+        return;
+      }
+      setReviewAttempts(data.reviewAttempts);
+      setDefenseSessions(data.defenseSessions);
+      setMocked(data.mocked);
+      setLoadingState("ready");
+    } catch {
+      if (!cancelledRef?.current) {
+        setLoadingState("error");
       }
     }
+  }, []);
 
-    void loadFeed();
+  useEffect(() => {
+    const cancelledRef = { current: false };
+    void loadFeed(cancelledRef);
 
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
     };
-  }, []);
+  }, [loadFeed]);
 
   const artifacts = useMemo(() => {
     const combined = [...flattenReviewArtifacts(reviewAttempts), ...flattenDefenseArtifacts(defenseSessions)].sort((a, b) =>
@@ -129,6 +130,9 @@ export default function EvidenceClient({ modules }: Props) {
       <section className="panel evidence-shell">
         <h2>Evidence feed unavailable</h2>
         <p className="muted">The page could not load review or defense artifacts.</p>
+        <button type="button" className="action-btn" onClick={() => void loadFeed()}>
+          Retry
+        </button>
       </section>
     );
   }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { getDashboardData, getTmuxSessions } from "@/lib/api";
 import { SourcePolicyBadge } from "@/app/components/SourcePolicyBadge";
 import { TmuxSessions } from "@/app/components/TmuxSessions";
+import { DataSourceBadge } from "@/app/components/DataSourceBadge";
 
 function Pill({ children }: { children: ReactNode }) {
   return <span className="pill">{children}</span>;
@@ -50,6 +51,9 @@ export default async function HomePage() {
           <h2>Current session</h2>
           <p>{progression.progress?.current_exercise ?? "No active exercise"}</p>
           <p>{progression.progress?.current_step ?? "No current step"}</p>
+          <div className="stack-list">
+            <DataSourceBadge sourceMode={data.sourceMode} />
+          </div>
           <div className="stack-list">
             {(progression.progress?.in_progress ?? []).map((item) => (
               <Pill key={item}>{item}</Pill>

--- a/apps/web/app/profiles/page.tsx
+++ b/apps/web/app/profiles/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useAuth } from "@/app/components/AuthProvider";
 import { getDashboardData, type TrackItem } from "@/lib/api";
@@ -63,36 +63,37 @@ export default function ProfilesPage() {
   const [isCreating, setIsCreating] = useState(false);
   const [switchingId, setSwitchingId] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadPage = useCallback(async (cancelledRef?: { current: boolean }) => {
+    setLoadingState("loading");
 
-    async function loadPage() {
-      try {
-        const [dashboard, profiles] = await Promise.all([getDashboardData(), listProfiles()]);
-        if (cancelled) {
-          return;
-        }
+    try {
+      const [dashboard, profiles] = await Promise.all([getDashboardData(), listProfiles()]);
+      if (cancelledRef?.current) {
+        return;
+      }
 
-        setTracks(dashboard.curriculum.tracks);
-        setProfilesState(profiles);
-        setForm((current) => ({
-          ...current,
-          track: current.track || dashboard.curriculum.tracks[0]?.id || "",
-        }));
-        setLoadingState("ready");
-      } catch {
-        if (!cancelled) {
-          setLoadingState("error");
-        }
+      setTracks(dashboard.curriculum.tracks);
+      setProfilesState(profiles);
+      setForm((current) => ({
+        ...current,
+        track: current.track || dashboard.curriculum.tracks[0]?.id || "",
+      }));
+      setLoadingState("ready");
+    } catch {
+      if (!cancelledRef?.current) {
+        setLoadingState("error");
       }
     }
+  }, []);
 
-    void loadPage();
+  useEffect(() => {
+    const cancelledRef = { current: false };
+    void loadPage(cancelledRef);
 
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
     };
-  }, []);
+  }, [loadPage]);
   const activeProfile = profilesState?.activeProfile ?? null;
   const sessionEmail = session?.user.email ?? "Authenticated learner";
 
@@ -170,9 +171,14 @@ export default function ProfilesPage() {
           <p className="lead">
             The UI could not load the profile catalog. Refresh the page or return to the dashboard.
           </p>
-          <Link href="/" className="action-btn">
-            Back to dashboard
-          </Link>
+          <div className="stack-list">
+            <button type="button" className="action-btn" onClick={() => void loadPage()}>
+              Retry
+            </button>
+            <Link href="/" className="action-btn">
+              Back to dashboard
+            </Link>
+          </div>
         </section>
       </main>
     );

--- a/apps/web/app/review/ReviewClient.tsx
+++ b/apps/web/app/review/ReviewClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   createReviewAttempt,
@@ -124,31 +124,32 @@ export default function ReviewClient({ modules }: Props) {
   const [feedback, setFeedback] = useState<string | null>(null);
   const [feedbackTone, setFeedbackTone] = useState<"success" | "error">("success");
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadItems = useCallback(async (cancelledRef?: { current: boolean }) => {
+    setLoadingState("loading");
 
-    async function loadItems() {
-      try {
-        const result = await listReviewAttempts();
-        if (cancelled) {
-          return;
-        }
-        setItems(result.items);
-        setSourceMode(result.mocked ? "mocked" : "live");
-        setLoadingState("ready");
-      } catch {
-        if (!cancelled) {
-          setLoadingState("error");
-        }
+    try {
+      const result = await listReviewAttempts();
+      if (cancelledRef?.current) {
+        return;
+      }
+      setItems(result.items);
+      setSourceMode(result.mocked ? "mocked" : "live");
+      setLoadingState("ready");
+    } catch {
+      if (!cancelledRef?.current) {
+        setLoadingState("error");
       }
     }
+  }, []);
 
-    void loadItems();
+  useEffect(() => {
+    const cancelledRef = { current: false };
+    void loadItems(cancelledRef);
 
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
     };
-  }, []);
+  }, [loadItems]);
 
   const reviewQuestions = useMemo(
     () =>
@@ -238,6 +239,9 @@ export default function ReviewClient({ modules }: Props) {
       <section className="panel review-shell">
         <h2>Review workspace unavailable</h2>
         <p className="muted">The page could not load recent review attempts.</p>
+        <button type="button" className="action-btn" onClick={() => void loadItems()}>
+          Retry
+        </button>
       </section>
     );
   }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -67,7 +67,9 @@ export type QualityEquivalent = {
   human_review_focus: string[];
 };
 
-export type DashboardData = {
+export type DataSourceMode = "live" | "demo";
+
+type DashboardPayload = {
   curriculum: {
     metadata: {
       campus: string;
@@ -135,6 +137,10 @@ export type DashboardData = {
   };
 };
 
+export type DashboardData = DashboardPayload & {
+  sourceMode: DataSourceMode;
+};
+
 export type AnalyticsSummary = {
   total_events: number;
   module_completions: number;
@@ -155,16 +161,24 @@ export type AnalyticsChartRow = {
   suffix: string;
 };
 
-export type AnalyticsData = {
+type AnalyticsPayload = {
   summary: AnalyticsSummary;
   modules_completed: AnalyticsChartRow[];
   average_time: AnalyticsChartRow[];
   success_rate: AnalyticsChartRow[];
 };
 
-const DEMO_MODE_ENABLED = process.env.NEXT_PUBLIC_ENABLE_DEMO_MODE === "true";
+export type AnalyticsData = AnalyticsPayload & {
+  sourceMode: DataSourceMode;
+};
 
-const fallbackData: DashboardData = {
+const DEMO_MODE_ENABLED = process.env.NEXT_PUBLIC_ENABLE_DEMO_MODE === "true";
+const E2E_OVERRIDE_ENABLED = process.env.NEXT_PUBLIC_ENABLE_E2E_API_OVERRIDE === "true";
+const API_OVERRIDE_COOKIE_KEY = "training_api_base_override";
+const DEMO_MODE_COOKIE_KEY = "training_demo_mode";
+const DEFAULT_API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+const fallbackData: DashboardPayload = {
   curriculum: {
     metadata: {
       campus: "42 Lausanne",
@@ -418,7 +432,7 @@ const fallbackData: DashboardData = {
   }
 };
 
-const fallbackAnalyticsData: AnalyticsData = {
+const fallbackAnalyticsData: AnalyticsPayload = {
   summary: {
     total_events: 24,
     module_completions: 7,
@@ -533,8 +547,63 @@ export type TmuxSessionsData = {
   total: number;
 };
 
+function readClientCookie(name: string): string | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const match = document.cookie
+    .split("; ")
+    .find((entry) => entry.startsWith(`${name}=`));
+
+  return match ? decodeURIComponent(match.slice(name.length + 1)) : null;
+}
+
+async function readServerCookie(name: string): Promise<string | null> {
+  if (!E2E_OVERRIDE_ENABLED || typeof window !== "undefined") {
+    return null;
+  }
+
+  const { cookies } = await import("next/headers");
+  const cookieStore = await cookies();
+  return cookieStore.get(name)?.value ?? null;
+}
+
+async function readOverrideCookie(name: string): Promise<string | null> {
+  if (!E2E_OVERRIDE_ENABLED) {
+    return null;
+  }
+
+  if (typeof window !== "undefined") {
+    return readClientCookie(name);
+  }
+
+  return readServerCookie(name);
+}
+
+async function resolveApiUrl(): Promise<string> {
+  const override = await readOverrideCookie(API_OVERRIDE_COOKIE_KEY);
+  if (!override) {
+    return DEFAULT_API_URL;
+  }
+
+  try {
+    return new URL(override).toString().replace(/\/$/, "");
+  } catch {
+    return DEFAULT_API_URL;
+  }
+}
+
+async function resolveDemoModeEnabled(): Promise<boolean> {
+  if (DEMO_MODE_ENABLED) {
+    return true;
+  }
+
+  return (await readOverrideCookie(DEMO_MODE_COOKIE_KEY)) === "true";
+}
+
 export async function getTmuxSessions(): Promise<TmuxSessionsData> {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+  const apiUrl = await resolveApiUrl();
 
   try {
     const response = await fetch(`${apiUrl}/api/v1/tmux/sessions`, { cache: "no-store" });
@@ -548,34 +617,38 @@ export async function getTmuxSessions(): Promise<TmuxSessionsData> {
 }
 
 export async function getDashboardData(): Promise<DashboardData> {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+  const apiUrl = await resolveApiUrl();
+  const demoModeEnabled = await resolveDemoModeEnabled();
 
   try {
     const response = await fetch(`${apiUrl}/api/v1/dashboard`, { cache: "no-store" });
     if (!response.ok) {
       throw new Error(`API returned ${response.status}`);
     }
-    return (await response.json()) as DashboardData;
+    const payload = (await response.json()) as DashboardPayload;
+    return { ...payload, sourceMode: "live" };
   } catch (error) {
-    if (DEMO_MODE_ENABLED) {
-      return fallbackData;
+    if (demoModeEnabled) {
+      return { ...fallbackData, sourceMode: "demo" };
     }
     throw error;
   }
 }
 
 export async function getAnalyticsData(): Promise<AnalyticsData> {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+  const apiUrl = await resolveApiUrl();
+  const demoModeEnabled = await resolveDemoModeEnabled();
 
   try {
     const response = await fetch(`${apiUrl}/api/v1/analytics/dashboard`, { cache: "no-store" });
     if (!response.ok) {
       throw new Error(`API returned ${response.status}`);
     }
-    return (await response.json()) as AnalyticsData;
+    const payload = (await response.json()) as AnalyticsPayload;
+    return { ...payload, sourceMode: "live" };
   } catch (error) {
-    if (DEMO_MODE_ENABLED) {
-      return fallbackAnalyticsData;
+    if (demoModeEnabled) {
+      return { ...fallbackAnalyticsData, sourceMode: "demo" };
     }
     throw error;
   }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       timeout: 120_000,
     },
     {
-      command: `bash -lc 'cd ${__dirname} && NEXT_PUBLIC_API_URL=http://127.0.0.1:${apiPort} NEXT_PUBLIC_ENABLE_DEMO_MODE=false npm run dev -- --hostname ${webHost} --port ${webPort}'`,
+      command: `bash -lc 'cd ${__dirname} && NEXT_PUBLIC_API_URL=http://127.0.0.1:${apiPort} NEXT_PUBLIC_ENABLE_DEMO_MODE=false NEXT_PUBLIC_ENABLE_E2E_API_OVERRIDE=true npm run dev -- --hostname ${webHost} --port ${webPort}'`,
       url: baseURL,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,

--- a/apps/web/tests/e2e/api-failure-regressions.spec.ts
+++ b/apps/web/tests/e2e/api-failure-regressions.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const WEB_URL = "http://127.0.0.1:3000";
+const API_URL = "http://127.0.0.1:8000";
+const DEAD_API_URL = "http://127.0.0.1:65530";
+const PASSWORD = "supersecret";
+const API_OVERRIDE_COOKIE_KEY = "training_api_base_override";
+const DEMO_MODE_COOKIE_KEY = "training_demo_mode";
+
+function uniqueId() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function registerAuthenticatedSession(page: Page) {
+  const email = `api-failure-${uniqueId()}@example.com`;
+  const response = await page.context().request.post(`${API_URL}/api/v1/auth/register`, {
+    data: {
+      email,
+      password: PASSWORD,
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+  return email;
+}
+
+async function addAppCookies(page: Page, values: Record<string, string>) {
+  await page.context().addCookies(
+    Object.entries(values).map(([name, value]) => ({
+      name,
+      value,
+      url: WEB_URL,
+    })),
+  );
+}
+
+async function fulfillOutage(route: Route) {
+  await route.fulfill({
+    status: 503,
+    contentType: "application/json",
+    body: JSON.stringify({ detail: "service unavailable" }),
+  });
+}
+
+test("dashboard, analytics and defense stop loudly when the live API is unavailable", async ({ page }) => {
+  await registerAuthenticatedSession(page);
+  await addAppCookies(page, {
+    [API_OVERRIDE_COOKIE_KEY]: DEAD_API_URL,
+  });
+
+  for (const path of ["/", "/analytics", "/defense"]) {
+    await page.goto(path);
+    await expect(page.getByText(/stopped instead of/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+  }
+});
+
+test("dashboard, analytics and defense expose demo mode explicitly when fallback is opt-in", async ({ page }) => {
+  await registerAuthenticatedSession(page);
+  await addAppCookies(page, {
+    [API_OVERRIDE_COOKIE_KEY]: DEAD_API_URL,
+    [DEMO_MODE_COOKIE_KEY]: "true",
+  });
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /One learning system/i })).toBeVisible();
+  await expect(page.getByText("Demo mode")).toBeVisible();
+
+  await page.goto("/analytics");
+  await expect(page.getByRole("heading", { name: "Analytics dashboard" })).toBeVisible();
+  await expect(page.getByText("Demo mode")).toBeVisible();
+
+  await page.goto("/defense");
+  await expect(page.getByRole("heading", { name: "Defense and guided review" })).toBeVisible();
+  await expect(page.getByText("Demo mode")).toBeVisible();
+});
+
+test("profiles, review and defense keep explicit error and retry states during API outages", async ({ page }) => {
+  await registerAuthenticatedSession(page);
+
+  await page.route("**/api/v1/profiles**", fulfillOutage);
+  await page.goto("/profiles");
+  await expect(page.getByRole("heading", { name: "Profile management is temporarily unavailable." })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+  await page.unroute("**/api/v1/profiles**", fulfillOutage);
+
+  await page.route("**/api/v1/review-attempts**", fulfillOutage);
+  await page.goto("/review");
+  await expect(page.getByRole("heading", { name: "Review workspace unavailable" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+  await page.unroute("**/api/v1/review-attempts**", fulfillOutage);
+
+  await page.route("**/api/v1/defense/start", fulfillOutage);
+  await page.goto("/defense");
+  await expect(page.getByRole("heading", { name: "Start a defense session" })).toBeVisible();
+  await page.getByRole("button", { name: "Begin defense" }).click();
+  await expect(page.getByText("service unavailable")).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- expose live versus demo data source state on dashboard, analytics and defense surfaces
- add explicit retry states to profiles, review and evidence outage screens instead of dead-end errors
- add Playwright regression coverage for production outage mode and opt-in demo mode across dashboard, analytics, profiles, review and defense
- enable test-only API override cookies during Playwright runs so server-rendered pages can be exercised against simulated API outages without changing production behavior

## Validation
- cd apps/web && npm run lint
- cd apps/web && npm run build
- cd apps/web && npm run test:e2e

Closes #226
