### PR TITLE
fix: bootstrap prod schema before api startup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      api_migrate:
+        condition: service_completed_successfully
     ports:
       - "8000:8000"
     healthcheck:
@@ -60,6 +62,21 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+
+  api_migrate:
+    build:
+      context: .
+      dockerfile: services/api/Dockerfile
+      target: runtime
+    restart: "no"
+    environment:
+      DATA_ROOT: /
+      DATABASE_URL: postgresql+asyncpg://training:training@postgres:5432/training
+      APP_SECRET_KEY: "${APP_SECRET_KEY:-change-me-in-production}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: ["alembic", "upgrade", "head"]
 
   ai_gateway:
     build:


### PR DESCRIPTION
## Summary
- add a one-shot api_migrate service to docker-compose.prod.yml
- make the production API wait for Alembic migrations to complete successfully
- unblock the release integration job so the prod stack serves DB-backed routes on first boot

## Validation
- Release dry-run on branch: run 23722401110
- integration: passed
- docker api, ai-gateway and web jobs: passed
- test matrix on linux, windows and macos: passed
- install matrix on linux, windows and macos: passed

Related to #254
