### PR TITLE
fix: add greenlet to api requirements

### DIFF
--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.115.6
 uvicorn==0.34.0
 pydantic==2.10.4
 sqlmodel==0.0.22
+greenlet==3.3.2
 alembic==1.14.1
 asyncpg==0.30.0
 aiosqlite==0.21.0


### PR DESCRIPTION
## Summary
- add explicit greenlet dependency to API requirements for SQLAlchemy async portability
- align the API dependency set with the release matrix expectation on macOS, Windows and Linux
- unblock #260 and the release dry-run blocker identified in #254

## Validation
- services/api: .venv/bin/pytest tests -q
- release dry-run on branch: 23721986887 (macOS test-matrix now passes; run still in progress at PR creation time)

Closes #260