### PR TITLE
feat: terminal Q&A defense + provenance tags for mentor (#292)

### DIFF
--- a/apps/web/app/defense/DefenseClient.tsx
+++ b/apps/web/app/defense/DefenseClient.tsx
@@ -9,7 +9,6 @@ import {
   GuidedPanel,
   GuidedSelect,
   GuidedStatusBar,
-  GuidedTextarea,
   GuidedSidebarSection,
 } from "@/app/components/GuidedSurface";
 import { TerminalPane } from "@/app/components/TerminalPane";
@@ -555,15 +554,24 @@ export default function DefenseClient({
               ) : null}
 
               <div className="space-y-5">
-                <p className="font-mono text-[14px] font-bold leading-9 text-[var(--shell-success)]">
+                <p className="font-mono text-[14px] font-bold leading-9 whitespace-pre-wrap text-[var(--shell-success)]">
                   examiner&gt; {currentQuestion.text}
                 </p>
-                <GuidedTextarea
-                  value={answer}
-                  onChange={(event) => setAnswer(event.target.value)}
-                  placeholder="learner > explain how you reason about this question..."
-                  disabled={submitting || lastFeedback !== null}
-                />
+                <div className="border border-[rgba(0,224,110,0.4)] bg-[var(--shell-canvas)] px-4 py-3">
+                  <textarea
+                    value={answer}
+                    onChange={(event) => setAnswer(event.target.value)}
+                    placeholder="learner > type your answer..."
+                    disabled={submitting || lastFeedback !== null}
+                    className="min-h-[110px] w-full resize-none bg-transparent font-mono text-[13px] leading-[22px] text-[var(--shell-ink)] outline-none placeholder:text-[var(--shell-dim)]"
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" && !event.shiftKey && answer.trim().length > 0 && !submitting && lastFeedback === null) {
+                        event.preventDefault();
+                        void handleSubmitAnswer(answer.trim());
+                      }
+                    }}
+                  />
+                </div>
               </div>
 
               {lastFeedback ? (

--- a/apps/web/app/mentor/MentorClient.tsx
+++ b/apps/web/app/mentor/MentorClient.tsx
@@ -12,7 +12,6 @@ import {
   GuidedStatusBar,
   GuidedTextarea,
 } from "@/app/components/GuidedSurface";
-import { SourcePolicyBadge } from "@/app/components/SourcePolicyBadge";
 import { TerminalPane } from "@/app/components/TerminalPane";
 
 type Module = {
@@ -395,27 +394,9 @@ export default function MentorClient({
                     </div>
 
                     {message.response && message.response.sources_used.length > 0 ? (
-                      <div className="flex flex-wrap items-center gap-2">
-                        {message.response.sources_used.map((source, index) => (
-                          <span key={`${message.id}-${index}`} className="inline-flex items-center gap-2">
-                            <SourcePolicyBadge tier={source.tier} />
-                            {source.url ? (
-                              <a
-                                href={source.url}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--shell-dim)] underline-offset-4 hover:text-[var(--shell-success)] hover:underline"
-                              >
-                                {source.label}
-                              </a>
-                            ) : (
-                              <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--shell-dim)]">
-                                {source.label}
-                              </span>
-                            )}
-                          </span>
-                        ))}
-                      </div>
+                      <p className="font-mono text-[9px] text-[var(--shell-dim)]">
+                        {`source: ${message.response.sources_used.map((s) => s.label).join(", ")} (${message.response.sources_used[0]?.tier ?? "unknown"}) // ${message.response.confidence_level}`}
+                      </p>
                     ) : null}
 
                     <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary

- **Defense (page 05)**: Replace `GuidedTextarea` with terminal-style answer input matching Figma — green bordered area (`border-[rgba(0,224,110,0.4)]`), transparent bg, monospace `learner >` placeholder, Enter key submit
- **Mentor (page 06)**: Replace `SourcePolicyBadge` component badges with Figma-canonical provenance text tags: `source: label (tier) // confidence`
- Clean up unused imports (`GuidedTextarea` from Defense, `SourcePolicyBadge` from Mentor)

## Test plan
- [x] `tsc --noEmit` — zero new errors (only pre-existing Playwright devDep errors)
- [x] ESLint — clean
- [ ] Manual: verify `/defense` answer input has green terminal border and monospace font
- [ ] Manual: verify `/mentor` responses show text-based provenance tags instead of badge components

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)