### PR TITLE
fix: repair promote release workflow parsing

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -25,18 +25,7 @@ jobs:
 
           echo "Looking up release for tag or release name: ${TAG}"
           RELEASE_JSON="$(gh api repos/${{ github.repository }}/releases)"
-          RELEASE_ID="$(printf '%s' "${RELEASE_JSON}" | python3 - "${TAG}" <<'PY'
-import json
-import sys
-
-tag = sys.argv[1]
-releases = json.load(sys.stdin)
-for release in releases:
-    if release.get("tag_name") == tag or release.get("name") == tag:
-        print(release["id"])
-        break
-PY
-)"
+          RELEASE_ID="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json, sys; tag = sys.argv[1]; releases = json.load(sys.stdin); print(next((str(release[\"id\"]) for release in releases if release.get(\"tag_name\") == tag or release.get(\"name\") == tag), \"\"))' "${TAG}")"
 
           if [ -z "${RELEASE_ID}" ]; then
             echo "::error::Release '${TAG}' not found"
@@ -46,12 +35,7 @@ PY
           RELEASE_STATE="$(gh api repos/${{ github.repository }}/releases/${RELEASE_ID} -q '{draft: .draft, prerelease: .prerelease, tag_name: .tag_name, name: .name}')"
           echo "Matched release: ${RELEASE_STATE}"
 
-          DRAFT="$(printf '%s' "${RELEASE_STATE}" | python3 - <<'PY'
-import json
-import sys
-print(str(json.load(sys.stdin)["draft"]).lower())
-PY
-)"
+          DRAFT="$(printf '%s' "${RELEASE_STATE}" | python3 -c 'import json, sys; print(str(json.load(sys.stdin)[\"draft\"]).lower())')"
 
           if [ "${DRAFT}" != "true" ]; then
             echo "Release '${TAG}' is already published (draft=${DRAFT}). Nothing to do."


### PR DESCRIPTION
## Summary
- replace heredoc-based Python snippets in .github/workflows/promote-release.yml
- keep the release promotion logic intact while making the workflow valid YAML
- remove the false failing workflow check on pushes to main

## Validation
- parsed the workflow locally after the change
