### PR TITLE
style: apply HUD tokens globally (#289)

### DIFF
--- a/apps/web/app/components/GuidedSurface.tsx
+++ b/apps/web/app/components/GuidedSurface.tsx
@@ -137,7 +137,7 @@ export function GuidedActionButton({
     variant === "primary"
       ? "border-[var(--shell-success)] bg-[var(--shell-success)] text-[var(--shell-canvas)] hover:bg-[var(--shell-success-strong)]"
       : variant === "danger"
-        ? "border-[var(--shell-danger)] bg-[var(--shell-danger)] text-[var(--shell-canvas)] hover:bg-[#ff6161]"
+        ? "border-[var(--shell-danger)] bg-[var(--shell-danger)] text-[var(--shell-canvas)] hover:brightness-125"
         : "border-[var(--shell-border-strong)] bg-transparent text-[var(--shell-ink)] hover:border-[var(--shell-success)] hover:text-[var(--shell-success)]";
 
   return (
@@ -193,11 +193,11 @@ export function GuidedBadge({
 }) {
   const className =
     tone === "success"
-      ? "border-[rgba(0,224,110,0.4)] text-[var(--shell-success)]"
+      ? "border-[var(--shell-success)]/40 text-[var(--shell-success)]"
       : tone === "warning"
-        ? "border-[rgba(255,175,0,0.35)] text-[var(--shell-warning)]"
+        ? "border-[var(--shell-warning)]/35 text-[var(--shell-warning)]"
         : tone === "danger"
-          ? "border-[rgba(255,65,65,0.35)] text-[var(--shell-danger)]"
+          ? "border-[var(--shell-danger)]/35 text-[var(--shell-danger)]"
           : "border-[var(--shell-border-strong)] text-[var(--shell-muted)]";
 
   return (

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -3,7 +3,13 @@ import type { ReactNode } from "react";
 
 import { DataSourceBadge } from "@/app/components/DataSourceBadge";
 import { getAnalyticsData, getDashboardData, getTmuxSessions } from "@/lib/api";
-import { countSkills, deriveModuleState, getLearningContext, getTrackTheme, summarizeSessions } from "@/lib/learner-progress";
+import {
+  countSkills,
+  deriveModuleState,
+  getLearningContext,
+  getTrackTheme,
+  summarizeSessions,
+} from "@/lib/learner-progress";
 
 function Panel({
   children,
@@ -13,7 +19,9 @@ function Panel({
   className?: string;
 }) {
   return (
-    <section className={`border border-[var(--shell-border)] bg-[var(--shell-panel)] ${className}`}>
+    <section
+      className={`border border-[var(--shell-border)] bg-[var(--shell-panel)] ${className}`}
+    >
       {children}
     </section>
   );
@@ -30,9 +38,15 @@ function StatBlock({
 }) {
   return (
     <div className="border-b border-[var(--shell-border)] px-4 py-4 last:border-b-0">
-      <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">{label}</p>
-      <p className="mt-3 font-mono text-2xl font-semibold text-[var(--shell-ink)]">{value}</p>
-      <p className="mt-2 font-mono text-[10px] leading-5 text-[var(--shell-muted)]">{detail}</p>
+      <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">
+        {label}
+      </p>
+      <p className="mt-3 font-mono text-2xl font-semibold text-[var(--shell-ink)]">
+        {value}
+      </p>
+      <p className="mt-2 font-mono text-[10px] leading-5 text-[var(--shell-muted)]">
+        {detail}
+      </p>
     </div>
   );
 }
@@ -64,27 +78,36 @@ function ModuleNode({
       : state === "in_progress"
         ? {
             borderColor: "var(--shell-warning)",
-            backgroundColor: "rgba(247, 190, 22, 0.08)",
+            backgroundColor:
+              "color-mix(in srgb, var(--shell-warning) 8%, transparent)",
             textColor: "var(--shell-warning)",
           }
         : {
             borderColor: "var(--shell-border)",
-            backgroundColor: "rgba(45, 47, 54, 0.15)",
+            backgroundColor:
+              "color-mix(in srgb, var(--shell-border) 15%, transparent)",
             textColor: "var(--shell-dim)",
           };
 
   const connectorColor = state === "todo" ? "var(--shell-border)" : accent;
-  const phaseLabel = state === "in_progress" ? "active" : state === "done" ? "done" : phase;
+  const phaseLabel =
+    state === "in_progress" ? "active" : state === "done" ? "done" : phase;
 
   return (
     <div className="flex min-w-[240px] items-center gap-3">
       <Link
         href={href}
         className="flex min-h-[120px] min-w-[180px] flex-col justify-between border px-4 py-4 transition-colors hover:border-[var(--shell-success)]"
-        style={{ borderColor: visual.borderColor, backgroundColor: visual.backgroundColor }}
+        style={{
+          borderColor: visual.borderColor,
+          backgroundColor: visual.backgroundColor,
+        }}
       >
         <div className="flex items-start justify-between gap-3">
-          <span className="font-mono text-[10px] uppercase tracking-[0.24em]" style={{ color: visual.textColor }}>
+          <span
+            className="font-mono text-[10px] uppercase tracking-[0.24em]"
+            style={{ color: visual.textColor }}
+          >
             {phaseLabel}
           </span>
           <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
@@ -95,7 +118,10 @@ function ModuleNode({
           {title}
         </h3>
       </Link>
-      <div className="h-px min-w-8 flex-1 border-t border-dashed" style={{ borderColor: connectorColor }} />
+      <div
+        className="h-px min-w-8 flex-1 border-t border-dashed"
+        style={{ borderColor: connectorColor }}
+      />
     </div>
   );
 }
@@ -108,7 +134,8 @@ export default async function DashboardPage() {
   ]);
 
   const { curriculum, progression } = data;
-  const { activeTrack, activeModule, modules, trackStats } = getLearningContext(data);
+  const { activeTrack, activeModule, modules, trackStats } =
+    getLearningContext(data);
   const orderedTracks = [...curriculum.tracks].sort((left, right) => {
     if (left.id === activeTrack) {
       return -1;
@@ -119,7 +146,9 @@ export default async function DashboardPage() {
     return 0;
   });
 
-  const completedModules = modules.filter((entry) => entry.state === "done").length;
+  const completedModules = modules.filter(
+    (entry) => entry.state === "done",
+  ).length;
   const totalModules = modules.length;
   const totalSkills = countSkills(curriculum.tracks);
   const tmuxSummary = summarizeSessions(tmuxData.sessions);
@@ -156,23 +185,33 @@ export default async function DashboardPage() {
         </Panel>
 
         <Panel className="px-5 py-5">
-          <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Session health</p>
+          <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">
+            Session health
+          </p>
           <div className="mt-4 grid gap-3">
             <div className="flex items-center justify-between border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.24em]">
               <span className="text-[var(--shell-muted)]">Live panes</span>
-              <span className="text-[var(--shell-success)]">{tmuxSummary.active}</span>
+              <span className="text-[var(--shell-success)]">
+                {tmuxSummary.active}
+              </span>
             </div>
             <div className="flex items-center justify-between border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.24em]">
               <span className="text-[var(--shell-muted)]">Idle panes</span>
-              <span className="text-[var(--shell-ink)]">{tmuxSummary.idle}</span>
+              <span className="text-[var(--shell-ink)]">
+                {tmuxSummary.idle}
+              </span>
             </div>
             <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4">
-              <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Current focus</p>
+              <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">
+                Current focus
+              </p>
               <p className="mt-3 font-mono text-sm text-[var(--shell-ink)]">
                 {progression.progress?.current_exercise ?? "No active exercise"}
               </p>
               <p className="mt-2 font-mono text-[10px] leading-5 text-[var(--shell-muted)]">
-                {progression.progress?.current_step ?? progression.next_command ?? "No current step visible in the learner session."}
+                {progression.progress?.current_step ??
+                  progression.next_command ??
+                  "No current step visible in the learner session."}
               </p>
             </div>
           </div>
@@ -183,12 +222,16 @@ export default async function DashboardPage() {
         <Panel className="px-6 py-5">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
-              <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Dashboard</p>
+              <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">
+                Dashboard
+              </p>
               <h1 className="mt-3 font-mono text-2xl font-semibold uppercase tracking-[0.1em] text-[var(--shell-ink)]">
                 Skill graph // learner state
               </h1>
               <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--shell-muted)]">
-                This surface is now dedicated to the competency map. It keeps the cross-track graph readable and pushes curriculum detail back into track and module views.
+                This surface is now dedicated to the competency map. It keeps
+                the cross-track graph readable and pushes curriculum detail back
+                into track and module views.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-3">
@@ -225,29 +268,44 @@ export default async function DashboardPage() {
               const theme = getTrackTheme(track.id);
 
               return (
-                <section key={track.id} className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-5 py-5">
+                <section
+                  key={track.id}
+                  className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-5 py-5"
+                >
                   <div className="flex flex-wrap items-start justify-between gap-4">
                     <div>
-                      <p className="font-mono text-[9px] uppercase tracking-[0.28em]" style={{ color: theme.accent }}>
+                      <p
+                        className="font-mono text-[9px] uppercase tracking-[0.28em]"
+                        style={{ color: theme.accent }}
+                      >
                         {theme.label} track
                       </p>
                       <h2 className="mt-3 font-mono text-lg font-semibold uppercase tracking-[0.12em] text-[var(--shell-ink)]">
                         {track.title}
                       </h2>
-                      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--shell-muted)]">{track.summary}</p>
+                      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--shell-muted)]">
+                        {track.summary}
+                      </p>
                     </div>
                     <div className="min-w-[180px]">
-                      <p className="font-mono text-right text-xl font-semibold" style={{ color: theme.accent }}>
+                      <p
+                        className="font-mono text-right text-xl font-semibold"
+                        style={{ color: theme.accent }}
+                      >
                         {stats?.percentComplete ?? 0}%
                       </p>
                       <div className="mt-3 h-2 overflow-hidden border border-[var(--shell-border)] bg-[var(--shell-panel)]">
                         <div
                           className="h-full"
-                          style={{ width: `${stats?.percentComplete ?? 0}%`, backgroundColor: theme.accent }}
+                          style={{
+                            width: `${stats?.percentComplete ?? 0}%`,
+                            backgroundColor: theme.accent,
+                          }}
                         />
                       </div>
                       <p className="mt-3 text-right font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
-                        {stats?.completedModules ?? 0}/{stats?.totalModules ?? track.modules.length} modules
+                        {stats?.completedModules ?? 0}/
+                        {stats?.totalModules ?? track.modules.length} modules
                       </p>
                     </div>
                   </div>
@@ -255,7 +313,13 @@ export default async function DashboardPage() {
                   <div className="mt-6 overflow-x-auto pb-2">
                     <div className="flex min-w-max items-center">
                       {track.modules.map((module, index) => {
-                        const state = deriveModuleState(module.id, track.id, activeTrack, activeModule, track.modules);
+                        const state = deriveModuleState(
+                          module.id,
+                          track.id,
+                          activeTrack,
+                          activeModule,
+                          track.modules,
+                        );
                         const isLast = index === track.modules.length - 1;
 
                         return (
@@ -272,7 +336,12 @@ export default async function DashboardPage() {
                             {isLast ? null : (
                               <div
                                 className="h-px min-w-12 border-t border-dashed"
-                                style={{ borderColor: state === "todo" ? "var(--shell-border)" : theme.accent }}
+                                style={{
+                                  borderColor:
+                                    state === "todo"
+                                      ? "var(--shell-border)"
+                                      : theme.accent,
+                                }}
                               />
                             )}
                           </div>

--- a/apps/web/app/defense/DefenseClient.tsx
+++ b/apps/web/app/defense/DefenseClient.tsx
@@ -153,9 +153,13 @@ export default function DefenseClient({
 
   const [results, setResults] = useState<DefenseResultResponse | null>(null);
 
-  const currentModule = modules.find((module) => module.id === selectedModule) ?? modules[0] ?? null;
+  const currentModule =
+    modules.find((module) => module.id === selectedModule) ??
+    modules[0] ??
+    null;
   const currentQuestion = questions[activeQuestionIndex] ?? null;
-  const currentTmux = tmuxSessions.find((session) => session.name === selectedTmux) ?? null;
+  const currentTmux =
+    tmuxSessions.find((session) => session.name === selectedTmux) ?? null;
 
   useEffect(() => {
     if (phase !== "active" || deadline === null) {
@@ -163,7 +167,10 @@ export default function DefenseClient({
     }
 
     const tick = () => {
-      const remaining = Math.max(0, Math.ceil((deadline.getTime() - Date.now()) / 1000));
+      const remaining = Math.max(
+        0,
+        Math.ceil((deadline.getTime() - Date.now()) / 1000),
+      );
       setSecondsLeft(remaining);
     };
 
@@ -177,13 +184,16 @@ export default function DefenseClient({
       return null;
     }
 
-    const average = history.reduce((total, item) => total + item.score, 0) / history.length;
+    const average =
+      history.reduce((total, item) => total + item.score, 0) / history.length;
     return average;
   }, [history]);
 
   const breakdown = useMemo(() => {
     return questions.map((question) => {
-      const entry = history.find((item) => item.questionId === question.question_id) ?? null;
+      const entry =
+        history.find((item) => item.questionId === question.question_id) ??
+        null;
       return {
         id: question.question_id,
         label: `Q${questions.findIndex((candidate) => candidate.question_id === question.question_id) + 1}`,
@@ -220,7 +230,9 @@ export default function DefenseClient({
     let terminalContext: Record<string, unknown> | undefined;
     if (selectedTmux) {
       try {
-        const paneResponse = await fetch(`${apiUrl}/api/v1/tmux/pane/${encodeURIComponent(selectedTmux)}`);
+        const paneResponse = await fetch(
+          `${apiUrl}/api/v1/tmux/pane/${encodeURIComponent(selectedTmux)}`,
+        );
         if (paneResponse.ok) {
           const pane = await paneResponse.json();
           terminalContext = { panes: { [selectedTmux]: pane.content } };
@@ -245,7 +257,9 @@ export default function DefenseClient({
       });
 
       if (!response.ok) {
-        const body = await response.json().catch(() => ({ detail: response.statusText }));
+        const body = await response
+          .json()
+          .catch(() => ({ detail: response.statusText }));
         throw new Error(body.detail ?? `API error ${response.status}`);
       }
 
@@ -257,17 +271,27 @@ export default function DefenseClient({
       setLastFeedback(null);
       setResults(null);
       setHistory([]);
-      setDeadline(data.current_question_deadline ? new Date(data.current_question_deadline) : null);
+      setDeadline(
+        data.current_question_deadline
+          ? new Date(data.current_question_deadline)
+          : null,
+      );
       setPhase("active");
     } catch (caughtError) {
-      setError(caughtError instanceof Error ? caughtError.message : "Failed to start defense");
+      setError(
+        caughtError instanceof Error
+          ? caughtError.message
+          : "Failed to start defense",
+      );
     } finally {
       setLoading(false);
     }
   }
 
   async function fetchResults(currentSessionId: string) {
-    const response = await fetch(`${apiUrl}/api/v1/defense/${currentSessionId}/result`);
+    const response = await fetch(
+      `${apiUrl}/api/v1/defense/${currentSessionId}/result`,
+    );
     if (!response.ok) {
       throw new Error(`Failed to fetch results: ${response.status}`);
     }
@@ -297,7 +321,9 @@ export default function DefenseClient({
       });
 
       if (!response.ok) {
-        const body = await response.json().catch(() => ({ detail: response.statusText }));
+        const body = await response
+          .json()
+          .catch(() => ({ detail: response.statusText }));
         throw new Error(body.detail ?? `API error ${response.status}`);
       }
 
@@ -330,11 +356,19 @@ export default function DefenseClient({
           setActiveQuestionIndex((value) => value + 1);
           setAnswer("");
           setLastFeedback(null);
-          setDeadline(data.next_question_deadline ? new Date(data.next_question_deadline) : null);
+          setDeadline(
+            data.next_question_deadline
+              ? new Date(data.next_question_deadline)
+              : null,
+          );
         }, 1800);
       }
     } catch (caughtError) {
-      setError(caughtError instanceof Error ? caughtError.message : "Failed to submit answer");
+      setError(
+        caughtError instanceof Error
+          ? caughtError.message
+          : "Failed to submit answer",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -362,7 +396,9 @@ export default function DefenseClient({
       <GuidedSidebarSection label="Running score">
         <div className="space-y-1">
           <p className="font-mono text-4xl font-bold text-[var(--shell-warning)]">
-            {runningScore === null ? "__ / 5" : `${formatFiveScale(runningScore)} / 5`}
+            {runningScore === null
+              ? "__ / 5"
+              : `${formatFiveScale(runningScore)} / 5`}
           </p>
           <GuidedBadge tone={sourceMode === "live" ? "success" : "warning"}>
             {sourceMode === "live" ? "API live" : "demo mode"}
@@ -377,7 +413,10 @@ export default function DefenseClient({
           ) : (
             breakdown.map((entry) => (
               <p key={entry.id}>
-                {entry.label} {scoreBars(entry.score)} {entry.score === null ? "___" : `${Math.round(entry.score * 5)}/5`}
+                {entry.label} {scoreBars(entry.score)}{" "}
+                {entry.score === null
+                  ? "___"
+                  : `${Math.round(entry.score * 5)}/5`}
               </p>
             ))
           )}
@@ -420,7 +459,7 @@ export default function DefenseClient({
           {sidebar}
 
           <div className="grid gap-4">
-            <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[rgba(255,65,65,0.3)] bg-[rgba(255,65,65,0.05)] px-6 py-3">
+            <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[var(--shell-danger)]/30 bg-[var(--shell-danger)]/5 px-6 py-3">
               <div>
                 <p className="font-mono text-[13px] font-bold uppercase tracking-[0.22em] text-[var(--shell-danger)]">
                   Defense // {currentModule?.id ?? "no-module"}
@@ -447,19 +486,27 @@ export default function DefenseClient({
                 Start a defense session
               </h2>
               <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--shell-muted)]">
-                Configure the oral defense exactly once, attach terminal context if needed, then answer timed questions in your own words.
-                This flow stays strict on reasoning quality and never falls back to solution-style hints.
+                Configure the oral defense exactly once, attach terminal context
+                if needed, then answer timed questions in your own words. This
+                flow stays strict on reasoning quality and never falls back to
+                solution-style hints.
               </p>
 
               {error ? (
-                <p className="mt-5 font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-danger)]" role="alert">
+                <p
+                  className="mt-5 font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-danger)]"
+                  role="alert"
+                >
                   {error}
                 </p>
               ) : null}
 
               <div className="mt-8 grid gap-4 lg:grid-cols-2">
                 <GuidedField label="Module">
-                  <GuidedSelect value={selectedModule} onChange={(event) => setSelectedModule(event.target.value)}>
+                  <GuidedSelect
+                    value={selectedModule}
+                    onChange={(event) => setSelectedModule(event.target.value)}
+                  >
                     {modules.map((module) => (
                       <option key={module.id} value={module.id}>
                         {module.trackTitle} — {module.title} ({module.phase})
@@ -469,7 +516,10 @@ export default function DefenseClient({
                 </GuidedField>
 
                 <GuidedField label="Terminal session">
-                  <GuidedSelect value={selectedTmux} onChange={(event) => setSelectedTmux(event.target.value)}>
+                  <GuidedSelect
+                    value={selectedTmux}
+                    onChange={(event) => setSelectedTmux(event.target.value)}
+                  >
                     <option value="">None — no terminal context</option>
                     {tmuxSessions.map((session) => (
                       <option key={session.name} value={session.name}>
@@ -481,7 +531,12 @@ export default function DefenseClient({
                 </GuidedField>
 
                 <GuidedField label="Questions">
-                  <GuidedSelect value={numQuestions} onChange={(event) => setNumQuestions(Number(event.target.value))}>
+                  <GuidedSelect
+                    value={numQuestions}
+                    onChange={(event) =>
+                      setNumQuestions(Number(event.target.value))
+                    }
+                  >
                     {[1, 2, 3, 4, 5].map((value) => (
                       <option key={value} value={value}>
                         {value}
@@ -491,7 +546,12 @@ export default function DefenseClient({
                 </GuidedField>
 
                 <GuidedField label="Time per question">
-                  <GuidedSelect value={timeLimit} onChange={(event) => setTimeLimit(Number(event.target.value))}>
+                  <GuidedSelect
+                    value={timeLimit}
+                    onChange={(event) =>
+                      setTimeLimit(Number(event.target.value))
+                    }
+                  >
                     {[30, 45, 60, 90, 120, 180].map((value) => (
                       <option key={value} value={value}>
                         {value}s
@@ -502,7 +562,10 @@ export default function DefenseClient({
               </div>
 
               <div className="mt-8 flex flex-wrap gap-3">
-                <GuidedActionButton onClick={handleStart} disabled={loading || !selectedModule}>
+                <GuidedActionButton
+                  onClick={handleStart}
+                  disabled={loading || !selectedModule}
+                >
                   {loading ? "Starting..." : "Begin defense"}
                 </GuidedActionButton>
               </div>
@@ -519,7 +582,8 @@ export default function DefenseClient({
   }
 
   if (phase === "active" && currentQuestion !== null) {
-    const timerTone = secondsLeft <= 5 ? "danger" : secondsLeft <= 15 ? "warning" : "default";
+    const timerTone =
+      secondsLeft <= 5 ? "danger" : secondsLeft <= 15 ? "warning" : "default";
 
     return (
       <div className="grid gap-4">
@@ -527,7 +591,7 @@ export default function DefenseClient({
           {sidebar}
 
           <div className="grid gap-4">
-            <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[rgba(255,65,65,0.3)] bg-[rgba(255,65,65,0.05)] px-6 py-3">
+            <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[var(--shell-danger)]/30 bg-[var(--shell-danger)]/5 px-6 py-3">
               <p className="font-mono text-[13px] font-bold uppercase tracking-[0.22em] text-[var(--shell-danger)]">
                 Defense // {currentModule?.id ?? "no-module"}
               </p>
@@ -570,24 +634,39 @@ export default function DefenseClient({
                 <GuidedPanel
                   className={`px-4 py-4 ${
                     lastFeedback.score >= 0.7
-                      ? "border-[rgba(0,224,110,0.35)]"
+                      ? "border-[var(--shell-success)]/35"
                       : lastFeedback.score >= 0.4
-                        ? "border-[rgba(255,175,0,0.35)]"
-                        : "border-[rgba(255,65,65,0.35)]"
+                        ? "border-[var(--shell-warning)]/35"
+                        : "border-[var(--shell-danger)]/35"
                   }`}
                 >
                   <div className="flex flex-wrap items-center gap-3">
-                    <GuidedBadge tone={lastFeedback.score >= 0.7 ? "success" : lastFeedback.score >= 0.4 ? "warning" : "danger"}>
+                    <GuidedBadge
+                      tone={
+                        lastFeedback.score >= 0.7
+                          ? "success"
+                          : lastFeedback.score >= 0.4
+                            ? "warning"
+                            : "danger"
+                      }
+                    >
                       score: {Math.round(lastFeedback.score * 100)}%
                     </GuidedBadge>
-                    {lastFeedback.timed_out ? <GuidedBadge tone="danger">timed out</GuidedBadge> : null}
+                    {lastFeedback.timed_out ? (
+                      <GuidedBadge tone="danger">timed out</GuidedBadge>
+                    ) : null}
                   </div>
-                  <p className="mt-4 text-sm leading-7 text-[var(--shell-muted)]">{lastFeedback.feedback}</p>
+                  <p className="mt-4 text-sm leading-7 text-[var(--shell-muted)]">
+                    {lastFeedback.feedback}
+                  </p>
                 </GuidedPanel>
               ) : null}
 
               {error ? (
-                <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-danger)]" role="alert">
+                <p
+                  className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-danger)]"
+                  role="alert"
+                >
                   {error}
                 </p>
               ) : null}
@@ -595,13 +674,19 @@ export default function DefenseClient({
               <div className="flex flex-wrap gap-3">
                 <GuidedActionButton
                   onClick={() => void handleSubmitAnswer(answer.trim())}
-                  disabled={submitting || answer.trim().length === 0 || lastFeedback !== null}
+                  disabled={
+                    submitting ||
+                    answer.trim().length === 0 ||
+                    lastFeedback !== null
+                  }
                 >
                   {submitting ? "Submitting..." : "Submit"}
                 </GuidedActionButton>
                 <GuidedActionButton
                   variant="secondary"
-                  onClick={() => void handleSubmitAnswer("[skipped by learner]")}
+                  onClick={() =>
+                    void handleSubmitAnswer("[skipped by learner]")
+                  }
                   disabled={submitting || lastFeedback !== null}
                 >
                   Skip
@@ -632,7 +717,7 @@ export default function DefenseClient({
           {sidebar}
 
           <div className="grid gap-4">
-            <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[rgba(255,65,65,0.3)] bg-[rgba(255,65,65,0.05)] px-6 py-3">
+            <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[var(--shell-danger)]/30 bg-[var(--shell-danger)]/5 px-6 py-3">
               <p className="font-mono text-[13px] font-bold uppercase tracking-[0.22em] text-[var(--shell-danger)]">
                 Defense // {currentModule?.id ?? "no-module"}
               </p>
@@ -651,7 +736,9 @@ export default function DefenseClient({
               <p className="mt-4 font-mono text-4xl font-bold text-[var(--shell-warning)]">
                 {Math.round(results.overall_score * 100)}%
               </p>
-              <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--shell-muted)]">{results.summary}</p>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--shell-muted)]">
+                {results.summary}
+              </p>
               {results.timed_out_questions > 0 ? (
                 <p className="mt-3 font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-danger)]">
                   {results.timed_out_questions} question(s) timed out
@@ -663,24 +750,44 @@ export default function DefenseClient({
                   <GuidedPanel key={item.question_id} className="px-4 py-4">
                     <div className="flex flex-wrap items-center gap-3">
                       <GuidedBadge>question {index + 1}</GuidedBadge>
-                      <GuidedBadge tone={item.score >= 0.7 ? "success" : item.score >= 0.4 ? "warning" : "danger"}>
+                      <GuidedBadge
+                        tone={
+                          item.score >= 0.7
+                            ? "success"
+                            : item.score >= 0.4
+                              ? "warning"
+                              : "danger"
+                        }
+                      >
                         {Math.round(item.score * 100)}%
                       </GuidedBadge>
                       <GuidedBadge>{item.skill}</GuidedBadge>
                     </div>
-                    <p className="mt-4 font-mono text-sm leading-7 text-[var(--shell-ink)]">{item.question}</p>
-                    <p className="mt-4 text-sm leading-7 text-[var(--shell-muted)]">{item.feedback}</p>
+                    <p className="mt-4 font-mono text-sm leading-7 text-[var(--shell-ink)]">
+                      {item.question}
+                    </p>
+                    <p className="mt-4 text-sm leading-7 text-[var(--shell-muted)]">
+                      {item.feedback}
+                    </p>
                     <div className="mt-4 flex flex-wrap gap-2">
-                      {item.timed_out ? <GuidedBadge tone="danger">timed out</GuidedBadge> : null}
-                      {!item.answered ? <GuidedBadge tone="warning">not answered</GuidedBadge> : null}
-                      <GuidedBadge>{item.elapsed_seconds.toFixed(1)}s</GuidedBadge>
+                      {item.timed_out ? (
+                        <GuidedBadge tone="danger">timed out</GuidedBadge>
+                      ) : null}
+                      {!item.answered ? (
+                        <GuidedBadge tone="warning">not answered</GuidedBadge>
+                      ) : null}
+                      <GuidedBadge>
+                        {item.elapsed_seconds.toFixed(1)}s
+                      </GuidedBadge>
                     </div>
                   </GuidedPanel>
                 ))}
               </div>
 
               <div className="mt-8 flex flex-wrap gap-3">
-                <GuidedActionButton onClick={handleReset}>New defense</GuidedActionButton>
+                <GuidedActionButton onClick={handleReset}>
+                  New defense
+                </GuidedActionButton>
               </div>
             </GuidedPanel>
           </div>
@@ -698,13 +805,19 @@ export default function DefenseClient({
     <GuidedPanel className="px-6 py-6">
       {error ? (
         <>
-          <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-danger)]">{error}</p>
+          <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-danger)]">
+            {error}
+          </p>
           <div className="mt-4">
-            <GuidedActionButton onClick={handleReset}>Try again</GuidedActionButton>
+            <GuidedActionButton onClick={handleReset}>
+              Try again
+            </GuidedActionButton>
           </div>
         </>
       ) : (
-        <p className="font-mono text-sm text-[var(--shell-muted)]">Loading...</p>
+        <p className="font-mono text-sm text-[var(--shell-muted)]">
+          Loading...
+        </p>
       )}
     </GuidedPanel>
   );

--- a/apps/web/app/profiles/page.tsx
+++ b/apps/web/app/profiles/page.tsx
@@ -33,7 +33,8 @@ function validateProfileForm(values: ProfileFormState): FormErrors {
   }
 
   if (values.login.trim() && !/^[a-z0-9-]+$/i.test(values.login.trim())) {
-    errors.login = "Use only letters, numbers or hyphens for the optional login.";
+    errors.login =
+      "Use only letters, numbers or hyphens for the optional login.";
   }
 
   return errors;
@@ -66,12 +67,18 @@ function normalizeNextPath(value: string | null) {
 export default function ProfilesPage() {
   const { refreshSession, session } = useAuth();
   const [tracks, setTracks] = useState<TrackItem[]>([]);
-  const [profilesState, setProfilesState] = useState<ProfilesState | null>(null);
+  const [profilesState, setProfilesState] = useState<ProfilesState | null>(
+    null,
+  );
   const [form, setForm] = useState<ProfileFormState>(INITIAL_FORM);
   const [errors, setErrors] = useState<FormErrors>({});
-  const [loadingState, setLoadingState] = useState<"loading" | "ready" | "error">("loading");
+  const [loadingState, setLoadingState] = useState<
+    "loading" | "ready" | "error"
+  >("loading");
   const [feedback, setFeedback] = useState<string | null>(null);
-  const [feedbackTone, setFeedbackTone] = useState<"success" | "error">("success");
+  const [feedbackTone, setFeedbackTone] = useState<"success" | "error">(
+    "success",
+  );
   const [isCreating, setIsCreating] = useState(false);
   const [switchingId, setSwitchingId] = useState<string | null>(null);
   const [searchState, setSearchState] = useState({
@@ -84,7 +91,10 @@ export default function ProfilesPage() {
     setLoadingState("loading");
 
     try {
-      const [dashboard, profiles] = await Promise.all([getDashboardData(), listProfiles()]);
+      const [dashboard, profiles] = await Promise.all([
+        getDashboardData(),
+        listProfiles(),
+      ]);
       if (cancelledRef?.current) {
         return;
       }
@@ -167,7 +177,11 @@ export default function ProfilesPage() {
       );
     } catch (error) {
       setFeedbackTone("error");
-      setFeedback(error instanceof Error ? error.message : "Unable to create a new profile.");
+      setFeedback(
+        error instanceof Error
+          ? error.message
+          : "Unable to create a new profile.",
+      );
     } finally {
       setIsCreating(false);
     }
@@ -188,7 +202,11 @@ export default function ProfilesPage() {
       );
     } catch (error) {
       setFeedbackTone("error");
-      setFeedback(error instanceof Error ? error.message : "Unable to switch the active profile.");
+      setFeedback(
+        error instanceof Error
+          ? error.message
+          : "Unable to switch the active profile.",
+      );
     } finally {
       setSwitchingId(null);
     }
@@ -205,7 +223,8 @@ export default function ProfilesPage() {
             Loading profile workspace...
           </h1>
           <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--shell-muted)]">
-            Preparing the available tracks and the current active learner context.
+            Preparing the available tracks and the current active learner
+            context.
           </p>
         </section>
       </main>
@@ -216,12 +235,15 @@ export default function ProfilesPage() {
     return (
       <main className="grid gap-6">
         <section className="border border-[var(--shell-border)] bg-[var(--shell-panel)] p-6 lg:p-8">
-          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--shell-success)]">Profiles</p>
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--shell-success)]">
+            Profiles
+          </p>
           <h1 className="mt-3 font-mono text-3xl uppercase tracking-[0.08em] text-[var(--shell-ink)]">
             Profile management is temporarily unavailable.
           </h1>
           <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--shell-muted)]">
-            The UI could not load the profile catalog. Refresh the page or return to the dashboard.
+            The UI could not load the profile catalog. Refresh the page or
+            return to the dashboard.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <button
@@ -260,34 +282,50 @@ export default function ProfilesPage() {
       <section className="grid gap-6 border border-[var(--shell-border)] bg-[var(--shell-panel)] p-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.8fr)] lg:p-8">
         <div>
           <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--shell-success)]">
-            {onboardingComplete ? "Onboarding complete" : isOnboarding ? "First-run onboarding" : "Profiles"}
+            {onboardingComplete
+              ? "Onboarding complete"
+              : isOnboarding
+                ? "First-run onboarding"
+                : "Profiles"}
           </p>
           <h1 className="mt-3 font-mono text-3xl uppercase tracking-[0.08em] text-[var(--shell-ink)]">
             {heroTitle}
           </h1>
-          <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--shell-muted)]">{heroLead}</p>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--shell-muted)]">
+            {heroLead}
+          </p>
 
           <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4">
-              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">Connected user</p>
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
+                Connected user
+              </p>
               <p className="mt-2 break-all font-mono text-xs uppercase tracking-[0.12em] text-[var(--shell-ink)]">
                 {sessionEmail}
               </p>
             </div>
             <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4">
-              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">Active profile</p>
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
+                Active profile
+              </p>
               <p className="mt-2 font-mono text-xs uppercase tracking-[0.12em] text-[var(--shell-ink)]">
-                {activeProfile ? formatTrackTitle(activeProfile.track, tracks) : "Not selected yet"}
+                {activeProfile
+                  ? formatTrackTitle(activeProfile.track, tracks)
+                  : "Not selected yet"}
               </p>
             </div>
             <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4">
-              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">Profiles linked</p>
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
+                Profiles linked
+              </p>
               <p className="mt-2 font-mono text-xs uppercase tracking-[0.12em] text-[var(--shell-ink)]">
                 {profilesState.profiles.length}
               </p>
             </div>
             <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4">
-              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">Data source</p>
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-muted)]">
+                Data source
+              </p>
               <p className="mt-2 font-mono text-xs uppercase tracking-[0.12em] text-[var(--shell-ink)]">
                 {profilesState.mocked ? "Demo mode" : "API live state"}
               </p>
@@ -300,7 +338,7 @@ export default function ProfilesPage() {
                 "mt-6 border px-4 py-4 font-mono text-[11px] leading-6",
                 feedbackTone === "success"
                   ? "border-[var(--shell-success)]/35 bg-[var(--shell-success)]/10 text-[var(--shell-ink)]"
-                  : "border-[#ff7a7a]/35 bg-[#ff7a7a]/10 text-[#ffd0d0]",
+                  : "border-[var(--shell-danger)]/35 bg-[var(--shell-danger)]/10 text-[var(--shell-danger)]",
               ].join(" ")}
               aria-live="polite"
             >
@@ -329,7 +367,8 @@ export default function ProfilesPage() {
                 2. Confirm the active context
               </p>
               <p className="mt-2">
-                The active profile becomes the learner scope used by modules, review, mentor and defense.
+                The active profile becomes the learner scope used by modules,
+                review, mentor and defense.
               </p>
             </div>
             <div className="border border-[var(--shell-border)] px-4 py-3">
@@ -366,7 +405,8 @@ export default function ProfilesPage() {
                 Active learner context
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--shell-muted)]">
-                Switch between existing profiles when you want to move from one track to another without mixing progression.
+                Switch between existing profiles when you want to move from one
+                track to another without mixing progression.
               </p>
             </div>
             <Link
@@ -379,7 +419,8 @@ export default function ProfilesPage() {
 
           {profilesState.profiles.length === 0 ? (
             <div className="mt-6 border border-dashed border-[var(--shell-border)] px-5 py-6 text-sm leading-7 text-[var(--shell-muted)]">
-              No learner profile exists yet. Create one in the right panel to unlock the guided learning flow.
+              No learner profile exists yet. Create one in the right panel to
+              unlock the guided learning flow.
             </div>
           ) : (
             <div className="mt-6 grid gap-4 md:grid-cols-2">
@@ -407,10 +448,16 @@ export default function ProfilesPage() {
                     <h3 className="mt-3 font-mono text-lg uppercase tracking-[0.08em] text-[var(--shell-ink)]">
                       {formatTrackTitle(profile.track, tracks)}
                     </h3>
-                    <p className="mt-3 text-sm text-[var(--shell-muted)]">Login handle: {profile.login}</p>
+                    <p className="mt-3 text-sm text-[var(--shell-muted)]">
+                      Login handle: {profile.login}
+                    </p>
                     <div className="mt-4 space-y-2 text-sm text-[var(--shell-muted)]">
                       <p>Started {formatDateLabel(profile.startedAt)}</p>
-                      <p>{profile.currentModule ? `Current module: ${profile.currentModule}` : "No module selected yet"}</p>
+                      <p>
+                        {profile.currentModule
+                          ? `Current module: ${profile.currentModule}`
+                          : "No module selected yet"}
+                      </p>
                     </div>
                     <button
                       type="button"
@@ -423,7 +470,11 @@ export default function ProfilesPage() {
                       onClick={() => void handleSwitchProfile(profile)}
                       disabled={isActive || switchingId === profile.id}
                     >
-                      {isActive ? "Active profile" : switchingId === profile.id ? "Switching..." : "Set active"}
+                      {isActive
+                        ? "Active profile"
+                        : switchingId === profile.id
+                          ? "Switching..."
+                          : "Set active"}
                     </button>
                   </article>
                 );
@@ -441,13 +492,20 @@ export default function ProfilesPage() {
               Add a track profile
             </h2>
             <p className="mt-3 text-sm leading-7 text-[var(--shell-muted)]">
-              One profile per track. Use the optional login field if you want a custom handle instead of the generated one.
+              One profile per track. Use the optional login field if you want a
+              custom handle instead of the generated one.
             </p>
           </div>
 
-          <form className="profiles-form mt-6 flex flex-col gap-5" noValidate onSubmit={handleCreateProfile}>
+          <form
+            className="profiles-form mt-6 flex flex-col gap-5"
+            noValidate
+            onSubmit={handleCreateProfile}
+          >
             <label className="flex flex-col gap-3">
-              <span className="font-mono text-[10px] uppercase tracking-[0.35em] text-[var(--shell-muted)]">Track</span>
+              <span className="font-mono text-[10px] uppercase tracking-[0.35em] text-[var(--shell-muted)]">
+                Track
+              </span>
               <select
                 className="h-12 rounded-none border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 font-mono text-[12px] uppercase tracking-[0.16em] text-[var(--shell-ink)] outline-none focus:border-[var(--shell-success)]"
                 value={form.track}
@@ -461,7 +519,11 @@ export default function ProfilesPage() {
                   </option>
                 ))}
               </select>
-              {errors.track ? <small className="font-mono text-[11px] text-[#ff7a7a]">{errors.track}</small> : null}
+              {errors.track ? (
+                <small className="font-mono text-[11px] text-[var(--shell-danger)]">
+                  {errors.track}
+                </small>
+              ) : null}
             </label>
 
             <label className="flex flex-col gap-3">
@@ -477,7 +539,11 @@ export default function ProfilesPage() {
                 onChange={(event) => updateField("login", event.target.value)}
                 aria-invalid={Boolean(errors.login)}
               />
-              {errors.login ? <small className="font-mono text-[11px] text-[#ff7a7a]">{errors.login}</small> : null}
+              {errors.login ? (
+                <small className="font-mono text-[11px] text-[var(--shell-danger)]">
+                  {errors.login}
+                </small>
+              ) : null}
             </label>
 
             <button
@@ -494,8 +560,9 @@ export default function ProfilesPage() {
               Current integration state
             </strong>
             <p className="mt-2">
-              This page uses the authenticated session cookie and the live <code>/api/v1/profiles</code> endpoints.
-              Browser-backed mock data is available only when explicit demo mode is enabled.
+              This page uses the authenticated session cookie and the live{" "}
+              <code>/api/v1/profiles</code> endpoints. Browser-backed mock data
+              is available only when explicit demo mode is enabled.
             </p>
           </div>
         </aside>

--- a/apps/web/app/review/ReviewClient.tsx
+++ b/apps/web/app/review/ReviewClient.tsx
@@ -78,7 +78,9 @@ function validateForm(values: FormState): FormErrors {
   }
   if (
     values.score &&
-    (Number.isNaN(Number(values.score)) || Number(values.score) < 0 || Number(values.score) > 100)
+    (Number.isNaN(Number(values.score)) ||
+      Number(values.score) < 0 ||
+      Number(values.score) > 100)
   ) {
     errors.score = "Score must stay between 0 and 100.";
   }
@@ -100,7 +102,10 @@ function formatTimestamp(value: string) {
   }).format(new Date(value));
 }
 
-function buildArtifacts(notes: string, selectedLenses: string[]): EvidenceArtifact[] {
+function buildArtifacts(
+  notes: string,
+  selectedLenses: string[],
+): EvidenceArtifact[] {
   const lines = notes
     .split("\n")
     .map((line) => line.trim())
@@ -127,15 +132,25 @@ function buildArtifacts(notes: string, selectedLenses: string[]): EvidenceArtifa
 }
 
 export default function ReviewClient({ modules }: Props) {
-  const [form, setForm] = useState<FormState>({ ...INITIAL_FORM, moduleId: modules[0]?.id ?? "" });
+  const [form, setForm] = useState<FormState>({
+    ...INITIAL_FORM,
+    moduleId: modules[0]?.id ?? "",
+  });
   const [errors, setErrors] = useState<FormErrors>({});
-  const [selectedLenses, setSelectedLenses] = useState<string[]>([REVIEW_LENSES[0], REVIEW_LENSES[4]]);
+  const [selectedLenses, setSelectedLenses] = useState<string[]>([
+    REVIEW_LENSES[0],
+    REVIEW_LENSES[4],
+  ]);
   const [items, setItems] = useState<ReviewAttemptRecord[]>([]);
-  const [loadingState, setLoadingState] = useState<"loading" | "ready" | "error">("loading");
+  const [loadingState, setLoadingState] = useState<
+    "loading" | "ready" | "error"
+  >("loading");
   const [sourceMode, setSourceMode] = useState<"live" | "mocked">("live");
   const [submitState, setSubmitState] = useState<"idle" | "submitting">("idle");
   const [feedback, setFeedback] = useState<string | null>(null);
-  const [feedbackTone, setFeedbackTone] = useState<"success" | "error">("success");
+  const [feedbackTone, setFeedbackTone] = useState<"success" | "error">(
+    "success",
+  );
 
   const loadItems = useCallback(async (cancelledRef?: { current: boolean }) => {
     setLoadingState("loading");
@@ -192,7 +207,9 @@ export default function ReviewClient({ modules }: Props) {
 
   function toggleLens(value: string) {
     setSelectedLenses((current) =>
-      current.includes(value) ? current.filter((item) => item !== value) : [...current, value],
+      current.includes(value)
+        ? current.filter((item) => item !== value)
+        : [...current, value],
     );
     setFeedback(null);
   }
@@ -223,7 +240,9 @@ export default function ReviewClient({ modules }: Props) {
       setItems((current) => [result.item, ...current]);
       setSourceMode(result.mocked ? "mocked" : "live");
       setFeedbackTone("success");
-      setFeedback(`Review submitted for ${moduleLabel(form.moduleId, modules)}.`);
+      setFeedback(
+        `Review submitted for ${moduleLabel(form.moduleId, modules)}.`,
+      );
       setForm((current) => ({
         ...current,
         score: "",
@@ -233,14 +252,21 @@ export default function ReviewClient({ modules }: Props) {
       }));
     } catch (error) {
       setFeedbackTone("error");
-      setFeedback(error instanceof Error ? error.message : "Unable to submit the review.");
+      setFeedback(
+        error instanceof Error ? error.message : "Unable to submit the review.",
+      );
     } finally {
       setSubmitState("idle");
     }
   }
 
   if (loadingState === "loading") {
-    return <GuidedEmptyState title="Loading review workspace..." body="The guided review workspace is bootstrapping recent attempts and evidence prompts." />;
+    return (
+      <GuidedEmptyState
+        title="Loading review workspace..."
+        body="The guided review workspace is bootstrapping recent attempts and evidence prompts."
+      />
+    );
   }
 
   if (loadingState === "error") {
@@ -270,8 +296,9 @@ export default function ReviewClient({ modules }: Props) {
                 Submit a guided review
               </h1>
               <p className="mt-4 text-sm leading-7 text-[var(--shell-muted)]">
-                Prepare a peer-style evaluation before the real defense pressure hits. Frame the review lenses, attach evidence
-                and leave a trace of the exact questions another learner should challenge.
+                Prepare a peer-style evaluation before the real defense pressure
+                hits. Frame the review lenses, attach evidence and leave a trace
+                of the exact questions another learner should challenge.
               </p>
             </div>
             <GuidedBadge tone={sourceMode === "live" ? "success" : "warning"}>
@@ -281,10 +308,19 @@ export default function ReviewClient({ modules }: Props) {
         </GuidedPanel>
 
         <GuidedPanel className="px-6 py-6">
-          <form className="review-form grid gap-6" noValidate onSubmit={handleSubmit}>
+          <form
+            className="review-form grid gap-6"
+            noValidate
+            onSubmit={handleSubmit}
+          >
             <div className="grid gap-4 lg:grid-cols-2">
               <GuidedField label="Module">
-                <GuidedSelect value={form.moduleId} onChange={(event) => updateField("moduleId", event.target.value)}>
+                <GuidedSelect
+                  value={form.moduleId}
+                  onChange={(event) =>
+                    updateField("moduleId", event.target.value)
+                  }
+                >
                   {modules.map((module) => (
                     <option key={module.id} value={module.id}>
                       {module.trackTitle} — {module.title}
@@ -302,7 +338,9 @@ export default function ReviewClient({ modules }: Props) {
                 <input
                   className="min-h-11 border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-2 font-mono text-sm text-[var(--shell-ink)] outline-none transition-colors focus:border-[var(--shell-success)]"
                   value={form.reviewerId}
-                  onChange={(event) => updateField("reviewerId", event.target.value)}
+                  onChange={(event) =>
+                    updateField("reviewerId", event.target.value)
+                  }
                 />
                 {errors.reviewerId ? (
                   <small className="font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--shell-danger)]">
@@ -315,7 +353,9 @@ export default function ReviewClient({ modules }: Props) {
                 <input
                   className="min-h-11 border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-2 font-mono text-sm text-[var(--shell-ink)] outline-none transition-colors focus:border-[var(--shell-success)]"
                   value={form.learnerId}
-                  onChange={(event) => updateField("learnerId", event.target.value)}
+                  onChange={(event) =>
+                    updateField("learnerId", event.target.value)
+                  }
                 />
               </GuidedField>
 
@@ -344,12 +384,19 @@ export default function ReviewClient({ modules }: Props) {
                     key={lens}
                     className={`flex cursor-pointer items-start gap-3 border px-4 py-3 transition-colors ${
                       active
-                        ? "border-[var(--shell-success)] bg-[rgba(0,224,110,0.08)]"
+                        ? "border-[var(--shell-success)] bg-[var(--shell-success)]/8"
                         : "border-[var(--shell-border)] bg-[var(--shell-canvas)]"
                     }`}
                   >
-                    <input type="checkbox" checked={active} onChange={() => toggleLens(lens)} className="mt-1" />
-                    <span className="text-sm leading-6 text-[var(--shell-ink)]">{lens}</span>
+                    <input
+                      type="checkbox"
+                      checked={active}
+                      onChange={() => toggleLens(lens)}
+                      className="mt-1"
+                    />
+                    <span className="text-sm leading-6 text-[var(--shell-ink)]">
+                      {lens}
+                    </span>
                   </label>
                 );
               })}
@@ -358,7 +405,9 @@ export default function ReviewClient({ modules }: Props) {
             <GuidedField label="Code or command snippet">
               <GuidedTextarea
                 value={form.codeSnippet}
-                onChange={(event) => updateField("codeSnippet", event.target.value)}
+                onChange={(event) =>
+                  updateField("codeSnippet", event.target.value)
+                }
                 placeholder="Paste the function, command sequence or excerpt you want reviewed."
               />
               {errors.codeSnippet ? (
@@ -371,7 +420,9 @@ export default function ReviewClient({ modules }: Props) {
             <GuidedField label="Review notes">
               <GuidedTextarea
                 value={form.feedback}
-                onChange={(event) => updateField("feedback", event.target.value)}
+                onChange={(event) =>
+                  updateField("feedback", event.target.value)
+                }
                 placeholder="Describe what a peer should challenge, confirm or re-explain."
               />
               {errors.feedback ? (
@@ -384,14 +435,21 @@ export default function ReviewClient({ modules }: Props) {
             <GuidedField label="Evidence notes">
               <GuidedTextarea
                 value={form.evidenceNotes}
-                onChange={(event) => updateField("evidenceNotes", event.target.value)}
+                onChange={(event) =>
+                  updateField("evidenceNotes", event.target.value)
+                }
                 placeholder="One line per artifact: command output, self-note, checklist item, warning..."
               />
             </GuidedField>
 
             <div className="flex flex-wrap gap-3">
-              <GuidedActionButton type="submit" disabled={submitState === "submitting"}>
-                {submitState === "submitting" ? "Submitting..." : "Submit review"}
+              <GuidedActionButton
+                type="submit"
+                disabled={submitState === "submitting"}
+              >
+                {submitState === "submitting"
+                  ? "Submitting..."
+                  : "Submit review"}
               </GuidedActionButton>
             </div>
 
@@ -399,8 +457,8 @@ export default function ReviewClient({ modules }: Props) {
               <div
                 className={`border px-4 py-3 font-mono text-[10px] uppercase tracking-[0.24em] ${
                   feedbackTone === "success"
-                    ? "border-[rgba(0,224,110,0.35)] text-[var(--shell-success)]"
-                    : "border-[rgba(255,65,65,0.35)] text-[var(--shell-danger)]"
+                    ? "border-[var(--shell-success)]/35 text-[var(--shell-success)]"
+                    : "border-[var(--shell-danger)]/35 text-[var(--shell-danger)]"
                 }`}
               >
                 {feedback}
@@ -436,14 +494,20 @@ export default function ReviewClient({ modules }: Props) {
             <div className="space-y-3">
               {items.length === 0 ? (
                 <p className="text-sm leading-6 text-[var(--shell-muted)]">
-                  No review has been captured yet. The first submission will appear here.
+                  No review has been captured yet. The first submission will
+                  appear here.
                 </p>
               ) : (
                 items.map((item) => (
-                  <article key={item.id} className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4">
+                  <article
+                    key={item.id}
+                    className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4"
+                  >
                     <div className="flex items-start justify-between gap-4 font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--shell-dim)]">
                       <span>{formatTimestamp(item.createdAt)}</span>
-                      <span>{item.score !== null ? `${item.score}/100` : "no score"}</span>
+                      <span>
+                        {item.score !== null ? `${item.score}/100` : "no score"}
+                      </span>
                     </div>
                     <p className="mt-3 font-mono text-sm font-semibold uppercase tracking-[0.12em] text-[var(--shell-ink)]">
                       {item.reviewerId}
@@ -451,9 +515,13 @@ export default function ReviewClient({ modules }: Props) {
                     <p className="mt-2 text-sm leading-6 text-[var(--shell-muted)]">
                       {moduleLabel(item.moduleId, modules)}
                     </p>
-                    <p className="mt-3 text-sm leading-6 text-[var(--shell-muted)]">{item.feedback}</p>
+                    <p className="mt-3 text-sm leading-6 text-[var(--shell-muted)]">
+                      {item.feedback}
+                    </p>
                     <div className="mt-3 flex flex-wrap gap-2">
-                      <GuidedBadge>{item.evidenceArtifacts.length} artifacts</GuidedBadge>
+                      <GuidedBadge>
+                        {item.evidenceArtifacts.length} artifacts
+                      </GuidedBadge>
                     </div>
                   </article>
                 ))


### PR DESCRIPTION
## Summary
- Replace **all hardcoded `rgba()` and hex colors** with `--shell-*` CSS custom properties across 5 canonical page components
- Zero hardcoded colors remain outside of `login/page.tsx` (covered by #293) and `tracks/` talent-tree CSS classes (separate refactor)

## Files changed (5)
| File | Changes |
|------|---------|
| `dashboard/page.tsx` | `rgba(247,190,22,...)` → `color-mix(--shell-warning)`, `rgba(45,47,54,...)` → `color-mix(--shell-border)` |
| `profiles/page.tsx` | `#ff7a7a` → `--shell-danger` (3 occurrences) |
| `defense/DefenseClient.tsx` | `rgba(255,65,65,...)` → `--shell-danger/30`, `rgba(0,224,110,...)` → `--shell-success/35`, `rgba(255,175,0,...)` → `--shell-warning/35` |
| `review/ReviewClient.tsx` | `rgba(0,224,110,0.08)` → `--shell-success/8`, `rgba(255,65,65,0.35)` → `--shell-danger/35` |
| `GuidedSurface.tsx` | `#ff6161` → `brightness-125 filter`, `rgba()` badge borders → `--shell-*/opacity` |

## Figma reference
https://www.figma.com/design/qqaNVWa3c7UoVrrBo9gk3c

## Out of scope (noted in #289)
- `tracks/page.tsx` talent-tree CSS classes (`.talent-*` in globals.css use light palette)
- `modules/[id]/page.tsx` CSS classes (`.page-shell`, `.panel`, `.pill`)
- These require a separate design system migration

## Test plan
- [ ] Dashboard renders correctly (module cards, progress bars)
- [ ] Defense flow: setup → active → results (badge colors, error states)
- [ ] Review form: lens checkboxes highlight, feedback messages styled
- [ ] Profiles: error messages in red, success in green
- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] No visual regression on pages already using `--shell-*` tokens

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)