### PR TITLE
feat: interactive node graph on dashboard (#290)

### DIFF
--- a/apps/web/app/dashboard/SkillGraph.tsx
+++ b/apps/web/app/dashboard/SkillGraph.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState, useCallback } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export type NodeState = "done" | "in_progress" | "todo";
+
+export type GraphNodeData = {
+  id: string;
+  title: string;
+  trackId: string;
+  phase: string;
+  skillCount: number;
+  state: NodeState;
+  prerequisites: string[];
+};
+
+type LayoutNode = GraphNodeData & { x: number; y: number; tier: number };
+
+type Edge = {
+  fromId: string;
+  toId: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+type TrackTheme = {
+  accent: string;
+  surface: string;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const NODE_W = 160;
+const NODE_H = 56;
+const TIER_GAP = 120;
+const COL_GAP = 40;
+const PAD = 40;
+
+/* ------------------------------------------------------------------ */
+/*  Layout algorithm                                                   */
+/* ------------------------------------------------------------------ */
+
+function computeLayout(nodes: GraphNodeData[]): {
+  layout: LayoutNode[];
+  edges: Edge[];
+  width: number;
+  height: number;
+} {
+  if (nodes.length === 0) return { layout: [], edges: [], width: 0, height: 0 };
+
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+
+  // Compute tier (depth) for each node via BFS from roots
+  const tierMap = new Map<string, number>();
+
+  function tier(id: string, visited: Set<string>): number {
+    if (tierMap.has(id)) return tierMap.get(id)!;
+    if (visited.has(id)) return 0;
+    visited.add(id);
+    const node = byId.get(id);
+    const deps = (node?.prerequisites ?? []).filter((d) => byId.has(d));
+    if (deps.length === 0) { tierMap.set(id, 0); return 0; }
+    const max = Math.max(...deps.map((d) => tier(d, visited)));
+    const t = max + 1;
+    tierMap.set(id, t);
+    return t;
+  }
+
+  for (const n of nodes) tier(n.id, new Set());
+
+  // Group by tier, sort within tier by original order
+  const tiers = new Map<number, GraphNodeData[]>();
+  for (const n of nodes) {
+    const t = tierMap.get(n.id) ?? 0;
+    if (!tiers.has(t)) tiers.set(t, []);
+    tiers.get(t)!.push(n);
+  }
+
+  const maxTier = Math.max(...tiers.keys());
+
+  // Compute canvas width from widest tier
+  let maxRowW = 0;
+  for (const [, row] of tiers) {
+    const w = row.length * NODE_W + (row.length - 1) * COL_GAP;
+    if (w > maxRowW) maxRowW = w;
+  }
+  const canvasW = Math.max(maxRowW + PAD * 2, 600);
+
+  // Position nodes
+  const layout: LayoutNode[] = [];
+  for (let t = 0; t <= maxTier; t++) {
+    const row = tiers.get(t) ?? [];
+    const rowW = row.length * NODE_W + (row.length - 1) * COL_GAP;
+    const startX = (canvasW - rowW) / 2;
+    const y = t * TIER_GAP + PAD;
+    for (let i = 0; i < row.length; i++) {
+      layout.push({ ...row[i], x: startX + i * (NODE_W + COL_GAP), y, tier: t });
+    }
+  }
+
+  // Build edges
+  const posMap = new Map(layout.map((n) => [n.id, n]));
+  const edges: Edge[] = [];
+  for (const n of nodes) {
+    for (const depId of n.prerequisites) {
+      const from = posMap.get(depId);
+      const to = posMap.get(n.id);
+      if (from && to) {
+        edges.push({
+          fromId: depId,
+          toId: n.id,
+          x1: from.x + NODE_W / 2,
+          y1: from.y + NODE_H,
+          x2: to.x + NODE_W / 2,
+          y2: to.y,
+        });
+      }
+    }
+  }
+
+  const canvasH = (maxTier + 1) * TIER_GAP + PAD * 2;
+  return { layout, edges, width: canvasW, height: canvasH };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Visual helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+function nodeVisual(state: NodeState, theme: TrackTheme) {
+  if (state === "done") {
+    return {
+      border: theme.accent,
+      bg: theme.surface,
+      text: theme.accent,
+      label: "done",
+    };
+  }
+  if (state === "in_progress") {
+    return {
+      border: "var(--shell-warning)",
+      bg: "rgba(247, 190, 22, 0.08)",
+      text: "var(--shell-warning)",
+      label: "active",
+    };
+  }
+  return {
+    border: "var(--shell-border)",
+    bg: "rgba(45, 47, 54, 0.15)",
+    text: "var(--shell-dim)",
+    label: "locked",
+  };
+}
+
+function edgeColor(fromState: NodeState, accent: string) {
+  if (fromState === "done") return accent;
+  if (fromState === "in_progress") return "var(--shell-warning)";
+  return "var(--shell-border)";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function SkillGraph({
+  nodes,
+  themes,
+}: {
+  nodes: GraphNodeData[];
+  themes: Record<string, TrackTheme>;
+}) {
+  const { layout, edges, width, height } = useMemo(() => computeLayout(nodes), [nodes]);
+  const byId = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = selectedId ? byId.get(selectedId) ?? null : null;
+
+  const handleSelect = useCallback((id: string) => {
+    setSelectedId((prev) => (prev === id ? null : id));
+  }, []);
+
+  const handleKey = useCallback(
+    (id: string, e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleSelect(id);
+      }
+    },
+    [handleSelect],
+  );
+
+  if (nodes.length === 0) return null;
+
+  const themeFor = (trackId: string) =>
+    themes[trackId] ?? { accent: "var(--shell-success)", surface: "var(--shell-10)" };
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+      {/* Canvas */}
+      <div
+        className="relative overflow-x-auto border border-[var(--shell-border)] bg-[var(--shell-canvas)]"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle, var(--shell-border) 1px, transparent 1px)",
+          backgroundSize: "20px 20px",
+        }}
+      >
+        <svg
+          width={width}
+          height={height}
+          className="mx-auto block"
+          role="img"
+          aria-label="Module dependency graph"
+        >
+          {/* Edges */}
+          {edges.map((e) => {
+            const from = byId.get(e.fromId);
+            return (
+              <line
+                key={`${e.fromId}-${e.toId}`}
+                x1={e.x1}
+                y1={e.y1}
+                x2={e.x2}
+                y2={e.y2}
+                stroke={edgeColor(from?.state ?? "todo", themeFor(from?.trackId ?? "shell").accent)}
+                strokeWidth={1}
+                strokeDasharray="6 4"
+                strokeOpacity={0.6}
+              />
+            );
+          })}
+
+          {/* Nodes */}
+          {layout.map((node) => {
+            const theme = themeFor(node.trackId);
+            const v = nodeVisual(node.state, theme);
+            const isSelected = node.id === selectedId;
+
+            return (
+              <foreignObject key={node.id} x={node.x} y={node.y} width={NODE_W} height={NODE_H}>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => handleSelect(node.id)}
+                  onKeyDown={(e) => handleKey(node.id, e)}
+                  className="flex h-full cursor-pointer flex-col justify-between px-3 py-2 transition-colors"
+                  style={{
+                    borderWidth: isSelected || node.state === "in_progress" ? 2 : 1,
+                    borderStyle: "solid",
+                    borderColor: isSelected ? "var(--shell-success)" : v.border,
+                    backgroundColor: v.bg,
+                    boxShadow: isSelected ? "0 0 0 2px var(--shell-success)" : "none",
+                  }}
+                >
+                  <div className="flex items-start justify-between gap-1">
+                    <span
+                      className="font-mono text-[9px] uppercase tracking-[0.24em]"
+                      style={{ color: v.text }}
+                    >
+                      {v.label}
+                    </span>
+                    <span className="font-mono text-[9px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
+                      {node.skillCount}sk
+                    </span>
+                  </div>
+                  <h3
+                    className="truncate font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--shell-ink)]"
+                  >
+                    {node.title}
+                  </h3>
+                </div>
+              </foreignObject>
+            );
+          })}
+        </svg>
+
+        {/* Status bar */}
+        <div className="flex items-center justify-between border-t border-[var(--shell-border)] px-4 py-1.5">
+          <p className="font-mono text-[10px] text-[var(--shell-dim)]">
+            {nodes.length} nodes // {edges.length} edges
+          </p>
+        </div>
+      </div>
+
+      {/* Detail sidebar */}
+      <aside className="border border-[var(--shell-border)] bg-[var(--shell-panel)]">
+        {selected ? (
+          <NodeDetail node={selected} allNodes={nodes} themeFor={themeFor} />
+        ) : (
+          <div className="flex h-full items-center justify-center p-6">
+            <p className="text-center font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-dim)]">
+              Click a node to inspect
+            </p>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Node detail panel                                                  */
+/* ------------------------------------------------------------------ */
+
+function NodeDetail({
+  node,
+  allNodes,
+  themeFor,
+}: {
+  node: GraphNodeData;
+  allNodes: GraphNodeData[];
+  themeFor: (trackId: string) => TrackTheme;
+}) {
+  const byId = new Map(allNodes.map((n) => [n.id, n]));
+  const prereqs = node.prerequisites.map((id) => byId.get(id)).filter(Boolean) as GraphNodeData[];
+  const dependents = allNodes.filter((n) => n.prerequisites.includes(node.id));
+  const theme = themeFor(node.trackId);
+  const v = nodeVisual(node.state, theme);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Section label pattern from Figma */}
+      <div>
+        <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Module</p>
+        <p className="mt-1 font-mono text-sm font-semibold uppercase tracking-[0.12em] text-[var(--shell-ink)]">
+          {node.title}
+        </p>
+      </div>
+
+      <div>
+        <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Status</p>
+        <p className="mt-1 font-mono text-xs font-bold uppercase" style={{ color: v.text }}>
+          {v.label}
+        </p>
+      </div>
+
+      <div>
+        <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Skills</p>
+        <p className="mt-1 font-mono text-xs text-[var(--shell-muted)]">
+          {node.skillCount} skills // {node.phase} phase
+        </p>
+      </div>
+
+      {prereqs.length > 0 && (
+        <div>
+          <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Prerequisites</p>
+          <div className="mt-1 space-y-0.5">
+            {prereqs.map((dep, i) => (
+              <p key={dep.id} className="font-mono text-[10px] leading-4 text-[var(--shell-dim)]">
+                <span>{i === prereqs.length - 1 ? "└── " : "├── "}</span>
+                <span className={dep.state === "done" ? "text-[var(--shell-success)]" : ""}>
+                  {dep.title}
+                </span>
+                {dep.state === "done" && (
+                  <span className="ml-1 text-[var(--shell-success)]">[DONE]</span>
+                )}
+              </p>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {dependents.length > 0 && (
+        <div>
+          <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Unlocks</p>
+          <div className="mt-1 space-y-0.5">
+            {dependents.map((dep) => (
+              <p key={dep.id} className="font-mono text-[10px] leading-4 text-[var(--shell-dim)]">
+                <span className="text-[var(--shell-muted)]">→ </span>
+                {dep.title}
+              </p>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Action */}
+      <div className="mt-auto pt-2">
+        {node.state === "todo" ? (
+          <p className="font-mono text-[10px] text-[var(--shell-dim)]">Complete prerequisites to unlock</p>
+        ) : (
+          <Link
+            href={`/modules/${node.id}`}
+            className="flex h-8 items-center justify-center font-mono text-[10px] font-bold uppercase tracking-[0.24em] transition-colors"
+            style={{
+              backgroundColor: node.state === "in_progress" ? "var(--shell-warning)" : theme.accent,
+              color: "var(--shell-canvas)",
+            }}
+          >
+            {node.state === "in_progress" ? "[ CONTINUE ]" : "[ REVIEW ]"}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -5,6 +5,8 @@ import { DataSourceBadge } from "@/app/components/DataSourceBadge";
 import { getAnalyticsData, getDashboardData, getTmuxSessions } from "@/lib/api";
 import { countSkills, deriveModuleState, getLearningContext, getTrackTheme, summarizeSessions } from "@/lib/learner-progress";
 
+import { SkillGraph, type GraphNodeData } from "./SkillGraph";
+
 function Panel({
   children,
   className = "",
@@ -37,69 +39,6 @@ function StatBlock({
   );
 }
 
-function ModuleNode({
-  href,
-  title,
-  phase,
-  skillCount,
-  state,
-  accent,
-  surface,
-}: {
-  href: string;
-  title: string;
-  phase: string;
-  skillCount: number;
-  state: "done" | "in_progress" | "todo";
-  accent: string;
-  surface: string;
-}) {
-  const visual =
-    state === "done"
-      ? {
-          borderColor: accent,
-          backgroundColor: surface,
-          textColor: accent,
-        }
-      : state === "in_progress"
-        ? {
-            borderColor: "var(--shell-warning)",
-            backgroundColor: "rgba(247, 190, 22, 0.08)",
-            textColor: "var(--shell-warning)",
-          }
-        : {
-            borderColor: "var(--shell-border)",
-            backgroundColor: "rgba(45, 47, 54, 0.15)",
-            textColor: "var(--shell-dim)",
-          };
-
-  const connectorColor = state === "todo" ? "var(--shell-border)" : accent;
-  const phaseLabel = state === "in_progress" ? "active" : state === "done" ? "done" : phase;
-
-  return (
-    <div className="flex min-w-[240px] items-center gap-3">
-      <Link
-        href={href}
-        className="flex min-h-[120px] min-w-[180px] flex-col justify-between border px-4 py-4 transition-colors hover:border-[var(--shell-success)]"
-        style={{ borderColor: visual.borderColor, backgroundColor: visual.backgroundColor }}
-      >
-        <div className="flex items-start justify-between gap-3">
-          <span className="font-mono text-[10px] uppercase tracking-[0.24em]" style={{ color: visual.textColor }}>
-            {phaseLabel}
-          </span>
-          <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
-            {skillCount} skills
-          </span>
-        </div>
-        <h3 className="mt-6 font-mono text-sm font-semibold uppercase tracking-[0.12em] text-[var(--shell-ink)]">
-          {title}
-        </h3>
-      </Link>
-      <div className="h-px min-w-8 flex-1 border-t border-dashed" style={{ borderColor: connectorColor }} />
-    </div>
-  );
-}
-
 export default async function DashboardPage() {
   const [data, analytics, tmuxData] = await Promise.all([
     getDashboardData(),
@@ -109,23 +48,37 @@ export default async function DashboardPage() {
 
   const { curriculum, progression } = data;
   const { activeTrack, activeModule, modules, trackStats } = getLearningContext(data);
-  const orderedTracks = [...curriculum.tracks].sort((left, right) => {
-    if (left.id === activeTrack) {
-      return -1;
-    }
-    if (right.id === activeTrack) {
-      return 1;
-    }
-    return 0;
-  });
 
   const completedModules = modules.filter((entry) => entry.state === "done").length;
   const totalModules = modules.length;
   const totalSkills = countSkills(curriculum.tracks);
   const tmuxSummary = summarizeSessions(tmuxData.sessions);
 
+  // Build graph nodes from all tracks
+  const graphNodes: GraphNodeData[] = curriculum.tracks.flatMap((track) =>
+    track.modules.map((mod) => ({
+      id: mod.id,
+      title: mod.title,
+      trackId: track.id,
+      phase: mod.phase,
+      skillCount: mod.skills.length,
+      state: deriveModuleState(mod.id, track.id, activeTrack, activeModule, track.modules),
+      prerequisites: (mod.prerequisites ?? []).filter((depId) =>
+        curriculum.tracks.some((t) => t.modules.some((m) => m.id === depId)),
+      ),
+    })),
+  );
+
+  // Build themes map for the client component
+  const themes: Record<string, { accent: string; surface: string }> = {};
+  for (const track of curriculum.tracks) {
+    const t = getTrackTheme(track.id);
+    themes[track.id] = { accent: t.accent, surface: t.surface };
+  }
+
   return (
     <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
+      {/* ---------- Sidebar stats ---------- */}
       <div className="grid gap-4">
         <Panel>
           <StatBlock
@@ -179,6 +132,7 @@ export default async function DashboardPage() {
         </Panel>
       </div>
 
+      {/* ---------- Main content ---------- */}
       <div className="grid gap-4">
         <Panel className="px-6 py-5">
           <div className="flex flex-wrap items-center justify-between gap-4">
@@ -188,7 +142,7 @@ export default async function DashboardPage() {
                 Skill graph // learner state
               </h1>
               <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--shell-muted)]">
-                This surface is now dedicated to the competency map. It keeps the cross-track graph readable and pushes curriculum detail back into track and module views.
+                Interactive competency map. Click any node to inspect prerequisites, skills and progress. Edges show dependency chains across the curriculum.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-3">
@@ -218,69 +172,35 @@ export default async function DashboardPage() {
           </div>
         </Panel>
 
-        <Panel className="px-6 py-6">
-          <div className="grid gap-6">
-            {orderedTracks.map((track) => {
+        {/* Interactive node graph */}
+        <SkillGraph nodes={graphNodes} themes={themes} />
+
+        {/* Per-track progress summary */}
+        <Panel className="px-6 py-5">
+          <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Track progress</p>
+          <div className="mt-4 grid gap-3">
+            {curriculum.tracks.map((track) => {
               const stats = trackStats.find((entry) => entry.id === track.id);
               const theme = getTrackTheme(track.id);
-
               return (
-                <section key={track.id} className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-5 py-5">
-                  <div className="flex flex-wrap items-start justify-between gap-4">
-                    <div>
-                      <p className="font-mono text-[9px] uppercase tracking-[0.28em]" style={{ color: theme.accent }}>
-                        {theme.label} track
-                      </p>
-                      <h2 className="mt-3 font-mono text-lg font-semibold uppercase tracking-[0.12em] text-[var(--shell-ink)]">
-                        {track.title}
-                      </h2>
-                      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--shell-muted)]">{track.summary}</p>
-                    </div>
-                    <div className="min-w-[180px]">
-                      <p className="font-mono text-right text-xl font-semibold" style={{ color: theme.accent }}>
-                        {stats?.percentComplete ?? 0}%
-                      </p>
-                      <div className="mt-3 h-2 overflow-hidden border border-[var(--shell-border)] bg-[var(--shell-panel)]">
-                        <div
-                          className="h-full"
-                          style={{ width: `${stats?.percentComplete ?? 0}%`, backgroundColor: theme.accent }}
-                        />
-                      </div>
-                      <p className="mt-3 text-right font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
-                        {stats?.completedModules ?? 0}/{stats?.totalModules ?? track.modules.length} modules
-                      </p>
+                <div key={track.id} className="flex items-center gap-4 border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="font-mono text-[9px] uppercase tracking-[0.28em]" style={{ color: theme.accent }}>
+                      {theme.label} track
+                    </p>
+                    <p className="mt-1 truncate font-mono text-xs font-semibold uppercase tracking-[0.12em] text-[var(--shell-ink)]">
+                      {track.title}
+                    </p>
+                  </div>
+                  <div className="w-24">
+                    <div className="h-1.5 overflow-hidden border border-[var(--shell-border)] bg-[var(--shell-panel)]">
+                      <div className="h-full" style={{ width: `${stats?.percentComplete ?? 0}%`, backgroundColor: theme.accent }} />
                     </div>
                   </div>
-
-                  <div className="mt-6 overflow-x-auto pb-2">
-                    <div className="flex min-w-max items-center">
-                      {track.modules.map((module, index) => {
-                        const state = deriveModuleState(module.id, track.id, activeTrack, activeModule, track.modules);
-                        const isLast = index === track.modules.length - 1;
-
-                        return (
-                          <div key={module.id} className="flex items-center">
-                            <ModuleNode
-                              href={`/modules/${module.id}`}
-                              title={module.title}
-                              phase={module.phase}
-                              skillCount={module.skills.length}
-                              state={state}
-                              accent={theme.accent}
-                              surface={theme.surface}
-                            />
-                            {isLast ? null : (
-                              <div
-                                className="h-px min-w-12 border-t border-dashed"
-                                style={{ borderColor: state === "todo" ? "var(--shell-border)" : theme.accent }}
-                              />
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </section>
+                  <p className="font-mono text-sm font-semibold tabular-nums" style={{ color: theme.accent }}>
+                    {stats?.percentComplete ?? 0}%
+                  </p>
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
## Summary
- Replace flat horizontal module cards with an **interactive SVG node graph** on the dashboard
- **SkillGraph** client component: tier-based layout from `prerequisites`, click-to-select nodes, keyboard navigation, dot-grid background (2px on charcoal), dashed edges
- **Node states**: done (track accent), active (amber/warning), locked (grey/border) — matches Figma HUD spec
- **Detail sidebar**: selected module shows prereqs with `[DONE]` markers, unlocked dependents, skills/phase, CTA buttons
- **Track progress panel**: compact per-track summary with progress bars replaces the old per-track horizontal scroll sections

## Design reference
Figma canonical: https://www.figma.com/design/qqaNVWa3c7UoVrrBo9gk3c — Page 02 Dashboard + Page 03 Track Explorer node patterns

## Test plan
- [x] `tsc --noEmit` — zero new errors (pre-existing Playwright type errors only)
- [x] Build failure is pre-existing (PostCSS/Turbopack, same on develop)
- [ ] Manual: verify graph renders at `/dashboard` with demo data
- [ ] Manual: click nodes, verify detail panel, keyboard nav (Enter/Space)
- [ ] Manual: check responsive layout (sidebar collapses on mobile)
- [ ] Manual: verify dot-grid background and dashed edges visible

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)