### PR TITLE
feat: add draft release gate before stable publication (#241)

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,39 @@
+name: Promote draft release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag of the draft release to promote (e.g. v0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Promote draft to stable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag }}"
+
+          echo "Looking up release for tag: ${TAG}"
+          DRAFT=$(gh release view "${TAG}" --json isDraft --jq '.isDraft' 2>&1) || {
+            echo "::error::Release '${TAG}' not found"
+            exit 1
+          }
+
+          if [ "${DRAFT}" != "true" ]; then
+            echo "Release '${TAG}' is already published (draft=${DRAFT}). Nothing to do."
+            exit 0
+          fi
+
+          echo "Promoting '${TAG}' from draft to stable..."
+          gh release edit "${TAG}" --draft=false
+          echo "Release '${TAG}' is now stable."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,5 +330,5 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}
           body: ${{ steps.notes.outputs.notes }}
-          draft: false
+          draft: true
           prerelease: ${{ contains(steps.version.outputs.tag, '-') }}


### PR DESCRIPTION
## Summary
- **`release.yml`**: change `draft: false` → `draft: true` in the `github-release` job so tag pushes create draft releases requiring manual review
- **`promote-release.yml`**: new `workflow_dispatch` workflow that takes a tag input and promotes the corresponding draft release to stable via `gh release edit --draft=false`

## Flow
1. Push a tag (`v0.2.0`) → CI runs tests, Docker builds, integration → creates a **draft** release
2. Team reviews the draft on the GitHub Releases page
3. When ready, trigger **Promote draft release** workflow with the tag → release becomes stable

## Files changed
- `.github/workflows/release.yml` — line 333: `draft: true`
- `.github/workflows/promote-release.yml` — new workflow

## Test plan
- [x] YAML syntax valid
- [x] Promote workflow handles missing release (error), already-published release (no-op), and draft release (promotes)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)