### PR TITLE
feat: implement canonical App Shell variants with status bar and rail icons (#295)

### DIFF
--- a/apps/web/app/components/AppShell.tsx
+++ b/apps/web/app/components/AppShell.tsx
@@ -238,7 +238,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   const sessionHandle = getSessionHandle(session?.user.email ?? null);
   const trackLabel = session?.learnerProfile?.track ?? "shell";
   const routeLabel = buildRouteLabel(pathname);
-  const contentPadding = density === "compact" ? "px-4 py-4 lg:px-6 lg:py-5" : "px-4 py-5 lg:px-6 lg:py-6";
+  const contentPadding = density === "compact" ? "px-4 py-4 pb-10 lg:px-6 lg:py-5 lg:pb-10" : "px-4 py-5 pb-12 lg:px-6 lg:py-6 lg:pb-12";
 
   async function handleLogout() {
     await logout();
@@ -315,7 +315,13 @@ export function AppShell({ children }: { children: ReactNode }) {
                   no contextual data
                 </p>
               )
-            ) : null}
+            ) : (
+              /* Collapsed rail icon indicators per Figma canonical spec */
+              <div className="flex flex-col items-center gap-3">
+                <span className="text-[14px] text-[var(--shell-muted)]" title="Context">◈</span>
+                <span className="text-[14px] text-[var(--shell-muted)]" title="Stats">▤</span>
+              </div>
+            )}
           </div>
 
           <div className="mt-auto border-t border-[var(--shell-border)] px-2 py-3">
@@ -421,6 +427,18 @@ export function AppShell({ children }: { children: ReactNode }) {
           {children}
         </main>
       </div>
+
+      {/* Status bar — canonical Figma spec, fixed bottom */}
+      <footer
+        className="fixed inset-x-0 bottom-0 z-20 flex h-7 items-center justify-between border-t border-[var(--shell-border)] bg-[var(--shell-panel)] px-4 font-mono text-[10px] uppercase tracking-[0.22em] text-[var(--shell-dim)]"
+        style={{ marginLeft: `${contentOffset}px` }}
+        aria-label="Status bar"
+      >
+        <span>{routeLabel}</span>
+        <span>
+          42-training v1.0 // {status === "authenticated" ? "jwt:active" : "jwt:none"} // sync:2s
+        </span>
+      </footer>
     </div>
   );
 }

--- a/apps/web/app/components/AppShell.tsx
+++ b/apps/web/app/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, type ReactNode } from "react";
 
 import { useAuth } from "@/app/components/AuthProvider";
 import { useUiPreferences } from "@/app/components/UiPreferencesProvider";
+import { useSidebarSlot } from "@/app/components/SidebarSlotProvider";
 
 type NavItem = {
   href: string;
@@ -185,41 +186,12 @@ function railButtonClass(variant: RailAction["variant"], expanded: boolean) {
   return `${base} ${sizing} border-[var(--shell-border-strong)] bg-[var(--shell-panel)] text-[var(--shell-ink)] hover:border-[var(--shell-muted)] hover:text-[var(--shell-success)]`;
 }
 
-function SidebarLink({
-  expanded,
-  item,
-  pathname,
-}: {
-  expanded: boolean;
-  item: NavItem;
-  pathname: string;
-}) {
-  const active = item.isActive(pathname);
-
-  return (
-    <Link
-      href={item.href}
-      className={[
-        "flex items-center gap-3 border border-transparent px-3 py-2 text-[10px] font-medium uppercase tracking-[0.24em]",
-        active
-          ? "border-[var(--shell-border)] bg-[var(--shell-panel)] text-[var(--shell-success)]"
-          : "text-[var(--shell-muted)] transition-colors hover:text-[var(--shell-ink)]",
-      ].join(" ")}
-      aria-current={active ? "page" : undefined}
-    >
-      <span className="inline-flex min-w-6 justify-center text-[11px] text-[var(--shell-success)]">
-        {item.shortLabel}
-      </span>
-      {expanded ? <span>{item.label}</span> : null}
-    </Link>
-  );
-}
-
 export function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname() ?? "/";
   const router = useRouter();
   const { density } = useUiPreferences();
   const { logout, session, status } = useAuth();
+  const { content: sidebarSlotContent } = useSidebarSlot();
   const [viewportWidth, setViewportWidth] = useState<number | null>(null);
   const [desktopExpanded, setDesktopExpanded] = useState(true);
   const [overlayExpanded, setOverlayExpanded] = useState(false);
@@ -335,34 +307,15 @@ export function AppShell({ children }: { children: ReactNode }) {
             </div>
           </div>
 
+          {/* Contextual rail content — injected by pages via <SidebarContent> */}
           <div className="flex-1 overflow-y-auto px-2 py-3">
-            <div className="space-y-5">
-              <section className="space-y-2">
-                {isExpanded ? (
-                  <p className="px-1 font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">
-                    Primary
-                  </p>
-                ) : null}
-                <nav className="grid gap-1" aria-label="Primary workspace navigation">
-                  {PRIMARY_NAV.map((item) => (
-                    <SidebarLink key={item.href} expanded={isExpanded} item={item} pathname={pathname} />
-                  ))}
-                </nav>
-              </section>
-
-              <section className="space-y-2">
-                {isExpanded ? (
-                  <p className="px-1 font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">
-                    Workspace
-                  </p>
-                ) : null}
-                <nav className="grid gap-1" aria-label="Secondary workspace navigation">
-                  {UTILITY_NAV.map((item) => (
-                    <SidebarLink key={item.href} expanded={isExpanded} item={item} pathname={pathname} />
-                  ))}
-                </nav>
-              </section>
-            </div>
+            {isExpanded ? (
+              sidebarSlotContent ?? (
+                <p className="px-1 font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--shell-dim)]">
+                  no contextual data
+                </p>
+              )
+            ) : null}
           </div>
 
           <div className="mt-auto border-t border-[var(--shell-border)] px-2 py-3">
@@ -420,6 +373,20 @@ export function AppShell({ children }: { children: ReactNode }) {
                     aria-current={active ? "page" : undefined}
                   >
                     {item.label}
+                  </Link>
+                );
+              })}
+              <span className="text-[var(--shell-border-strong)]">//</span>
+              {UTILITY_NAV.map((item) => {
+                const active = item.isActive(pathname);
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={navItemClass(active)}
+                    aria-current={active ? "page" : undefined}
+                  >
+                    {item.shortLabel}
                   </Link>
                 );
               })}

--- a/apps/web/app/components/AuthGuard.tsx
+++ b/apps/web/app/components/AuthGuard.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 
 import { AppShell } from "@/app/components/AppShell";
 import { useAuth } from "@/app/components/AuthProvider";
+import { SidebarSlotProvider } from "@/app/components/SidebarSlotProvider";
 
 const PUBLIC_PATHS = new Set(["/login"]);
 
@@ -29,7 +30,11 @@ export function AuthGuard({ children }: { children: ReactNode }) {
   }
 
   if (status === "authenticated") {
-    return <AppShell>{children}</AppShell>;
+    return (
+      <SidebarSlotProvider>
+        <AppShell>{children}</AppShell>
+      </SidebarSlotProvider>
+    );
   }
 
   return (

--- a/apps/web/app/components/SidebarSlotProvider.tsx
+++ b/apps/web/app/components/SidebarSlotProvider.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * SidebarSlotProvider — Context for injecting page-specific contextual
+ * content into the AppShell sidebar rail.
+ *
+ * Issue #288 — merge dual sidebars into single AppShell sidebar.
+ *
+ * Usage:
+ *   <SidebarContent>
+ *     <GuidedSidebarSection label="CONTEXT">...</GuidedSidebarSection>
+ *   </SidebarContent>
+ *
+ * The content renders inside the AppShell sidebar, not in the page DOM.
+ * Automatically cleans up on unmount.
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
+
+type SidebarSlotContextValue = {
+  content: ReactNode | null;
+  setContent: (content: ReactNode | null) => void;
+};
+
+const SidebarSlotContext = createContext<SidebarSlotContextValue>({
+  content: null,
+  setContent: () => {},
+});
+
+export function SidebarSlotProvider({ children }: { children: ReactNode }) {
+  const [content, setContent] = useState<ReactNode | null>(null);
+  return (
+    <SidebarSlotContext.Provider value={{ content, setContent }}>
+      {children}
+    </SidebarSlotContext.Provider>
+  );
+}
+
+export function useSidebarSlot() {
+  return useContext(SidebarSlotContext);
+}
+
+/**
+ * Declarative component — renders nothing in the page DOM but injects
+ * its children into the AppShell sidebar via context.
+ */
+export function SidebarContent({ children }: { children: ReactNode }) {
+  const { setContent } = useSidebarSlot();
+
+  useEffect(() => {
+    setContent(children);
+    return () => setContent(null);
+  }, [children, setContent]);
+
+  return null;
+}

--- a/apps/web/app/dashboard/DashboardSidebar.tsx
+++ b/apps/web/app/dashboard/DashboardSidebar.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Client wrapper to inject dashboard stats into the AppShell sidebar.
+ * Issue #288 — merge dual sidebars.
+ */
+
+import { SidebarContent } from "@/app/components/SidebarSlotProvider";
+
+type Props = {
+  completedModules: number;
+  totalModules: number;
+  completionEvents: number;
+  successRate: number;
+  defensesStarted: number;
+  mentorQueries: number;
+  totalSkills: number;
+  trackCount: number;
+  activePanes: number;
+  idlePanes: number;
+  currentExercise: string | null;
+  currentStep: string | null;
+};
+
+function StatLine({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-3 py-2">
+      <div className="flex items-baseline justify-between">
+        <span className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">{label}</span>
+        <span className="font-mono text-sm font-bold text-[var(--shell-ink)]">{value}</span>
+      </div>
+      <p className="mt-1 font-mono text-[8px] leading-4 text-[var(--shell-muted)]">{detail}</p>
+    </div>
+  );
+}
+
+export function DashboardSidebar(props: Props) {
+  return (
+    <SidebarContent>
+      <div className="flex flex-col gap-4">
+        <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Stats</p>
+        <div className="grid gap-2">
+          <StatLine label="Modules" value={`${props.completedModules}/${props.totalModules}`} detail={`${props.completionEvents} completions`} />
+          <StatLine label="Success" value={`${props.successRate}%`} detail="checkpoint reliability" />
+          <StatLine label="Defense" value={`${props.defensesStarted}`} detail="sessions started" />
+          <StatLine label="Mentor" value={`${props.mentorQueries}`} detail="AI interactions" />
+          <StatLine label="Skills" value={`${props.totalSkills}`} detail={`${props.trackCount} tracks`} />
+        </div>
+
+        <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Session health</p>
+        <div className="grid gap-2">
+          <div className="flex items-center justify-between border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-3 py-2 font-mono text-[10px] uppercase tracking-[0.24em]">
+            <span className="text-[var(--shell-muted)]">Live</span>
+            <span className="text-[var(--shell-success)]">{props.activePanes}</span>
+          </div>
+          <div className="flex items-center justify-between border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-3 py-2 font-mono text-[10px] uppercase tracking-[0.24em]">
+            <span className="text-[var(--shell-muted)]">Idle</span>
+            <span className="text-[var(--shell-ink)]">{props.idlePanes}</span>
+          </div>
+          <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-3 py-2">
+            <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Focus</p>
+            <p className="mt-1 font-mono text-[10px] text-[var(--shell-ink)]">
+              {props.currentExercise ?? "No active exercise"}
+            </p>
+          </div>
+        </div>
+      </div>
+    </SidebarContent>
+  );
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -20,24 +20,6 @@ function Panel({
   );
 }
 
-function StatBlock({
-  label,
-  value,
-  detail,
-}: {
-  label: string;
-  value: string;
-  detail: string;
-}) {
-  return (
-    <div className="border-b border-[var(--shell-border)] px-4 py-4 last:border-b-0">
-      <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">{label}</p>
-      <p className="mt-3 font-mono text-2xl font-semibold text-[var(--shell-ink)]">{value}</p>
-      <p className="mt-2 font-mono text-[10px] leading-5 text-[var(--shell-muted)]">{detail}</p>
-    </div>
-  );
-}
-
 function ModuleNode({
   href,
   title,

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 import { DataSourceBadge } from "@/app/components/DataSourceBadge";
+import { DashboardSidebar } from "@/app/dashboard/DashboardSidebar";
 import { getAnalyticsData, getDashboardData, getTmuxSessions } from "@/lib/api";
 import { countSkills, deriveModuleState, getLearningContext, getTrackTheme, summarizeSessions } from "@/lib/learner-progress";
 
@@ -125,60 +126,21 @@ export default async function DashboardPage() {
   const tmuxSummary = summarizeSessions(tmuxData.sessions);
 
   return (
-    <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
-      <div className="grid gap-4">
-        <Panel>
-          <StatBlock
-            label="Modules"
-            value={`${completedModules}/${totalModules}`}
-            detail={`${analytics.summary.module_completions} completion events recorded in analytics`}
-          />
-          <StatBlock
-            label="Success rate"
-            value={`${analytics.summary.checkpoint_success_rate}%`}
-            detail="Checkpoint reliability across evaluated learner attempts"
-          />
-          <StatBlock
-            label="Defense"
-            value={`${analytics.summary.defenses_started}`}
-            detail="Defense sessions started from the guided learner workflow"
-          />
-          <StatBlock
-            label="Mentor queries"
-            value={`${analytics.summary.mentor_queries}`}
-            detail="AI mentor interactions preserved in the pedagogical event stream"
-          />
-          <StatBlock
-            label="Skill coverage"
-            value={`${totalSkills}`}
-            detail={`${curriculum.tracks.length} tracks visible in the competency map`}
-          />
-        </Panel>
-
-        <Panel className="px-5 py-5">
-          <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Session health</p>
-          <div className="mt-4 grid gap-3">
-            <div className="flex items-center justify-between border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.24em]">
-              <span className="text-[var(--shell-muted)]">Live panes</span>
-              <span className="text-[var(--shell-success)]">{tmuxSummary.active}</span>
-            </div>
-            <div className="flex items-center justify-between border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.24em]">
-              <span className="text-[var(--shell-muted)]">Idle panes</span>
-              <span className="text-[var(--shell-ink)]">{tmuxSummary.idle}</span>
-            </div>
-            <div className="border border-[var(--shell-border)] bg-[var(--shell-canvas)] px-4 py-4">
-              <p className="font-mono text-[9px] uppercase tracking-[0.28em] text-[var(--shell-dim)]">Current focus</p>
-              <p className="mt-3 font-mono text-sm text-[var(--shell-ink)]">
-                {progression.progress?.current_exercise ?? "No active exercise"}
-              </p>
-              <p className="mt-2 font-mono text-[10px] leading-5 text-[var(--shell-muted)]">
-                {progression.progress?.current_step ?? progression.next_command ?? "No current step visible in the learner session."}
-              </p>
-            </div>
-          </div>
-        </Panel>
-      </div>
-
+    <>
+      <DashboardSidebar
+        completedModules={completedModules}
+        totalModules={totalModules}
+        completionEvents={analytics.summary.module_completions}
+        successRate={analytics.summary.checkpoint_success_rate}
+        defensesStarted={analytics.summary.defenses_started}
+        mentorQueries={analytics.summary.mentor_queries}
+        totalSkills={totalSkills}
+        trackCount={curriculum.tracks.length}
+        activePanes={tmuxSummary.active}
+        idlePanes={tmuxSummary.idle}
+        currentExercise={progression.progress?.current_exercise ?? null}
+        currentStep={progression.progress?.current_step ?? progression.next_command ?? null}
+      />
       <div className="grid gap-4">
         <Panel className="px-6 py-5">
           <div className="flex flex-wrap items-center justify-between gap-4">
@@ -286,6 +248,6 @@ export default async function DashboardPage() {
           </div>
         </Panel>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/app/defense/DefenseClient.tsx
+++ b/apps/web/app/defense/DefenseClient.tsx
@@ -12,6 +12,7 @@ import {
   GuidedTextarea,
   GuidedSidebarSection,
 } from "@/app/components/GuidedSurface";
+import { SidebarContent } from "@/app/components/SidebarSlotProvider";
 import { TerminalPane } from "@/app/components/TerminalPane";
 
 type DefenseQuestion = {
@@ -353,12 +354,8 @@ export default function DefenseClient({
     setHistory([]);
   }
 
-  const sidebar = (
-    <GuidedPanel className="flex flex-col gap-5 px-4 py-4">
-      <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.28em] text-[var(--shell-dim)]">
-        ◂ collapse
-      </p>
-
+  const sidebarContent = (
+    <div className="flex flex-col gap-5">
       <GuidedSidebarSection label="Running score">
         <div className="space-y-1">
           <p className="font-mono text-4xl font-bold text-[var(--shell-warning)]">
@@ -410,15 +407,14 @@ export default function DefenseClient({
           <p>answers: {history.length}</p>
         </div>
       </GuidedSidebarSection>
-    </GuidedPanel>
+    </div>
   );
 
   if (phase === "setup") {
     return (
       <div className="grid gap-4">
-        <div className="grid gap-4 xl:grid-cols-[240px_minmax(0,1fr)]">
-          {sidebar}
-
+        <SidebarContent>{sidebarContent}</SidebarContent>
+        <div className="grid gap-4">
           <div className="grid gap-4">
             <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[rgba(255,65,65,0.3)] bg-[rgba(255,65,65,0.05)] px-6 py-3">
               <div>
@@ -523,9 +519,8 @@ export default function DefenseClient({
 
     return (
       <div className="grid gap-4">
-        <div className="grid gap-4 xl:grid-cols-[240px_minmax(0,1fr)]">
-          {sidebar}
-
+        <SidebarContent>{sidebarContent}</SidebarContent>
+        <div className="grid gap-4">
           <div className="grid gap-4">
             <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[rgba(255,65,65,0.3)] bg-[rgba(255,65,65,0.05)] px-6 py-3">
               <p className="font-mono text-[13px] font-bold uppercase tracking-[0.22em] text-[var(--shell-danger)]">
@@ -628,9 +623,8 @@ export default function DefenseClient({
   if (phase === "results" && results !== null) {
     return (
       <div className="grid gap-4">
-        <div className="grid gap-4 xl:grid-cols-[240px_minmax(0,1fr)]">
-          {sidebar}
-
+        <SidebarContent>{sidebarContent}</SidebarContent>
+        <div className="grid gap-4">
           <div className="grid gap-4">
             <GuidedPanel className="flex min-h-12 items-center justify-between gap-4 border-[rgba(255,65,65,0.3)] bg-[rgba(255,65,65,0.05)] px-6 py-3">
               <p className="font-mono text-[13px] font-bold uppercase tracking-[0.22em] text-[var(--shell-danger)]">

--- a/apps/web/app/mentor/MentorClient.tsx
+++ b/apps/web/app/mentor/MentorClient.tsx
@@ -12,6 +12,7 @@ import {
   GuidedStatusBar,
   GuidedTextarea,
 } from "@/app/components/GuidedSurface";
+import { SidebarContent } from "@/app/components/SidebarSlotProvider";
 import { SourcePolicyBadge } from "@/app/components/SourcePolicyBadge";
 import { TerminalPane } from "@/app/components/TerminalPane";
 
@@ -262,12 +263,8 @@ export default function MentorClient({
 
   return (
     <div className="grid gap-4">
-      <div className="grid gap-4 xl:grid-cols-[240px_minmax(0,1fr)]">
-        <GuidedPanel className="flex flex-col gap-5 px-4 py-4">
-          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.28em] text-[var(--shell-dim)]">
-            ◂ collapse
-          </p>
-
+      <SidebarContent>
+        <div className="flex flex-col gap-5">
           <GuidedSidebarSection label="Source policy">
             <div className="space-y-1 font-mono text-[9px] leading-5 text-[var(--shell-success)]">
               {sourcePolicy.map((item) => (
@@ -327,9 +324,10 @@ export default function MentorClient({
               <p>intent: {sessionStats.intent}</p>
             </div>
           </GuidedSidebarSection>
-        </GuidedPanel>
+        </div>
+      </SidebarContent>
 
-        <div className="grid gap-4">
+      <div className="grid gap-4">
           <GuidedPanel className="flex min-h-10 items-center justify-between gap-4 px-5 py-3">
             <div>
               <p className="font-mono text-[12px] font-semibold uppercase tracking-[0.2em] text-[var(--shell-success)]">
@@ -490,8 +488,6 @@ export default function MentorClient({
             </div>
           </GuidedPanel>
         </div>
-      </div>
-
       <GuidedStatusBar
         left={`mentor:${messages.length === 0 ? "idle" : "active"} // queries:${sessionStats.queries} // refusals:${sessionStats.refusals}`}
         right={`42-training v1.0 // ${sourceMode === "live" ? "jwt:active" : "demo"} // terminal:${showTerminal && activeSession ? "injected" : "standby"}`}


### PR DESCRIPTION
## Summary
- Added collapsed rail icon indicators (◈ context, ▤ stats) when sidebar is at 48px/40px
- Added canonical status bar (28px) fixed at bottom: route label + runtime state (`jwt:active // sync:2s`)
- Added bottom padding on main content to prevent status bar overlap
- All 4 canonical Figma variants now match spec:
  1. Desktop expanded (240px rail)
  2. Desktop collapsed (48px rail with icons)
  3. Tablet (48px rail with overlay)
  4. Mobile (40px rail with overlay)

## Figma reference
Page `00 — App Shell (Canonical)` — frames 50:2, 50:33, 50:60, 50:78 in `qqaNVWa3c7UoVrrBo9gk3c`

## Test plan
- [x] `next build` compiles successfully
- [x] ESLint passes
- [ ] Manual: verify status bar appears at bottom across all pages
- [ ] Manual: verify collapsed rail shows ◈ ▤ icons + ▶ ? ⬤ action buttons
- [ ] Manual: verify overlay expansion on tablet/mobile

## Dependencies
- Requires #302 (#288 fix: merge dual sidebars)

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)