### PR TITLE
fix: unblock rc linux and mac packaging

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,9 +10,9 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dist": "electron-builder",
-    "dist:dmg": "electron-builder --mac dmg",
-    "dist:dir": "electron-builder --mac dir",
+    "dist": "electron-builder --publish never",
+    "dist:dmg": "electron-builder --mac dmg --publish never",
+    "dist:dir": "electron-builder --mac dir --publish never",
     "dist:win": "electron-builder --win nsis portable --publish never"
   },
   "build": {

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -219,7 +219,12 @@ cp -r "$REPO_ROOT/apps/web/services" "$BUILD_DIR/opt/42-training/apps/web/"
 cp "$REPO_ROOT/apps/web/package.json" "$BUILD_DIR/opt/42-training/apps/web/"
 cp "$REPO_ROOT/apps/web/package-lock.json" "$BUILD_DIR/opt/42-training/apps/web/" 2>/dev/null || true
 cp "$REPO_ROOT/apps/web/tsconfig.json" "$BUILD_DIR/opt/42-training/apps/web/"
-cp "$REPO_ROOT/apps/web/next.config.ts" "$BUILD_DIR/opt/42-training/apps/web/"
+for next_config in next.config.mjs next.config.js next.config.ts; do
+    if [ -f "$REPO_ROOT/apps/web/$next_config" ]; then
+        cp "$REPO_ROOT/apps/web/$next_config" "$BUILD_DIR/opt/42-training/apps/web/"
+        break
+    fi
+done
 
 # Curriculum data
 cp "$REPO_ROOT/packages/curriculum/data/"*.json "$BUILD_DIR/opt/42-training/packages/curriculum/data/"

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -20,6 +20,11 @@ DESKTOP_DIR="${ROOT_DIR}/desktop"
 STAGE_DIR="${DESKTOP_DIR}/staging"
 PYTHON="${PYTHON:-python3}"
 SIGN=false
+RELEASE_VERSION="${RELEASE_VERSION:-}"
+
+if [ -z "${RELEASE_VERSION}" ] && [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+  RELEASE_VERSION="${GITHUB_REF#refs/tags/v}"
+fi
 
 for arg in "$@"; do
   case "$arg" in
@@ -121,6 +126,11 @@ rm -rf "${STAGE_DIR}"
 
 # Install Electron dependencies
 (cd "${DESKTOP_DIR}" && npm ci)
+
+if [ -n "${RELEASE_VERSION}" ]; then
+  echo "  Applying desktop version: ${RELEASE_VERSION}"
+  (cd "${DESKTOP_DIR}" && npm version --no-git-tag-version "${RELEASE_VERSION}")
+fi
 
 # ------------------------------------------------------------------
 # 6. Build .dmg with electron-builder

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -20,6 +20,11 @@ $RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
 $DesktopDir = Join-Path $RepoRoot "desktop"
 $StageDir = Join-Path $DesktopDir "staging"
 $PythonExe = (Get-Command python -ErrorAction SilentlyContinue)?.Source
+$ReleaseVersion = $env:RELEASE_VERSION
+
+if (-not $ReleaseVersion -and $env:GITHUB_REF -like 'refs/tags/v*') {
+    $ReleaseVersion = $env:GITHUB_REF.Substring(11)
+}
 
 if (-not $PythonExe) {
     Write-Error "python is required on PATH to build the bundled desktop services."
@@ -102,6 +107,10 @@ Remove-Item $StageDir -Recurse -Force
 
 Push-Location $DesktopDir
 npm ci
+if ($ReleaseVersion) {
+    Write-Host "  Applying desktop version: $ReleaseVersion" -ForegroundColor Green
+    npm version $ReleaseVersion --no-git-tag-version
+}
 Pop-Location
 
 Write-Host "  Electron deps OK" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- fix Linux .deb packaging to copy the actual Next.js config file
- disable Electron auto-publish for macOS builds and align desktop version with the release tag
- align the Windows desktop bundle version with the release tag during tagged builds

## Validation
- bash -n scripts/build-macos.sh
- bash -n packaging/deb/build-deb.sh
- bash packaging/deb/build-deb.sh 0.1.0-localtest