### PR TITLE
feat: prod compose in release integration + structured CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   # -------------------------------------------------------------------
-  # 3. Integration smoke test (full stack via docker compose)
+  # 3. Integration smoke test (full stack via docker-compose.prod.yml)
   # -------------------------------------------------------------------
   integration:
     runs-on: ubuntu-latest
@@ -192,15 +192,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build all images
-        run: docker compose -f docker-compose.yml build
+        run: docker compose -f docker-compose.prod.yml build
 
       - name: Start infra
-        run: docker compose -f docker-compose.yml up -d postgres redis
+        run: docker compose -f docker-compose.prod.yml up -d postgres redis
 
       - name: Wait for infra healthy
         run: |
           for i in $(seq 1 20); do
-            HEALTHY=$(docker compose ps --format json | grep -c '"Health":"healthy"' || true)
+            HEALTHY=$(docker compose -f docker-compose.prod.yml ps --format json | grep -c '"Health":"healthy"' || true)
             if [ "$HEALTHY" -ge 2 ]; then
               echo "Infra healthy"
               break
@@ -210,9 +210,9 @@ jobs:
 
       - name: Start application services
         run: |
-          docker compose -f docker-compose.yml up -d api
+          docker compose -f docker-compose.prod.yml up -d api
           sleep 5
-          docker compose -f docker-compose.yml up -d ai_gateway web
+          docker compose -f docker-compose.prod.yml up -d ai_gateway web
           sleep 10
 
       - name: Validate all health endpoints
@@ -229,8 +229,8 @@ jobs:
       - name: Tear down
         if: always()
         run: |
-          docker compose -f docker-compose.yml logs --tail=20
-          docker compose -f docker-compose.yml down -v
+          docker compose -f docker-compose.prod.yml logs --tail=20
+          docker compose -f docker-compose.prod.yml down -v
 
   # -------------------------------------------------------------------
   # 4. Installability validation (pip + npm on each platform)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Release workflow with multi-platform validation (Linux, Windows, macOS) and Docker packaging (#232)
+- AI mentor chat page with source policy badges and terminal context (#189)
+- Tmux session state endpoint and dashboard display (#178)
+- Operator runbook for AI gateway (#176)
+- Figma-to-code workflow documentation (#214)
+- jsx-a11y ESLint plugin and component quality checklist (#213)
+- React component convention normalization (#212)
+- Oral defense session MVP with timed questions and scoring
+- Librarian resource search with source governance tiers
+- Reviewer code review with guardrail scrubbing
+- Intent classification routing (mentor, librarian, reviewer, examiner)
+- Module progression endpoints (start, complete, skip, validate)
+- Checkpoint submission and evidence persistence
+- Pedagogical event tracking and analytics dashboard
+- Authentication with JWT and learner profiles
+- Docker Compose setup (dev and production)
+- Curriculum data model for shell, C and Python+AI tracks
+
+### Changed
+- Integration tests in release workflow now use docker-compose.prod.yml (#244)
+
+### Fixed
+- JWT tamper helper now deterministically invalidates tokens in tests
+- ESLint peer dependency conflict with eslint-plugin-jsx-a11y on ESLint 10

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# generate-changelog.sh — Append git log entries to CHANGELOG.md [Unreleased] section.
+#
+# Usage:
+#   ./scripts/generate-changelog.sh              # since last tag
+#   ./scripts/generate-changelog.sh v0.1.0       # since specific tag
+#   ./scripts/generate-changelog.sh --dry-run    # print without writing
+#
+# Categorises commits by conventional-commit prefix:
+#   feat:     → Added
+#   fix:      → Fixed
+#   refactor: → Changed
+#   docs:     → Changed
+#   other     → Changed
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+DRY_RUN=false
+SINCE_TAG=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    *)         SINCE_TAG="$arg" ;;
+  esac
+done
+
+# Determine range
+if [ -z "$SINCE_TAG" ]; then
+  SINCE_TAG=$(git tag --sort=-creatordate | head -1 || true)
+fi
+
+if [ -n "$SINCE_TAG" ]; then
+  RANGE="${SINCE_TAG}..HEAD"
+  echo "Generating changelog since $SINCE_TAG"
+else
+  RANGE="HEAD"
+  echo "Generating changelog for all commits (no tags found)"
+fi
+
+# Collect commits by category
+ADDED=""
+FIXED=""
+CHANGED=""
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  subject="${line#* }"
+  if [[ "$subject" =~ ^feat ]]; then
+    ADDED+="- ${subject}"$'\n'
+  elif [[ "$subject" =~ ^fix ]]; then
+    FIXED+="- ${subject}"$'\n'
+  else
+    CHANGED+="- ${subject}"$'\n'
+  fi
+done < <(git log "$RANGE" --pretty=format:"%h %s" --no-merges 2>/dev/null)
+
+# Format output
+OUTPUT=""
+if [ -n "$ADDED" ]; then
+  OUTPUT+="### Added"$'\n'"$ADDED"$'\n'
+fi
+if [ -n "$CHANGED" ]; then
+  OUTPUT+="### Changed"$'\n'"$CHANGED"$'\n'
+fi
+if [ -n "$FIXED" ]; then
+  OUTPUT+="### Fixed"$'\n'"$FIXED"$'\n'
+fi
+
+if [ -z "$OUTPUT" ]; then
+  echo "No new commits found."
+  exit 0
+fi
+
+echo ""
+echo "=== Generated entries ==="
+echo ""
+echo "$OUTPUT"
+
+if [ "$DRY_RUN" = true ]; then
+  echo "(dry run — nothing written)"
+  exit 0
+fi
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "CHANGELOG.md not found at $CHANGELOG"
+  exit 1
+fi
+
+# Insert after ## [Unreleased] line
+MARKER="## \\[Unreleased\\]"
+if grep -q "$MARKER" "$CHANGELOG"; then
+  TMPFILE=$(mktemp)
+  awk -v new="$OUTPUT" "
+    /$MARKER/ { print; print \"\"; print new; next }
+    { print }
+  " "$CHANGELOG" > "$TMPFILE"
+  mv "$TMPFILE" "$CHANGELOG"
+  echo "Updated $CHANGELOG"
+else
+  echo "No [Unreleased] section found in CHANGELOG.md"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **#244**: Switch all `docker compose` commands in `.github/workflows/release.yml` integration job from `docker-compose.yml` to `docker-compose.prod.yml` (7 occurrences + comment)
- **#245**: Add `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with current project entries (Added/Changed/Fixed sections)
- **#245**: Add `scripts/generate-changelog.sh` that parses `git log` conventional commits into categorised changelog entries (feat→Added, fix→Fixed, other→Changed), with `--dry-run` support

Closes #244, closes #245

## Test plan

- [x] `release.yml` references only `docker-compose.prod.yml` (verified with grep)
- [x] `scripts/generate-changelog.sh --dry-run` produces correct categorised output
- [x] CHANGELOG.md follows Keep a Changelog format with valid markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)